### PR TITLE
nsd-control: Add missing stdio header

### DIFF
--- a/nsd-control.c
+++ b/nsd-control.c
@@ -42,6 +42,7 @@
  */
 
 #include "config.h"
+#include <stdio.h>
 #ifdef HAVE_SSL
 
 #include <sys/types.h>


### PR DESCRIPTION
stdio.h is needed in case HAVE_SSL is false as printf gets used.