### PR TITLE
Add option and logic to disable additional out-of-zone data.

### DIFF
--- a/configlexer.lex
+++ b/configlexer.lex
@@ -289,7 +289,7 @@ dnstap-log-auth-response-messages{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VA
 log-time-ascii{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_LOG_TIME_ASCII;}
 round-robin{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_ROUND_ROBIN;}
 minimal-responses{COLON} { LEXOUT(("v(%s) ", yytext)); return VAR_MINIMAL_RESPONSES;}
-additional-from-auth{COLON} { LEXOUT(("v(%s) ", yytext)); return VAR_ADDITIONAL_FROM_AUTH;}
+confine-to-zone{COLON} { LEXOUT(("v(%s) ", yytext)); return VAR_CONFINE_TO_ZONE;}
 refuse-any{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_REFUSE_ANY;}
 max-refresh-time{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_MAX_REFRESH_TIME;}
 min-refresh-time{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_MIN_REFRESH_TIME;}

--- a/configlexer.lex
+++ b/configlexer.lex
@@ -289,6 +289,7 @@ dnstap-log-auth-response-messages{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VA
 log-time-ascii{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_LOG_TIME_ASCII;}
 round-robin{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_ROUND_ROBIN;}
 minimal-responses{COLON} { LEXOUT(("v(%s) ", yytext)); return VAR_MINIMAL_RESPONSES;}
+additional-from-auth{COLON} { LEXOUT(("v(%s) ", yytext)); return VAR_ADDITIONAL_FROM_AUTH;}
 refuse-any{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_REFUSE_ANY;}
 max-refresh-time{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_MAX_REFRESH_TIME;}
 min-refresh-time{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_MIN_REFRESH_TIME;}

--- a/configparser.y
+++ b/configparser.y
@@ -71,7 +71,7 @@ extern config_parser_state_type* cfg_parser;
 %token VAR_ROUND_ROBIN VAR_ZONESTATS VAR_REUSEPORT VAR_VERSION
 %token VAR_MAX_REFRESH_TIME VAR_MIN_REFRESH_TIME
 %token VAR_MAX_RETRY_TIME VAR_MIN_RETRY_TIME
-%token VAR_MULTI_MASTER_CHECK VAR_MINIMAL_RESPONSES VAR_ADDITIONAL_FROM_AUTH VAR_REFUSE_ANY
+%token VAR_MULTI_MASTER_CHECK VAR_MINIMAL_RESPONSES VAR_CONFINE_TO_ZONE VAR_REFUSE_ANY
 %token VAR_USE_SYSTEMD VAR_DNSTAP VAR_DNSTAP_ENABLE VAR_DNSTAP_SOCKET_PATH
 %token VAR_DNSTAP_SEND_IDENTITY VAR_DNSTAP_SEND_VERSION VAR_DNSTAP_IDENTITY
 %token VAR_DNSTAP_VERSION VAR_DNSTAP_LOG_AUTH_QUERY_MESSAGES
@@ -111,7 +111,7 @@ content_server: server_ip_address | server_ip_transparent | server_debug_mode | 
 	server_zonefiles_write | server_log_time_ascii | server_round_robin |
 	server_reuseport | server_version | server_ip_freebind |
 	server_tls_service_key | server_tls_service_pem | server_tls_port |
-	server_minimal_responses | server_additional_from_auth | server_refuse_any | server_use_systemd |
+	server_minimal_responses | server_confine_to_zone | server_refuse_any | server_use_systemd |
 	server_hide_identity | server_tls_service_ocsp |
 	server_send_buffer_size | server_receive_buffer_size |
 	server_tcp_reject_overflow;
@@ -346,14 +346,13 @@ server_minimal_responses: VAR_MINIMAL_RESPONSES STRING
 		}
 	}
 	;
-server_additional_from_auth: VAR_ADDITIONAL_FROM_AUTH STRING
+server_confine_to_zone: VAR_CONFINE_TO_ZONE STRING
 	{
-		OUTYY(("P(server_additional_from_auth:%s)\n", $2));
+		OUTYY(("P(server_confine_to_zone:%s)\n", $2));
 		if(strcmp($2, "yes") != 0 && strcmp($2, "no") != 0) {
-			yyerror("additional-from-auth: expected yes or no.");
+			yyerror("confine-to-zone: expected yes or no.");
 		} else {
-			cfg_parser->opt->additional_from_auth =
-				(strcmp($2, "yes")==0);
+			cfg_parser->opt->confine_to_zone = (strcmp($2, "yes")==0);
 		}
 	}
 	;

--- a/configparser.y
+++ b/configparser.y
@@ -71,7 +71,7 @@ extern config_parser_state_type* cfg_parser;
 %token VAR_ROUND_ROBIN VAR_ZONESTATS VAR_REUSEPORT VAR_VERSION
 %token VAR_MAX_REFRESH_TIME VAR_MIN_REFRESH_TIME
 %token VAR_MAX_RETRY_TIME VAR_MIN_RETRY_TIME
-%token VAR_MULTI_MASTER_CHECK VAR_MINIMAL_RESPONSES VAR_REFUSE_ANY
+%token VAR_MULTI_MASTER_CHECK VAR_MINIMAL_RESPONSES VAR_ADDITIONAL_FROM_AUTH VAR_REFUSE_ANY
 %token VAR_USE_SYSTEMD VAR_DNSTAP VAR_DNSTAP_ENABLE VAR_DNSTAP_SOCKET_PATH
 %token VAR_DNSTAP_SEND_IDENTITY VAR_DNSTAP_SEND_VERSION VAR_DNSTAP_IDENTITY
 %token VAR_DNSTAP_VERSION VAR_DNSTAP_LOG_AUTH_QUERY_MESSAGES
@@ -111,7 +111,7 @@ content_server: server_ip_address | server_ip_transparent | server_debug_mode | 
 	server_zonefiles_write | server_log_time_ascii | server_round_robin |
 	server_reuseport | server_version | server_ip_freebind |
 	server_tls_service_key | server_tls_service_pem | server_tls_port |
-	server_minimal_responses | server_refuse_any | server_use_systemd |
+	server_minimal_responses | server_additional_from_auth | server_refuse_any | server_use_systemd |
 	server_hide_identity | server_tls_service_ocsp |
 	server_send_buffer_size | server_receive_buffer_size |
 	server_tcp_reject_overflow;
@@ -343,6 +343,17 @@ server_minimal_responses: VAR_MINIMAL_RESPONSES STRING
 		else {
 			cfg_parser->opt->minimal_responses = (strcmp($2, "yes")==0);
 			minimal_responses = cfg_parser->opt->minimal_responses;
+		}
+	}
+	;
+server_additional_from_auth: VAR_ADDITIONAL_FROM_AUTH STRING
+	{
+		OUTYY(("P(server_additional_from_auth:%s)\n", $2));
+		if(strcmp($2, "yes") != 0 && strcmp($2, "no") != 0) {
+			yyerror("additional-from-auth: expected yes or no.");
+		} else {
+			cfg_parser->opt->additional_from_auth =
+				(strcmp($2, "yes")==0);
 		}
 	}
 	;

--- a/nsd-checkconf.c
+++ b/nsd-checkconf.c
@@ -534,7 +534,7 @@ config_test_print_server(nsd_options_type* opt)
 	printf("\tlog-time-ascii: %s\n", opt->log_time_ascii?"yes":"no");
 	printf("\tround-robin: %s\n", opt->round_robin?"yes":"no");
 	printf("\tminimal-responses: %s\n", opt->minimal_responses?"yes":"no");
-	printf("\tadditonal-from-auth: %s\n",
+	printf("\tadditional-from-auth: %s\n",
 		opt->additional_from_auth ? "yes" : "no");
 	printf("\trefuse-any: %s\n", opt->refuse_any?"yes":"no");
 	printf("\tverbosity: %d\n", opt->verbosity);

--- a/nsd-checkconf.c
+++ b/nsd-checkconf.c
@@ -371,7 +371,7 @@ config_print_zone(nsd_options_type* opt, const char* k, int s, const char *o,
 		SERV_GET_BIN(log_time_ascii, o);
 		SERV_GET_BIN(round_robin, o);
 		SERV_GET_BIN(minimal_responses, o);
-		SERV_GET_BIN(additional_from_auth, o);
+		SERV_GET_BIN(confine_to_zone, o);
 		SERV_GET_BIN(refuse_any, o);
 		SERV_GET_BIN(tcp_reject_overflow, o);
 		/* str */
@@ -534,8 +534,8 @@ config_test_print_server(nsd_options_type* opt)
 	printf("\tlog-time-ascii: %s\n", opt->log_time_ascii?"yes":"no");
 	printf("\tround-robin: %s\n", opt->round_robin?"yes":"no");
 	printf("\tminimal-responses: %s\n", opt->minimal_responses?"yes":"no");
-	printf("\tadditional-from-auth: %s\n",
-		opt->additional_from_auth ? "yes" : "no");
+	printf("\tconfine-to-zone: %s\n",
+		opt->confine_to_zone ? "yes" : "no");
 	printf("\trefuse-any: %s\n", opt->refuse_any?"yes":"no");
 	printf("\tverbosity: %d\n", opt->verbosity);
 	for(ip = opt->ip_addresses; ip; ip=ip->next)

--- a/nsd-checkconf.c
+++ b/nsd-checkconf.c
@@ -371,6 +371,7 @@ config_print_zone(nsd_options_type* opt, const char* k, int s, const char *o,
 		SERV_GET_BIN(log_time_ascii, o);
 		SERV_GET_BIN(round_robin, o);
 		SERV_GET_BIN(minimal_responses, o);
+		SERV_GET_BIN(additional_from_auth, o);
 		SERV_GET_BIN(refuse_any, o);
 		SERV_GET_BIN(tcp_reject_overflow, o);
 		/* str */
@@ -533,6 +534,8 @@ config_test_print_server(nsd_options_type* opt)
 	printf("\tlog-time-ascii: %s\n", opt->log_time_ascii?"yes":"no");
 	printf("\tround-robin: %s\n", opt->round_robin?"yes":"no");
 	printf("\tminimal-responses: %s\n", opt->minimal_responses?"yes":"no");
+	printf("\tadditonal-from-auth: %s\n",
+		opt->additional_from_auth ? "yes" : "no");
 	printf("\trefuse-any: %s\n", opt->refuse_any?"yes":"no");
 	printf("\tverbosity: %d\n", opt->verbosity);
 	for(ip = opt->ip_addresses; ip; ip=ip->next)

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -392,6 +392,11 @@ that reduces packets, but exactly to the fragmentation length, the nsd.conf
 option reduces packets as small as possible.
 The default is no.
 .TP
+.B additional\-from\-auth:\fR <yes or no>
+If set to no, additional information will not be added to the response if the
+apex zone of the additional information does not match the apex zone of the
+initial query (E.G. CNAME resolution). Default is yes. 
+.TP
 .B refuse\-any:\fR <yes or no>
 Refuse queries of type ANY.  This is useful to stop query floods trying
 to get large responses.  Note that rrl ratelimiting also has type ANY as

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -392,10 +392,10 @@ that reduces packets, but exactly to the fragmentation length, the nsd.conf
 option reduces packets as small as possible.
 The default is no.
 .TP
-.B additional\-from\-auth:\fR <yes or no>
-If set to no, additional information will not be added to the response if the
+.B confine\-to\-zone:\fR <yes or no>
+If set to yes, additional information will not be added to the response if the
 apex zone of the additional information does not match the apex zone of the
-initial query (E.G. CNAME resolution). Default is yes. 
+initial query (E.G. CNAME resolution). Default is no. 
 .TP
 .B refuse\-any:\fR <yes or no>
 Refuse queries of type ANY.  This is useful to stop query floods trying

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -151,10 +151,10 @@ server:
 	# minimal-responses only emits extra data for referrals.
 	# minimal-responses: no
 
-	# Return additional information if the apex zone of the additional
-	# information is configured but does not match the apex zone of the
-	# initial query.
-	# additional-from-auth: yes
+	# Do not return additional information if the apex zone of the
+	# additional information is configured but does not match the apex zone
+	# of the initial query.
+	# confine-to-zone: no
 
 	# refuse queries of type ANY.  For stopping floods.
 	# refuse-any: no

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -151,6 +151,11 @@ server:
 	# minimal-responses only emits extra data for referrals.
 	# minimal-responses: no
 
+	# Return additional information if the apex zone of the additional
+	# information is configured but does not match the apex zone of the
+	# initial query.
+	# additional-from-auth: yes
+
 	# refuse queries of type ANY.  For stopping floods.
 	# refuse-any: no
 

--- a/options.c
+++ b/options.c
@@ -68,7 +68,7 @@ nsd_options_create(region_type* region)
 	opt->log_time_ascii = 1;
 	opt->round_robin = 0; /* also packet.h::round_robin */
 	opt->minimal_responses = 0; /* also packet.h::minimal_responses */
-	opt->additional_from_auth = 1;
+	opt->confine_to_zone = 0;
 	opt->refuse_any = 0;
 	opt->server_count = 1;
 	opt->tcp_count = 100;

--- a/options.c
+++ b/options.c
@@ -68,6 +68,7 @@ nsd_options_create(region_type* region)
 	opt->log_time_ascii = 1;
 	opt->round_robin = 0; /* also packet.h::round_robin */
 	opt->minimal_responses = 0; /* also packet.h::minimal_responses */
+	opt->additional_from_auth = 1;
 	opt->refuse_any = 0;
 	opt->server_count = 1;
 	opt->tcp_count = 100;

--- a/options.h
+++ b/options.h
@@ -76,7 +76,7 @@ struct nsd_options {
 	int server_count;
 	int tcp_count;
 	int tcp_reject_overflow;
-	int additional_from_auth;
+	int confine_to_zone;
 	int tcp_query_count;
 	int tcp_timeout;
 	int tcp_mss;

--- a/options.h
+++ b/options.h
@@ -76,6 +76,7 @@ struct nsd_options {
 	int server_count;
 	int tcp_count;
 	int tcp_reject_overflow;
+	int additional_from_auth;
 	int tcp_query_count;
 	int tcp_timeout;
 	int tcp_mss;

--- a/query.c
+++ b/query.c
@@ -1236,11 +1236,11 @@ answer_lookup_zone(struct nsd *nsd, struct query *q, answer_type *answer,
 	}
 
 	/*
-	 * If additional-from-auth is set to no do not return additional
+	 * If confine-to-zone is set to no do not return additional
 	 * information for a zone with a different apex from the query zone.
 	*/
-	if (!nsd->options->additional_from_auth &&
-	   (origzone != NULL && (origzone->apex->dname != q->zone->apex->dname))) {
+	if (nsd->options->confine_to_zone &&
+	   (origzone != NULL && dname_compare(origzone->apex->dname, q->zone->apex->dname))) {
 		return;
 	}
 

--- a/query.c
+++ b/query.c
@@ -1240,7 +1240,7 @@ answer_lookup_zone(struct nsd *nsd, struct query *q, answer_type *answer,
 	 * information for a zone with a different apex from the query zone.
 	*/
 	if (!nsd->options->additional_from_auth &&
-	   (origzone != NULL &&(origzone->apex->dname != q->zone->apex->dname))) {
+	   (origzone != NULL && (origzone->apex->dname != q->zone->apex->dname))) {
 		return;
 	}
 


### PR DESCRIPTION
NSD follows CNAME, DNAME, and possibly other data outside of the queried zone if the target zone is also configured in NSD. This may not always be desirable. This PR adds a configuration option and logic to disable this behavior. The option defaults to the current behavior. 

nsd.conf
```
server:
        ip-address: 127.0.0.1
        database: ""

remote-control:
        control-enable: yes
        control-interface: 127.0.0.1

zone:
        name: foo.test
        zonefile: /etc/nsd/foo.test.zone
zone:
        name: bar.test
        zonefile: /etc/nsd/bar.test.zone
```

foo.test.zone
```
@ IN SOA ns0.foo.test. username.foo.test. 0 0 0 0 0
cname-zone IN CNAME zone
cname-local IN CNAME  local.bar.test.
cname-remote IN CNAME remote.biz.test.
zone A 127.0.0.1
```
bar.test.zone
```
@ IN SOA ns0.bar.test. username.bar.test. 0 0 0 0 0
local A 127.0.0.2
```

Output:
```
[root@nsd-testing nsd]# dig +short @127.0.0.1 cname-zone.foo.test
zone.foo.test.
127.0.0.1
[root@nsd-testing nsd]# dig +short @127.0.0.1 cname-local.foo.test
local.bar.test.
127.0.0.2
[root@nsd-testing nsd]# dig +short @127.0.0.1 cname-remote.foo.test
remote.biz.test.
```

With the PR changes and additional-from-auth set to no:
```
root@nsd-testing nsd]# dig +short @127.0.0.1 cname-zone.foo.test
zone.foo.test.
127.0.0.1
[root@nsd-testing nsd]# dig +short @127.0.0.1 cname-local.foo.test
local.bar.test.
[root@nsd-testing nsd]# dig +short @127.0.0.1 cname-remote.foo.test
remote.biz.test.
```
I'm open to suggestions on the option name (I took this one from bind although it appears to be obsoleted now). I also contemplated allowing zones/patterns to override the global setting but wasn't sure if calling zone_options_find in the query path was a good idea. 