### PR TITLE
Add support for setting send and receive buffer sizes

### DIFF
--- a/configlexer.lex
+++ b/configlexer.lex
@@ -222,6 +222,7 @@ nsid{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_NSID;}
 logfile{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_LOGFILE;}
 server-count{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_SERVER_COUNT;}
 tcp-count{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TCP_COUNT;}
+tcp-reject-overflow{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TCP_REJECT_OVERFLOW;}
 tcp-query-count{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TCP_QUERY_COUNT;}
 tcp-timeout{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TCP_TIMEOUT;}
 tcp-mss{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_TCP_MSS;}

--- a/configlexer.lex
+++ b/configlexer.lex
@@ -205,6 +205,8 @@ ip-address{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_IP_ADDRESS;}
 interface{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_IP_ADDRESS;}
 ip-transparent{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_IP_TRANSPARENT;}
 ip-freebind{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_IP_FREEBIND;}
+send-buffer-size{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_SEND_BUFFER_SIZE;}
+receive-buffer-size{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_RECEIVE_BUFFER_SIZE;}
 debug-mode{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_DEBUG_MODE;}
 use-systemd{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_USE_SYSTEMD;}
 hide-version{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_HIDE_VERSION;}

--- a/configparser.y
+++ b/configparser.y
@@ -78,6 +78,7 @@ extern config_parser_state_type* cfg_parser;
 %token VAR_DNSTAP_LOG_AUTH_RESPONSE_MESSAGES
 %token VAR_TLS_SERVICE_KEY VAR_TLS_SERVICE_OCSP VAR_TLS_SERVICE_PEM VAR_TLS_PORT
 %token VAR_SEND_BUFFER_SIZE VAR_RECEIVE_BUFFER_SIZE
+%token VAR_TCP_REJECT_OVERFLOW
 
 %%
 toplevelvars: /* empty */ | toplevelvars toplevelvar ;
@@ -112,7 +113,8 @@ content_server: server_ip_address | server_ip_transparent | server_debug_mode | 
 	server_tls_service_key | server_tls_service_pem | server_tls_port |
 	server_minimal_responses | server_refuse_any | server_use_systemd |
 	server_hide_identity | server_tls_service_ocsp |
-	server_send_buffer_size | server_receive_buffer_size;
+	server_send_buffer_size | server_receive_buffer_size |
+	server_tcp_reject_overflow;
 server_ip_address: VAR_IP_ADDRESS STRING 
 	{ 
 		OUTYY(("P(server_ip_address:%s)\n", $2)); 
@@ -368,6 +370,17 @@ server_tcp_count: VAR_TCP_COUNT STRING
 		if(atoi($2) <= 0)
 			yyerror("number greater than zero expected");
 		else cfg_parser->opt->tcp_count = atoi($2);
+	}
+	;
+server_tcp_reject_overflow: VAR_TCP_REJECT_OVERFLOW STRING
+	{
+		OUTYY(("P(server_reject_overflow_tcp:%s)\n", $2));
+		if(strcmp($2, "yes") != 0 && strcmp($2, "no") != 0) {
+			yyerror("tcp-reject-overflow: expected yes or no.");
+		} else {
+			cfg_parser->opt->tcp_reject_overflow =
+				(strcmp($2, "yes")==0);
+		}
 	}
 	;
 server_pidfile: VAR_PIDFILE STRING

--- a/configparser.y
+++ b/configparser.y
@@ -77,6 +77,7 @@ extern config_parser_state_type* cfg_parser;
 %token VAR_DNSTAP_VERSION VAR_DNSTAP_LOG_AUTH_QUERY_MESSAGES
 %token VAR_DNSTAP_LOG_AUTH_RESPONSE_MESSAGES
 %token VAR_TLS_SERVICE_KEY VAR_TLS_SERVICE_OCSP VAR_TLS_SERVICE_PEM VAR_TLS_PORT
+%token VAR_SEND_BUFFER_SIZE VAR_RECEIVE_BUFFER_SIZE
 
 %%
 toplevelvars: /* empty */ | toplevelvars toplevelvar ;
@@ -110,7 +111,8 @@ content_server: server_ip_address | server_ip_transparent | server_debug_mode | 
 	server_reuseport | server_version | server_ip_freebind |
 	server_tls_service_key | server_tls_service_pem | server_tls_port |
 	server_minimal_responses | server_refuse_any | server_use_systemd |
-	server_hide_identity | server_tls_service_ocsp;
+	server_hide_identity | server_tls_service_ocsp |
+	server_send_buffer_size | server_receive_buffer_size;
 server_ip_address: VAR_IP_ADDRESS STRING 
 	{ 
 		OUTYY(("P(server_ip_address:%s)\n", $2)); 
@@ -141,12 +143,30 @@ server_ip_transparent: VAR_IP_TRANSPARENT STRING
 		else cfg_parser->opt->ip_transparent = (strcmp($2, "yes")==0);
 	}
 	;
-server_ip_freebind: VAR_IP_FREEBIND STRING 
-	{ 
-		OUTYY(("P(server_ip_freebind:%s)\n", $2)); 
+server_ip_freebind: VAR_IP_FREEBIND STRING
+	{
+		OUTYY(("P(server_ip_freebind:%s)\n", $2));
 		if(strcmp($2, "yes") != 0 && strcmp($2, "no") != 0)
 			yyerror("expected yes or no.");
 		else cfg_parser->opt->ip_freebind = (strcmp($2, "yes")==0);
+	}
+	;
+server_send_buffer_size: VAR_SEND_BUFFER_SIZE STRING
+	{
+		int sz = atoi($2);
+		OUTYY(("P(server_send_buffer_size:%s)\n", $2));
+		if(sz < 0)
+			yyerror("non-negative number expected");
+		else cfg_parser->opt->send_buffer_size = sz;
+	}
+	;
+server_receive_buffer_size: VAR_RECEIVE_BUFFER_SIZE STRING
+	{
+		int sz = atoi($2);
+		OUTYY(("P(server_receive_buffer_size:%s)\n", $2));
+		if(sz < 0)
+			yyerror("non-negative number expected");
+		else cfg_parser->opt->receive_buffer_size = sz;
 	}
 	;
 server_debug_mode: VAR_DEBUG_MODE STRING 

--- a/nsd-checkconf.c
+++ b/nsd-checkconf.c
@@ -402,6 +402,8 @@ config_print_zone(nsd_options_type* opt, const char* k, int s, const char *o,
 		SERV_GET_INT(statistics, o);
 		SERV_GET_INT(xfrd_reload_timeout, o);
 		SERV_GET_INT(verbosity, o);
+		SERV_GET_INT(send_buffer_size, o);
+		SERV_GET_INT(receive_buffer_size, o);
 #ifdef RATELIMIT
 		SERV_GET_INT(rrl_size, o);
 		SERV_GET_INT(rrl_ratelimit, o);
@@ -498,6 +500,8 @@ config_test_print_server(nsd_options_type* opt)
 	printf("\treuseport: %s\n", opt->reuseport?"yes":"no");
 	printf("\tdo-ip4: %s\n", opt->do_ip4?"yes":"no");
 	printf("\tdo-ip6: %s\n", opt->do_ip6?"yes":"no");
+	printf("\tsend-buffer-size: %d\n", opt->send_buffer_size);
+	printf("\treceive-buffer-size: %d\n", opt->receive_buffer_size);
 	printf("\thide-version: %s\n", opt->hide_version?"yes":"no");
 	printf("\thide-identity: %s\n", opt->hide_identity?"yes":"no");
 	print_string_var("database:", opt->database);

--- a/nsd-checkconf.c
+++ b/nsd-checkconf.c
@@ -372,6 +372,7 @@ config_print_zone(nsd_options_type* opt, const char* k, int s, const char *o,
 		SERV_GET_BIN(round_robin, o);
 		SERV_GET_BIN(minimal_responses, o);
 		SERV_GET_BIN(refuse_any, o);
+		SERV_GET_BIN(tcp_reject_overflow, o);
 		/* str */
 		SERV_GET_PATH(final, database, o);
 		SERV_GET_STR(identity, o);
@@ -504,6 +505,8 @@ config_test_print_server(nsd_options_type* opt)
 	printf("\treceive-buffer-size: %d\n", opt->receive_buffer_size);
 	printf("\thide-version: %s\n", opt->hide_version?"yes":"no");
 	printf("\thide-identity: %s\n", opt->hide_identity?"yes":"no");
+	printf("\ttcp-reject-overflow: %s\n",
+		opt->tcp_reject_overflow ? "yes" : "no");
 	print_string_var("database:", opt->database);
 	print_string_var("identity:", opt->identity);
 	print_string_var("version:", opt->version);
@@ -595,7 +598,6 @@ config_test_print_server(nsd_options_type* opt)
 		print_string_var("name:", zone->name);
 		print_zone_content_elems(zone->pattern);
 	}
-
 }
 
 static int

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -181,6 +181,12 @@ than 1 (such as, equal to the number of cpus).  The default is no.
 It works on Linux, but does not work on FreeBSD, and likely does not
 work on other systems.
 .TP
+.B send\-buffer\-size:\fR <number>
+Set the send buffer size for query-servicing sockets.  Set to 0 to use the default settings.
+.TP
+.B receive\-buffer\-size:\fR <number>
+Set the receive buffer size for query-servicing sockets.  Set to 0 to use the default settings.
+.TP
 .B debug\-mode:\fR <yes or no>
 Turns on debugging mode for nsd, does not fork a daemon process. 
 Default is no. Same as commandline option

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -251,6 +251,10 @@ The maximum number of concurrent, active TCP connections by each server.
 Default is 100. Same as commandline option
 .BR \-n .
 .TP
+.B tcp\-reject\-overflow:\fR <yes or no>
+If set to yes, TCP connections made beyond the maximum set by tcp-count will
+be dropped immediately (accepted and closed).  Default is no.
+.TP
 .B tcp\-query\-count:\fR <number>
 The maximum number of queries served on a single TCP connection.
 Default is 0, meaning there is no maximum.

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -109,6 +109,11 @@ server:
 	# Maximum number of concurrent TCP connections per server.
 	# tcp-count: 100
 
+	# Accept (and immediately close) TCP connections after maximum number
+	# of connections is reached to prevent kernel connection queue from
+	# growing.
+	# tcp-reject-overflow: no
+
 	# Maximum number of queries served on a single TCP connection.
 	# By default 0, which means no maximum.
 	# tcp-query-count: 0

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -33,6 +33,14 @@ server:
 	# use the reuseport socket option for performance. Default no.
 	# reuseport: no
 
+	# override maximum socket send buffer size.  Default of 0 results in
+	# send buffer size being set to 1048576 (bytes).
+	# send-buffer-size: 1048576
+
+	# override maximum socket receive buffer size. Default of 0 results in
+	# receive buffer size being set to 1048576 (bytes).
+	# receive-buffer-size: 1048576
+
 	# enable debug mode, does not fork daemon process into the background.
 	# debug-mode: no
 

--- a/options.c
+++ b/options.c
@@ -71,6 +71,7 @@ nsd_options_create(region_type* region)
 	opt->refuse_any = 0;
 	opt->server_count = 1;
 	opt->tcp_count = 100;
+	opt->tcp_reject_overflow = 0;
 	opt->tcp_query_count = 0;
 	opt->tcp_timeout = TCP_TIMEOUT;
 	opt->tcp_mss = 0;

--- a/options.c
+++ b/options.c
@@ -52,6 +52,8 @@ nsd_options_create(region_type* region)
 	opt->ip_addresses = NULL;
 	opt->ip_transparent = 0;
 	opt->ip_freebind = 0;
+	opt->send_buffer_size = 0;
+	opt->receive_buffer_size = 0;
 	opt->debug_mode = 0;
 	opt->verbosity = 0;
 	opt->hide_version = 0;

--- a/options.h
+++ b/options.h
@@ -75,6 +75,7 @@ struct nsd_options {
 	const char* logfile;
 	int server_count;
 	int tcp_count;
+	int tcp_reject_overflow;
 	int tcp_query_count;
 	int tcp_timeout;
 	int tcp_mss;

--- a/options.h
+++ b/options.h
@@ -61,6 +61,8 @@ struct nsd_options {
 
 	int ip_transparent;
 	int ip_freebind;
+	int send_buffer_size;
+	int receive_buffer_size;
 	int debug_mode;
 	int verbosity;
 	int hide_version;

--- a/server.c
+++ b/server.c
@@ -724,59 +724,61 @@ server_init_ifs(struct nsd *nsd, size_t from, size_t to, int* reuseport_works)
 #else
 		(void)reuseport_works;
 #endif /* SO_REUSEPORT */
-#if defined(SO_RCVBUF) || defined(SO_SNDBUF)
-	if(1) {
-	int rcv = 1*1024*1024;
-	int snd = 1*1024*1024;
-
-#ifdef SO_RCVBUF
+#if defined(SO_RCVBUF)
+	{
+		int rcv = 1*1024*1024;
+		if (nsd->options->receive_buffer_size > 0) {
+			rcv = nsd->options->receive_buffer_size;
+		}
 #  ifdef SO_RCVBUFFORCE
-	if(setsockopt(nsd->udp[i].s, SOL_SOCKET, SO_RCVBUFFORCE, (void*)&rcv,
-		(socklen_t)sizeof(rcv)) < 0) {
-		if(errno != EPERM && errno != ENOBUFS) {
-			log_msg(LOG_ERR, "setsockopt(..., SO_RCVBUFFORCE, "
+		if(setsockopt(nsd->udp[i].s, SOL_SOCKET, SO_RCVBUFFORCE, (void*)&rcv,
+			(socklen_t)sizeof(rcv)) < 0) {
+			if(errno != EPERM && errno != ENOBUFS) {
+				log_msg(LOG_ERR, "setsockopt(..., SO_RCVBUFFORCE, "
                                         "...) failed: %s", strerror(errno));
-			return -1;
-		} 
+				return -1;
+			}
+		}
 #  else
-	if(1) {
-#  endif /* SO_RCVBUFFORCE */
 		if(setsockopt(nsd->udp[i].s, SOL_SOCKET, SO_RCVBUF, (void*)&rcv,
-			 (socklen_t)sizeof(rcv)) < 0) {
+			(socklen_t)sizeof(rcv)) < 0) {
 			if(errno != ENOBUFS && errno != ENOSYS) {
 				log_msg(LOG_ERR, "setsockopt(..., SO_RCVBUF, "
                                         "...) failed: %s", strerror(errno));
 				return -1;
 			}
 		}
+#  endif /* SO_RCVBUFFORCE */
 	}
 #endif /* SO_RCVBUF */
 
 #ifdef SO_SNDBUF
+	{
+		int snd = 1*1024*1024;
+		if (nsd->options->send_buffer_size > 0) {
+			snd = nsd->options->send_buffer_size;
+		}
 #  ifdef SO_SNDBUFFORCE
-	if(setsockopt(nsd->udp[i].s, SOL_SOCKET, SO_SNDBUFFORCE, (void*)&snd,
-		(socklen_t)sizeof(snd)) < 0) {
-		if(errno != EPERM && errno != ENOBUFS) {
-			log_msg(LOG_ERR, "setsockopt(..., SO_SNDBUFFORCE, "
+		if(setsockopt(nsd->udp[i].s, SOL_SOCKET, SO_SNDBUFFORCE, (void*)&snd,
+			(socklen_t)sizeof(snd)) < 0) {
+			if(errno != EPERM && errno != ENOBUFS) {
+				log_msg(LOG_ERR, "setsockopt(..., SO_SNDBUFFORCE, "
                                         "...) failed: %s", strerror(errno));
-			return -1;
-		} 
+				return -1;
+			}
+		}
 #  else
-	if(1) {
-#  endif /* SO_SNDBUFFORCE */
 		if(setsockopt(nsd->udp[i].s, SOL_SOCKET, SO_SNDBUF, (void*)&snd,
-			 (socklen_t)sizeof(snd)) < 0) {
+			(socklen_t)sizeof(snd)) < 0) {
 			if(errno != ENOBUFS && errno != ENOSYS) {
 				log_msg(LOG_ERR, "setsockopt(..., SO_SNDBUF, "
                                         "...) failed: %s", strerror(errno));
 				return -1;
 			}
 		}
+#  endif /* SO_SNDBUFFFORCE */
 	}
 #endif /* SO_SNDBUF */
-
-	}
-#endif /* defined(SO_RCVBUF) || defined(SO_SNDBUF) */
 
 #if defined(INET6)
 		if (addr->ai_family == AF_INET6) {


### PR DESCRIPTION
This pull request adds support for overriding the default socket send and receive buffer sizes, which is useful in case the default buffer sizes (1m to avoid messages being lost in spikes (I think)) are either too small or too large.

For convenience I've pushed the implementation for forcefully rejecting connections to this branch too, hope that's ok.