### PR TITLE
tsig: Fix compilation without HAVE_SSL

### DIFF
--- a/tsig.c
+++ b/tsig.c
@@ -19,6 +19,10 @@
 #include "query.h"
 #include "rbtree.h"
 
+#ifndef HAVE_SSL
+#define CRYPTO_memcmp memcmp
+#endif
+
 static region_type *tsig_region;
 
 struct tsig_key_table


### PR DESCRIPTION
CRYPTO_memcmp is an OpenSSL function that is used outside of the HAVE_SSL path.
This fixes compilation when HAVE_SSL is false.