### PR TITLE
Add support for Coverity Scan service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,66 @@
 sudo: false
 language: c
-compiler:
-  - gcc
-addons:
-  apt:
-    packages:
-    - autoconf
-    - bison
-    - flex
-    - libssl-dev
-    - libevent-dev
-    - clang
+
+linux_gcc: &linux_gcc
+  os: linux
+  dist: xenial
+  compiler: gcc
+  addons:
+    apt:
+      update: true
+      sources: [ ubuntu-toolchain-r-test ]
+      packages: [ autoconf bison flex libssl-dev libevent-dev clang gcc-9 ]
+  before_install:
+    - eval "export CC=gcc-9"
+    - eval "export COV_COMPTYPE=gcc COV_PLATFORM=linux64"
+
+install_coverity: &install_coverity
+  if [ "${COVERITY_SCAN}" = "true" ]; then
+    COV_DIR="/tmp/coverity-scan-analysis";
+    COV_ARC="/tmp/cov-analysis-${COV_PLATFORM}.tgz";
+    test ! -d "${COV_DIR}" &&
+      mkdir -p "${COV_DIR}" &&
+      curl -s -S -F project="${TRAVIS_REPO_SLUG}"
+                 -F token="${COVERITY_SCAN_TOKEN}"
+                 -o "${COV_ARC}"
+                 "https://scan.coverity.com/download/cxx/${COV_PLATFORM}" &&
+      tar -xzf "${COV_ARC}" -C "${COV_DIR}";
+    COV_ANALYSIS=$(find "${COV_DIR}" -type d -name "cov-analysis*");
+    eval "export PATH=\"${PATH}:${COV_ANALYSIS}/bin\"";
+    eval "export SCAN_BUILD=\"cov-build --dir cov-int\"";
+    cov-configure --comptype ${COV_COMPTYPE} --compiler ${CC} --template;
+  fi
+
+submit_to_coverity_scan: &submit_to_coverity_scan
+  if [ "${COVERITY_SCAN}" = "true" ]; then
+    tar -czf analysis-results.tgz cov-int &&
+    curl -s -S -F project="${TRAVIS_REPO_SLUG}"
+               -F token="${COVERITY_SCAN_TOKEN}"
+               -F file=@analysis-results.tgz
+               -F version=$(git rev-parse --short HEAD)
+               -F description="Travis CI build"
+               -F email="${COVERITY_EMAIL:=spam@nlnetlabs.nl}"
+               "https://scan.coverity.com/builds";
+  fi
+
+install:
+  - *install_coverity
+
 script:
   - autoconf && autoheader
   - ./configure --enable-checking --disable-flto
-  - make
+  - ${SCAN_BUILD} make
   - make cutest && ./cutest
   - (cd tpkg; tar xzf clang-analysis.tpkg; cd clang-analysis.dir; bash clang-analysis.test)
+
+after_success:
+  - *submit_to_coverity_scan
+
+jobs:
+  include:
+    - <<: *linux_gcc
+      env: [ COVERITY_SCAN=true ]
+      if: type = cron
+    - <<: *linux_gcc
+      env: [ COVERITY_SCAN=false ]
+


### PR DESCRIPTION
This pull request adds support for the [Coverity Scan](https://scan.coverity.com/) service, a service that scans code for defects. I've personally found Coverity Scan to deliver pretty good results and thought it would be a good addition to our toolset. The way I implemented it is a little different from the default "recommended" way, which instructs the user to setup a *coverity_scan* branch. Personally I'd like to scan whichever branch I want and I guess in the case of NSD it makes most sense to just scan *master*, but it's determined by the branch that's used in the *Travis CI* cron job that you create. Apart from that it also switches the compiler used to build NSD from gcc 5 to gcc 9.

To start using the service:
1. Create a Coverity Scan account (simply sign in with GitHub)
2. Select the GitHub project (nlnetlabs/nsd in this case)
3. Configure who can see the results
4. Submit a first build
5. Set the environment variables `COVERITY_SCAN_TOKEN` and `COVERITY_EMAIL` at *Travis CI* for the nsd project
5. Create a cronjob with Travis CI for the nsd project

Please consider pulling these changes and enabling the Coverity Scan service