### PR TITLE
Change validity time to a shorter period (<2038)

### DIFF
--- a/nsd-control-setup.sh.in
+++ b/nsd-control-setup.sh.in
@@ -43,7 +43,7 @@ SERVERNAME=nsd
 CLIENTNAME=nsd-control
 
 # validity period for certificates
-DAYS=7200
+DAYS=3650
 
 # size of keys in bits
 BITS=3072


### PR DESCRIPTION
7200 days created a certificate with a Not After in 1902. Shortening it to half at least gives you a working certificate.