### PR TITLE
Fix logical typo from confine-to-zone option boolean change.

### DIFF
--- a/query.c
+++ b/query.c
@@ -1236,7 +1236,7 @@ answer_lookup_zone(struct nsd *nsd, struct query *q, answer_type *answer,
 	}
 
 	/*
-	 * If confine-to-zone is set to no do not return additional
+	 * If confine-to-zone is set to yes do not return additional
 	 * information for a zone with a different apex from the query zone.
 	*/
 	if (nsd->options->confine_to_zone &&

--- a/query.c
+++ b/query.c
@@ -1240,7 +1240,7 @@ answer_lookup_zone(struct nsd *nsd, struct query *q, answer_type *answer,
 	 * information for a zone with a different apex from the query zone.
 	*/
 	if (nsd->options->confine_to_zone &&
-	   (origzone != NULL && dname_compare(origzone->apex->dname, q->zone->apex->dname))) {
+	   (origzone != NULL && dname_compare(origzone->apex->dname, q->zone->apex->dname) != 0)) {
 		return;
 	}
 


### PR DESCRIPTION
Fix logical typo from confine-to-zone option boolean change. I missed this multiple times, sorry I didn't catch it before the merge of #39 .