### PR TITLE
Add popen3 and zone resource record iterator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 /nsd.conf.sample
 /nsd-mem
 /cutest
+/popen3_echo
 /udb-inspect
 /xfr-inspect
 /dnstap/dnstap.pb-c.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -74,7 +74,7 @@ EDIT		= sed \
 TARGETS=nsd nsd-checkconf nsd-checkzone nsd-control nsd.conf.sample nsd-control-setup.sh
 MANUALS=nsd.8 nsd-checkconf.8 nsd-checkzone.8 nsd-control.8 nsd.conf.5
 
-COMMON_OBJ=answer.o axfr.o buffer.o configlexer.o configparser.o dname.o dns.o edns.o iterated_hash.o lookup3.o namedb.o nsec3.o options.o packet.o query.o rbtree.o radtree.o rdata.o region-allocator.o rrl.o tsig.o tsig-openssl.o udb.o udbradtree.o udbzone.o util.o bitset.o
+COMMON_OBJ=answer.o axfr.o buffer.o configlexer.o configparser.o dname.o dns.o edns.o iterated_hash.o lookup3.o namedb.o nsec3.o options.o packet.o query.o rbtree.o radtree.o rdata.o region-allocator.o rrl.o tsig.o tsig-openssl.o udb.o udbradtree.o udbzone.o util.o bitset.o popen3.o
 XFRD_OBJ=xfrd-disk.o xfrd-notify.o xfrd-tcp.o xfrd.o remote.o $(DNSTAP_OBJ)
 NSD_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) difffile.o ipc.o mini_event.o netio.o nsd.o server.o dbaccess.o dbcreate.o zlexer.o zonec.o zparser.o
 ALL_OBJ=$(NSD_OBJ) nsd-checkconf.o nsd-checkzone.o nsd-control.o nsd-mem.o
@@ -439,6 +439,7 @@ options.o: $(srcdir)/options.c config.h $(srcdir)/options.h $(srcdir)/region-all
 packet.o: $(srcdir)/packet.c config.h $(srcdir)/packet.h $(srcdir)/dns.h $(srcdir)/namedb.h $(srcdir)/dname.h $(srcdir)/buffer.h \
  $(srcdir)/region-allocator.h $(srcdir)/util.h $(srcdir)/radtree.h $(srcdir)/rbtree.h $(srcdir)/query.h $(srcdir)/nsd.h $(srcdir)/edns.h $(srcdir)/tsig.h \
  $(srcdir)/rdata.h
+popen3.o: $(srcdir)/popen3.c $(srcdir)/popen3.h
 query.o: $(srcdir)/query.c config.h $(srcdir)/answer.h $(srcdir)/dns.h $(srcdir)/namedb.h $(srcdir)/dname.h $(srcdir)/buffer.h \
  $(srcdir)/region-allocator.h $(srcdir)/util.h $(srcdir)/radtree.h $(srcdir)/rbtree.h $(srcdir)/packet.h $(srcdir)/query.h $(srcdir)/nsd.h \
  $(srcdir)/edns.h $(srcdir)/tsig.h $(srcdir)/axfr.h $(srcdir)/options.h $(srcdir)/nsec3.h

--- a/Makefile.in
+++ b/Makefile.in
@@ -81,7 +81,7 @@ ALL_OBJ=$(NSD_OBJ) nsd-checkconf.o nsd-checkzone.o nsd-control.o nsd-mem.o
 NSD_CHECKCONF_OBJ=$(COMMON_OBJ) nsd-checkconf.o
 NSD_CHECKZONE_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o zparser.o zlexer.o nsd-checkzone.o
 NSD_CONTROL_OBJ=$(COMMON_OBJ) nsd-control.o
-CUTEST_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o zparser.o zlexer.o cutest_dname.o cutest_dns.o cutest_iterated_hash.o cutest_run.o cutest_radtree.o cutest_rbtree.o cutest_namedb.o cutest_options.o cutest_region.o cutest_rrl.o cutest_udb.o cutest_udbrad.o cutest_util.o cutest_bitset.o cutest.o qtest.o
+CUTEST_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o zparser.o zlexer.o cutest_dname.o cutest_dns.o cutest_iterated_hash.o cutest_run.o cutest_radtree.o cutest_rbtree.o cutest_namedb.o cutest_options.o cutest_region.o cutest_rrl.o cutest_udb.o cutest_udbrad.o cutest_util.o cutest_bitset.o cutest_popen3.o cutest.o qtest.o
 NSD_MEM_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o zparser.o zlexer.o nsd-mem.o
 all:	$(TARGETS) $(MANUALS)
 
@@ -164,7 +164,7 @@ nsd-control:	$(NSD_CONTROL_OBJ) $(LIBOBJS)
 nsd-mem:	$(NSD_MEM_OBJ) $(LIBOBJS)
 	$(LINK) -o $@ $(NSD_MEM_OBJ) $(LIBOBJS) $(SSL_LIBS) $(LIBS)
 
-cutest:	$(CUTEST_OBJ) $(LIBOBJS)
+cutest:	$(CUTEST_OBJ) $(LIBOBJS) popen3_echo
 	$(LINK) -o $@ $(CUTEST_OBJ) $(LIBOBJS) $(SSL_LIBS) $(LIBS)
 
 udb-inspect:	udb-inspect.o $(COMMON_OBJ) $(LIBOBJS)
@@ -173,8 +173,11 @@ udb-inspect:	udb-inspect.o $(COMMON_OBJ) $(LIBOBJS)
 xfr-inspect:	xfr-inspect.o $(COMMON_OBJ) $(LIBOBJS)
 	$(LINK) -o $@ xfr-inspect.o $(COMMON_OBJ) $(LIBOBJS) $(LIBS)
 
+popen3_echo: popen3.o popen3_echo.o
+	$(LINK) -o $@ popen3.o popen3_echo.o
+
 clean:
-	rm -f *.o $(TARGETS) $(MANUALS) cutest udb-inspect xfr-inspect nsd-mem
+	rm -f *.o $(TARGETS) $(MANUALS) cutest popen3_echo udb-inspect xfr-inspect nsd-mem
 
 distclean: clean
 	rm -f Makefile config.h config.log config.status dnstap/dnstap_config.h
@@ -290,6 +293,12 @@ cutest_util.o:	$(srcdir)/tpkg/cutest/cutest_util.c
 
 cutest_bitset.o: $(srcdir)/tpkg/cutest/cutest_bitset.c
 	$(COMPILE) -c $(srcdir)/tpkg/cutest/cutest_bitset.c
+
+cutest_popen3.o: $(srcdir)/tpkg/cutest/cutest_popen3.c
+	$(COMPILE) -c $(srcdir)/tpkg/cutest/cutest_popen3.c
+
+popen3_echo.o: $(srcdir)/tpkg/cutest/popen3_echo.c
+	$(COMPILE) -c $(srcdir)/tpkg/cutest/popen3_echo.c
 
 cutest.o:	$(srcdir)/tpkg/cutest/cutest.c
 	$(COMPILE) -c $(srcdir)/tpkg/cutest/cutest.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -81,7 +81,7 @@ ALL_OBJ=$(NSD_OBJ) nsd-checkconf.o nsd-checkzone.o nsd-control.o nsd-mem.o
 NSD_CHECKCONF_OBJ=$(COMMON_OBJ) nsd-checkconf.o
 NSD_CHECKZONE_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o zparser.o zlexer.o nsd-checkzone.o
 NSD_CONTROL_OBJ=$(COMMON_OBJ) nsd-control.o
-CUTEST_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o zparser.o zlexer.o cutest_dname.o cutest_dns.o cutest_iterated_hash.o cutest_run.o cutest_radtree.o cutest_rbtree.o cutest_namedb.o cutest_options.o cutest_region.o cutest_rrl.o cutest_udb.o cutest_udbrad.o cutest_util.o cutest_bitset.o cutest_popen3.o cutest.o qtest.o
+CUTEST_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o zparser.o zlexer.o cutest_dname.o cutest_dns.o cutest_iterated_hash.o cutest_run.o cutest_radtree.o cutest_rbtree.o cutest_namedb.o cutest_options.o cutest_region.o cutest_rrl.o cutest_udb.o cutest_udbrad.o cutest_util.o cutest_bitset.o cutest_popen3.o cutest_iter.o cutest.o qtest.o
 NSD_MEM_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o zparser.o zlexer.o nsd-mem.o
 all:	$(TARGETS) $(MANUALS)
 
@@ -296,6 +296,9 @@ cutest_bitset.o: $(srcdir)/tpkg/cutest/cutest_bitset.c
 
 cutest_popen3.o: $(srcdir)/tpkg/cutest/cutest_popen3.c
 	$(COMPILE) -c $(srcdir)/tpkg/cutest/cutest_popen3.c
+
+cutest_iter.o: $(srcdir)/tpkg/cutest/cutest_iter.c
+	$(COMPILE) -c $(srcdir)/tpkg/cutest/cutest_iter.c
 
 popen3_echo.o: $(srcdir)/tpkg/cutest/popen3_echo.c
 	$(COMPILE) -c $(srcdir)/tpkg/cutest/popen3_echo.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -81,7 +81,7 @@ ALL_OBJ=$(NSD_OBJ) nsd-checkconf.o nsd-checkzone.o nsd-control.o nsd-mem.o
 NSD_CHECKCONF_OBJ=$(COMMON_OBJ) nsd-checkconf.o
 NSD_CHECKZONE_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o zparser.o zlexer.o nsd-checkzone.o
 NSD_CONTROL_OBJ=$(COMMON_OBJ) nsd-control.o
-CUTEST_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o zparser.o zlexer.o cutest_dname.o cutest_dns.o cutest_iterated_hash.o cutest_run.o cutest_radtree.o cutest_rbtree.o cutest_namedb.o cutest_options.o cutest_region.o cutest_rrl.o cutest_udb.o cutest_udbrad.o cutest_util.o cutest_bitset.o cutest_popen3.o cutest_iter.o cutest.o qtest.o
+CUTEST_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o zparser.o zlexer.o cutest_dname.o cutest_dns.o cutest_iterated_hash.o cutest_run.o cutest_radtree.o cutest_rbtree.o cutest_namedb.o cutest_options.o cutest_region.o cutest_rrl.o cutest_udb.o cutest_udbrad.o cutest_util.o cutest_bitset.o cutest_popen3.o cutest_iter.o cutest_event.o cutest.o qtest.o
 NSD_MEM_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o zparser.o zlexer.o nsd-mem.o
 all:	$(TARGETS) $(MANUALS)
 
@@ -299,6 +299,9 @@ cutest_popen3.o: $(srcdir)/tpkg/cutest/cutest_popen3.c
 
 cutest_iter.o: $(srcdir)/tpkg/cutest/cutest_iter.c
 	$(COMPILE) -c $(srcdir)/tpkg/cutest/cutest_iter.c
+
+cutest_event.o: $(srcdir)/tpkg/cutest/cutest_event.c
+	$(COMPILE) -c $(srcdir)/tpkg/cutest/cutest_event.c
 
 popen3_echo.o: $(srcdir)/tpkg/cutest/popen3_echo.c
 	$(COMPILE) -c $(srcdir)/tpkg/cutest/popen3_echo.c

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -11,6 +11,12 @@
 21 January 2020: Wouter
 	- Fix leak in server bitset setup.
 
+16 January 2020: Jeroen
+	- Add zone resource record iterator for future zone-verification port.
+	- Set FD_CLOEXEC on opened sockets.
+	- Add popen3 implementation for future zone-verification port.
+	- Add -r option to cutest so that a subset of tests can be run.
+
 15 January 2020: Jeroen
 	- Add feature to pin server proccesses to specific cpus.
 	- Add feature to pin IP addresses to selected server processes.

--- a/doc/RELNOTES
+++ b/doc/RELNOTES
@@ -50,6 +50,8 @@ BUG FIXES:
 	  in the response.
 	- Merge PR#60: Minor portability fixes from michaelforney, with
 	  avoid pointer arithmetic on void* and avoid unnecessary VLA.
+CHANGES:
+	- Set FD_CLOEXEC on opened sockets.
 
 
 4.2.4

--- a/namedb.c
+++ b/namedb.c
@@ -701,3 +701,65 @@ namedb_lookup(struct namedb* db,
 	return domain_table_search(
 		db->domains, dname, closest_match, closest_encloser);
 }
+
+void zone_rr_iter_init(struct zone_rr_iter *iter, struct zone *zone)
+{
+	assert(iter != NULL);
+	assert(zone != NULL);
+	memset(iter, 0, sizeof(*iter));
+	iter->zone = zone;
+}
+
+rr_type *zone_rr_iter_next(struct zone_rr_iter *iter)
+{
+	assert(iter != NULL);
+	assert(iter->zone != NULL);
+
+	if(iter->index == -1) {
+		assert(iter->domain == NULL);
+		assert(iter->rrset == NULL);
+		return NULL;
+	} else if(iter->rrset == NULL) {
+		/* ensure SOA RR is returned first */
+		assert(iter->domain == NULL);
+		assert(iter->index == 0);
+		iter->rrset = iter->zone->soa_rrset;
+	}
+
+	while(iter->rrset != NULL) {
+		if(iter->index < iter->rrset->rr_count) {
+			return &iter->rrset->rrs[iter->index++];
+		}
+		iter->index = 0;
+		if(iter->domain == NULL) {
+			assert(iter->rrset == iter->zone->soa_rrset);
+			iter->domain = iter->zone->apex;
+			iter->rrset = iter->domain->rrsets;
+		} else {
+			iter->rrset = iter->rrset->next;
+		}
+		/* ensure SOA RR is not returned again and RR belongs to zone */
+		while((iter->rrset == NULL && iter->domain != NULL) ||
+		      (iter->rrset != NULL && (iter->rrset == iter->zone->soa_rrset ||
+		                               iter->rrset->zone != iter->zone)))
+		{
+			if(iter->rrset != NULL) {
+				iter->rrset = iter->rrset->next;
+			} else {
+				iter->domain = domain_next(iter->domain);
+				if(iter->domain != NULL &&
+				   dname_is_subdomain(domain_dname(iter->domain),
+				                      domain_dname(iter->zone->apex)))
+				{
+					iter->rrset = iter->domain->rrsets;
+				}
+			}
+		}
+	}
+
+	assert(iter->rrset == NULL);
+	assert(iter->domain == NULL);
+	iter->index = -1;
+
+	return NULL;
+}

--- a/namedb.h
+++ b/namedb.h
@@ -443,4 +443,21 @@ rrset_rrclass(rrset_type* rrset)
 	return rrset->rrs[0].klass;
 }
 
-#endif
+/*
+ * zone_rr_iter can be used to iterate over all RRs in a given zone. the
+ * SOA RRSET is guaranteed to be returned first.
+ */
+typedef struct zone_rr_iter zone_rr_iter_type;
+
+struct zone_rr_iter {
+	zone_type *zone;
+	domain_type *domain;
+	rrset_type *rrset;
+	ssize_t index;
+};
+
+void zone_rr_iter_init(zone_rr_iter_type *iter, zone_type *zone);
+
+rr_type *zone_rr_iter_next(zone_rr_iter_type *iter);
+
+#endif /* _NAMEDB_H_ */

--- a/popen3.c
+++ b/popen3.c
@@ -1,0 +1,172 @@
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "popen3.h"
+
+static void close_pipe(int fds[2])
+{
+	if(fds[0] != -1) {
+		close(fds[0]);
+		fds[0] = -1;
+	}
+	if(fds[1] != -1) {
+		close(fds[1]);
+		fds[1] = -1;
+	}
+}
+
+pid_t popen3(char *const *command,
+             FILE **finptr,
+             FILE **foutptr,
+             FILE **ferrptr)
+{
+	int err = 0;
+	int fdin[] = { -1, -1 };
+	int fdout[] = { -1, -1 };
+	int fderr[] = { -1, -1 };
+	int fdsig[] = { -1, -1 };
+	FILE *fin, *fout, *ferr;
+	pid_t pid;
+	ssize_t discard;
+
+	if(command == NULL || *command == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	fin = fout = ferr = NULL;
+
+	if(finptr != NULL && (pipe(fdin) == -1 ||
+			       (fin = fdopen(fdin[1], "w")) == NULL))
+	{
+		goto error;
+	}
+	if(foutptr != NULL && (pipe(fdout) == -1 ||
+			        (fout = fdopen(fdout[0], "r")) == NULL))
+	{
+		goto error;
+	}
+	if(ferrptr != NULL && (pipe(fderr) == -1 ||
+			        (ferr = fdopen(fderr[0], "r")) == NULL))
+	{
+		goto error;
+	}
+	if(pipe(fdsig) == -1 ||
+	   fcntl(fdsig[0], F_SETFD, FD_CLOEXEC) == -1 ||
+	   fcntl(fdsig[1], F_SETFD, FD_CLOEXEC) == -1)
+	{
+		goto error;
+	}
+
+	pid = fork();
+	switch(pid) {
+	case -1: /* error */
+		goto error;
+	case 0: /* child */
+		if(ferrptr != NULL) {
+			if(dup2(fderr[1], 2) == -1) {
+				goto error_dup2;
+			}
+			close_pipe(fderr);
+		} else {
+			close(2);
+		}
+		if(foutptr != NULL) {
+			if(dup2(fdout[1], 1) == -1) {
+				goto error_dup2;
+			}
+			close_pipe(fdout);
+		} else {
+			close(1);
+		}
+		if(finptr != NULL) {
+			if(dup2(fdin[0], 0) == -1) {
+				goto error_dup2;
+			}
+			close_pipe(fdin);
+		} else {
+			close(0);
+		}
+
+		execvp(*command, command);
+error_dup2:
+		err = errno;
+		close(fdsig[0]);
+		discard = write(fdsig[1], &err, sizeof(err));
+		(void)discard;
+		close(fdsig[1]);
+		exit(-1);
+	default: /* parent */
+	{
+		/* wait for signal pipe to close */
+		int ret;
+		fd_set rfds;
+
+		close(fdsig[1]);
+		fdsig[1] = -1;
+		do {
+			FD_ZERO(&rfds);
+			FD_SET(fdsig[0], &rfds);
+			ret = select(fdsig[0] + 1, &rfds, NULL, NULL, NULL);
+		} while(ret == -1 && errno == EINTR);
+
+		if(ret == -1) {
+			goto error;
+		}
+
+		if((ret = read(fdsig[0], &err, sizeof(err))) != 0) {
+			if(ret != -1) {
+				assert(ret == sizeof(err));
+				errno = err;
+			}
+			goto error;
+		}
+		close(fdsig[0]);
+		fdsig[0] = -1;
+	}
+		break;
+	}
+
+	if(finptr != NULL) {
+		close(fdin[0]);
+		*finptr = fin;
+	}
+	if(foutptr != NULL) {
+		close(fdout[1]);
+		*foutptr = fout;
+	}
+	if(ferrptr != NULL) {
+		close(fderr[1]);
+		*ferrptr = ferr;
+	}
+
+	return pid;
+
+error:
+	err = errno;
+
+	if(fin != NULL) {
+		fclose(fin);
+		fdin[1] = -1;
+	}
+	if(fout != NULL) {
+		fclose(fout);
+		fdout[0] = -1;
+	}
+	if(ferr != NULL) {
+		fclose(ferr);
+		fderr[0] = -1;
+	}
+
+	close_pipe(fdin);
+	close_pipe(fdout);
+	close_pipe(fderr);
+	close_pipe(fdsig);
+
+	errno = err;
+
+	return -1;
+}

--- a/popen3.h
+++ b/popen3.h
@@ -1,0 +1,27 @@
+/*
+ * popen3.h -- execute a command and connect stdin, stdout and stderr
+ *
+ * Copyright (c) 2019, NLnet Labs. All rights reserved.
+ *
+ * See LICENSE for the license.
+ *
+ */
+#ifndef _POPEN3_H_
+#define _POPEN3_H_
+
+#include <stdio.h>
+#include <sys/types.h>
+
+/*
+ * Execute a command and connect stdin, stdout and stderr of the process to
+ * respectively finptr, foutptr and ferrptr if non-NULL. The process
+ * identifier of the new process is returned on success and the pointers to
+ * the FILE handles will have been set. On failure, -1 is returned and none
+ * of the pointers will have been set.
+ */
+pid_t popen3(char *const *command,
+             FILE **finptr,
+             FILE **foutptr,
+             FILE **ferrptr);
+
+#endif /* _POPEN3_H_ */

--- a/tpkg/cutest.tdir/cutest.test
+++ b/tpkg/cutest.tdir/cutest.test
@@ -11,4 +11,5 @@ else
 fi
 
 # run the unit tests.
+export POPEN3_ECHO=../../popen3_echo
 ../../cutest

--- a/tpkg/cutest/cutest.c
+++ b/tpkg/cutest/cutest.c
@@ -1,5 +1,6 @@
 #include "config.h"
 #include <assert.h>
+#include <regex.h>
 #include <setjmp.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -111,17 +112,17 @@ void CuStringInsert(CuString* str, const char* text, int pos)
  * CuTest
  *-------------------------------------------------------------------------*/
 
-void CuTestInit(CuTest* t, const char* name, TestFunction function)
+void CuTestInit(CuTest* t, const char* name, CuTestFunction function)
 {
 	t->name = CuStrCopy(name);
-	t->failed = 0;
+	t->result = CuPassed;
 	t->ran = 0;
 	t->message = NULL;
 	t->function = function;
 	t->jumpBuf = NULL;
 }
 
-CuTest* CuTestNew(const char* name, TestFunction function)
+CuTest* CuTestNew(const char* name, CuTestFunction function)
 {
 	CuTest* tc = CU_ALLOC(CuTest);
 	CuTestInit(tc, name, function);
@@ -156,7 +157,7 @@ static void CuFailInternal(CuTest* tc, const char* file, int line, CuString* str
 	snprintf(buf, sizeof(buf), "%s:%d: ", file, line);
 	CuStringInsert(string, buf, 0);
 
-	tc->failed = 1;
+	tc->result = CuFailed;
 	tc->message = string->buffer;
 	if (tc->jumpBuf != 0) longjmp(*(tc->jumpBuf), 0);
 }
@@ -241,6 +242,7 @@ void CuAssertPtrEquals_LineMsg(CuTest* tc, const char* file, int line, const cha
 void CuSuiteInit(CuSuite* testSuite)
 {
 	testSuite->count = 0;
+	testSuite->skipCount = 0;
 	testSuite->failCount = 0;
 }
 
@@ -285,16 +287,53 @@ void CuSuiteRun(CuSuite* testSuite)
 	CuSuiteRunDisplay(testSuite, NULL);
 }
 
-void CuSuiteRunDisplay(CuSuite* testSuite, void (*callback)(int)) 
+void CuSuiteRunDisplay(CuSuite* testSuite, void (*callback)(CuTestResult))
 {
 	int i;
 	for (i = 0 ; i < testSuite->count ; ++i)
 	{
 		CuTest* testCase = testSuite->list[i];
 		CuTestRun(testCase);
-		if (testCase->failed) { testSuite->failCount += 1; }
-		if (callback) { callback(testCase->failed); }
+		if (testCase->result == CuFailed) { testSuite->failCount++; }
+		if (callback) { callback(testCase->result); }
 	}
+}
+
+int CuSuiteRunRegex(CuSuite* testSuite, const char *regex)
+{
+	return CuSuiteRunRegexDisplay(testSuite, regex, NULL);
+}
+
+int CuSuiteRunRegexDisplay(CuSuite* testSuite, const char *regex, void (*callback)(CuTestResult))
+{
+	int err;
+	regex_t preg;
+	regmatch_t pmatch[1];
+
+	if ((err = regcomp(&preg, regex, REG_EXTENDED | REG_NOSUB)) != 0)
+	{
+		return -1;
+	}
+
+	for (int i = 0; i < testSuite->count ; ++i)
+	{
+		CuTest* testCase = testSuite->list[i];
+		if (regexec(&preg, testCase->name, 0, pmatch, 0) == 0)
+		{
+			CuTestRun(testCase);
+			if (testCase->result == CuFailed) { testSuite->failCount++; }
+		}
+		else
+		{
+			testCase->result = CuSkipped;
+			testSuite->skipCount++;
+		}
+		if (callback) { callback(testCase->result); }
+	}
+
+	regfree(&preg);
+
+	return 0;
 }
 
 void CuSuiteSummary(CuSuite* testSuite, CuString* summary)
@@ -302,8 +341,13 @@ void CuSuiteSummary(CuSuite* testSuite, CuString* summary)
 	int i;
 	for (i = 0 ; i < testSuite->count ; ++i)
 	{
+		const char *r = ".";
 		CuTest* testCase = testSuite->list[i];
-		CuStringAppend(summary, testCase->failed ? "F" : ".");
+		if (testCase->result == CuSkipped)
+			r = "S";
+		else if (testCase->result == CuFailed)
+			r = "F";
+		CuStringAppend(summary, r);
 	}
 	CuStringAppend(summary, "\n\n");
 }
@@ -315,9 +359,11 @@ void CuSuiteDetails(CuSuite* testSuite, CuString* details)
 
 	if (testSuite->failCount == 0)
 	{
-		int passCount = testSuite->count - testSuite->failCount;
+		int passCount = testSuite->count - (testSuite->failCount + testSuite->skipCount);
 		const char* testWord = passCount == 1 ? "test" : "tests";
 		CuStringAppendFormat(details, "OK (%d %s)\n", passCount, testWord);
+		testWord = testSuite->skipCount == 1 ? "test" : "tests";
+		CuStringAppendFormat(details, "SKIP (%d %s)\n", testSuite->skipCount, testWord);
 	}
 	else
 	{
@@ -329,7 +375,7 @@ void CuSuiteDetails(CuSuite* testSuite, CuString* details)
 		for (i = 0 ; i < testSuite->count ; ++i)
 		{
 			CuTest* testCase = testSuite->list[i];
-			if (testCase->failed)
+			if (testCase->result == CuFailed)
 			{
 				failCount++;
 				CuStringAppendFormat(details, "%d) %s: %s\n",
@@ -339,7 +385,8 @@ void CuSuiteDetails(CuSuite* testSuite, CuString* details)
 		CuStringAppend(details, "\n!!!FAILURES!!!\n");
 
 		CuStringAppendFormat(details, "Runs: %d ",   testSuite->count);
-		CuStringAppendFormat(details, "Passes: %d ", testSuite->count - testSuite->failCount);
-		CuStringAppendFormat(details, "Fails: %d\n",  testSuite->failCount);
+		CuStringAppendFormat(details, "Skipped: %d ", testSuite->skipCount);
+		CuStringAppendFormat(details, "Passed: %d ", testSuite->count - (testSuite->failCount + testSuite->skipCount));
+		CuStringAppendFormat(details, "Failed: %d\n",  testSuite->failCount);
 	}
 }

--- a/tpkg/cutest/cutest.h
+++ b/tpkg/cutest/cutest.h
@@ -36,20 +36,29 @@ void CuStringResize(CuString* str, int newSize);
 
 typedef struct CuTest CuTest;
 
-typedef void (*TestFunction)(CuTest *);
+typedef void (*CuTestFunction)(CuTest *);
+
+typedef enum CuTestResult CuTestResult;
+
+enum CuTestResult
+{
+	CuPassed,
+	CuFailed,
+	CuSkipped
+};
 
 struct CuTest
 {
 	char* name;
-	TestFunction function;
-	int failed;
+	CuTestFunction function;
+	CuTestResult result;
 	int ran;
 	char* message;
 	jmp_buf *jumpBuf;
 };
 
-void CuTestInit(CuTest* t, const char* name, TestFunction function);
-CuTest* CuTestNew(const char* name, TestFunction function);
+void CuTestInit(CuTest* t, const char* name, CuTestFunction function);
+CuTest* CuTestNew(const char* name, CuTestFunction function);
 void CuTestFree(CuTest* tc);
 void CuTestRun(CuTest* tc);
 
@@ -104,7 +113,7 @@ typedef struct
 	int count;
 	CuTest* list[MAX_TEST_CASES];
 	int failCount;
-
+	int skipCount;
 } CuSuite;
 
 
@@ -116,7 +125,9 @@ void CuSuiteAddSuite(CuSuite* testSuite, CuSuite* testSuite2);
 void CuSuiteRun(CuSuite* testSuite);
 /* Added Wouter Wijngaards may 2006: same as CuSuiteRun, but
    callback is called for every test with as argument if testcase failed. */
-void CuSuiteRunDisplay(CuSuite* testSuite, void (*callback)(int));
+void CuSuiteRunDisplay(CuSuite* testSuite, void (*callback)(CuTestResult));
+int CuSuiteRunRegex(CuSuite* testSuite, const char *regex);
+int CuSuiteRunRegexDisplay(CuSuite* testSuite, const char *regex, void (*callback)(CuTestResult));
 void CuSuiteSummary(CuSuite* testSuite, CuString* summary);
 void CuSuiteDetails(CuSuite* testSuite, CuString* details);
 

--- a/tpkg/cutest/cutest_event.c
+++ b/tpkg/cutest/cutest_event.c
@@ -1,0 +1,357 @@
+#include "config.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#if defined(USE_MINI_EVENT)
+# include "mini_event.h"
+#elif defined(HAVE_EVENT_H)
+# include <event.h>
+#else
+# include <event2/event.h>
+# include <event2/event_struct.h>
+# include <event2/event_compat.h>
+#endif /* USE_MINI_EVENT */
+
+#include "nsd.h"
+#include "tpkg/cutest/cutest.h"
+
+struct proc {
+	pid_t pid;
+	int wstatus;
+	int fdin;
+	int fdout;
+	struct event event;
+	short events;
+};
+
+#define NUM_CHILDREN (3)
+
+struct testvars {
+	struct event_base *event_base;
+	struct event event_sigchld;
+	struct proc agent;
+	struct proc children[NUM_CHILDREN];
+	unsigned int sigchld_count;
+};
+
+static void
+child(int fdin, int fdout)
+{
+	char buf[32];
+	ssize_t cnt;
+	ssize_t discard;
+
+	/* FIXME: maybe necessary to register signal handler? */
+	discard = read(fdin, buf, sizeof(buf));
+	(void)discard;
+	cnt = snprintf(buf, sizeof(buf), "%d\n", getpid());
+	discard = write(fdout, buf, (size_t)(cnt >= 0 ? cnt : 0));
+	(void)discard;
+	exit(0);
+}
+
+static void
+sigterm_handler(int signo)
+{
+	(void)signo;
+	exit(0);
+}
+
+static void
+agent(int fdin, int fdout, struct testvars *vars, void(*func)(struct proc *))
+{
+	char buf[32];
+	ssize_t cnt;
+	ssize_t discard;
+
+	signal(SIGTERM, sigterm_handler);
+	discard = read(fdin, buf, sizeof(buf));
+	(void)discard;
+	for (size_t i = 0; i < NUM_CHILDREN; i++) {
+		func(&vars->children[i]);
+	}
+	cnt = snprintf(buf, sizeof(buf), "%d\n", getpid());
+	discard = write(fdout, buf, (size_t)(cnt >= 0 ? cnt : 0));
+	(void)discard;
+	exit(0);
+}
+
+static void
+agent_callback(int fd, short event, void *arg)
+{
+	char buf[] = "x";
+	struct proc *proc = (struct proc *)arg;
+	ssize_t discard;
+
+	(void)fd;
+	assert(arg != NULL);
+
+	if (event & EV_TIMEOUT) {
+		discard = write(fd, buf, strlen(buf));
+		(void)discard;
+	} else if(event & EV_WRITE) {
+		discard = write(fd, buf, strlen(buf));
+		(void)discard;
+		proc->events |= EV_WRITE;
+	}
+}
+
+static void
+child_callback(int fd, short event, void *arg)
+{
+	struct proc *proc = (struct proc *)arg;
+
+	(void)fd;
+	assert(arg != NULL);
+
+	if (event & EV_READ) {
+		proc->events |= EV_READ;
+	}
+}
+
+static void
+sigchld_callback(int sig, short event, void *arg)
+{
+	pid_t pid;
+	int wstatus = 0;
+	struct testvars *vars = (struct testvars *)arg;
+	struct proc *proc;
+
+	assert(sig == SIGCHLD);
+	assert(event & EV_SIGNAL);
+	assert(arg != NULL);
+
+	do {
+		pid = waitpid(-1, &wstatus, WNOHANG);
+		proc = NULL;
+		if(vars->agent.pid == pid) {
+			proc = &vars->agent;
+		} else if(pid > 0) {
+			for(int i = 0; i < NUM_CHILDREN; i++) {
+				if(vars->children[i].pid == pid) {
+					proc = &vars->children[i];
+				}
+			}
+		}
+		if(proc != NULL) {
+			vars->sigchld_count++;
+			proc->wstatus = wstatus;
+			proc->events |= EV_SIGNAL;
+		}
+	} while((pid == -1 && errno == EINTR) || (pid > 0));
+
+	if(vars->sigchld_count == (NUM_CHILDREN + 1)) {
+		event_base_loopexit(vars->event_base, NULL);
+	}
+}
+
+static void
+fork_children(struct testvars *vars)
+{
+	for(int i = 0; i < NUM_CHILDREN; i++) {
+		pid_t pid;
+		int ret, fdin[2], fdout[2];
+		ret = pipe(fdin);
+		assert(ret == 0);
+		ret = pipe(fdout);
+		assert(ret == 0);
+		if((pid = fork()) == 0) {
+			close(fdin[1]);
+			close(fdout[0]);
+			child(fdin[0], fdout[1]);
+			/* never reached */
+		}
+		close(fdin[0]);
+		close(fdout[1]);
+		vars->children[i].pid = pid;
+		vars->children[i].fdin = fdin[1];
+		vars->children[i].fdout = fdout[0];
+		event_set(
+			&vars->children[i].event,
+			 vars->children[i].fdin,
+			 EV_READ,
+			&child_callback,
+			&vars->children[i]);
+		event_base_set(vars->event_base, &vars->children[i].event);
+		event_add(&vars->children[i].event, NULL);
+	}
+}
+
+static void
+fork_agent(struct testvars *vars, void(*func)(struct proc *))
+{
+	pid_t pid;
+	int ret, fdin[2], fdout[2];
+	struct timeval timeout = { 1, 0 };
+	ret = pipe(fdin);
+	assert(ret == 0);
+	ret = pipe(fdout);
+	assert(ret == 0);
+	if((pid = fork()) == 0) {
+		close(fdin[1]);
+		close(fdout[0]);
+		agent(fdin[0], fdout[1], vars, func);
+		/* never reached */
+	}
+	close(fdin[0]);
+	close(fdout[1]);
+	vars->agent.pid = pid;
+	vars->agent.fdin = fdin[1];
+	vars->agent.fdout = fdout[0];
+	event_set(
+		&vars->agent.event,
+		 vars->agent.fdin,
+		 EV_WRITE,
+		&agent_callback,
+		 vars);
+	event_base_set(vars->event_base, &vars->agent.event);
+	event_add(&vars->agent.event, &timeout);
+}
+
+static void
+event_setup(struct testvars *vars)
+{
+	int ret;
+
+	memset(vars, 0, sizeof(*vars));
+	vars->event_base = nsd_child_event_base();
+	assert(vars->event_base != NULL);
+	event_set(&vars->event_sigchld, SIGCHLD, EV_SIGNAL | EV_PERSIST, sigchld_callback, vars);
+	ret = event_base_set(vars->event_base, &vars->event_sigchld);
+	assert(ret == 0);
+	ret = event_add(&vars->event_sigchld, NULL);
+	assert(ret == 0);
+
+	for(int i = 0; i < NUM_CHILDREN; i++) {
+		vars->children[i].pid = -1;
+		vars->children[i].fdin = -1;
+		vars->children[i].fdout = -1;
+		memset(&vars->children[i].event, 0, sizeof(vars->children[i].event));
+	}
+}
+
+static void
+event_teardown(struct testvars *vars)
+{
+	if(vars->agent.fdin != -1 &&
+	   event_initialized(&vars->agent.event) &&
+	   event_get_fd(&vars->agent.event) == vars->agent.fdin)
+	{
+		event_del(&vars->agent.event);
+	}
+
+	for(int i = 0; i < NUM_CHILDREN; i++) {
+		if(vars->children[i].fdin != -1 &&
+		   vars->children[i].event.ev_fd == vars->children[i].fdin)
+		{
+			event_del(&vars->children[i].event);
+		}
+	}
+
+	event_del(&vars->event_sigchld);
+	event_base_free(vars->event_base);
+
+	(void)vars;
+}
+
+static void
+stop_child(struct proc *proc)
+{
+	char buf[] = "x";
+	ssize_t discard;
+	discard = write(proc->fdin, buf, strlen(buf));
+	(void)discard;
+}
+
+static void
+terminate_child(struct proc *proc)
+{
+	kill(proc->pid, SIGTERM);
+}
+
+static void
+kill_child(struct proc *proc)
+{
+	kill(proc->pid, SIGKILL);
+}
+
+static void
+event_wait_for_children(CuTest *tc)
+{
+	int ret;
+	struct testvars vars;
+
+	event_setup(&vars);
+
+	fork_children(&vars);
+	fork_agent(&vars, stop_child);
+	ret = event_base_dispatch(vars.event_base);
+
+	CuAssert(tc, "", ret != -1);
+
+	for(int i = 0; i < NUM_CHILDREN; i++) {
+		CuAssert(tc, "", WIFEXITED(vars.children[i].wstatus));
+		CuAssert(tc, "", (vars.children[i].events & EV_SIGNAL));
+	}
+
+	event_teardown(&vars);
+}
+
+static void
+event_terminate_children(CuTest *tc)
+{
+	int ret;
+	struct testvars vars;
+
+	event_setup(&vars);
+
+	fork_children(&vars);
+	fork_agent(&vars, terminate_child);
+	ret = event_base_dispatch(vars.event_base);
+
+	CuAssert(tc, "", ret != -1);
+
+	for(int i = 0; i < NUM_CHILDREN; i++) {
+		CuAssert(tc, "", !WIFEXITED(vars.children[i].wstatus));
+		CuAssert(tc, "", (vars.children[i].events & EV_SIGNAL));
+	}
+
+	event_teardown(&vars);
+}
+
+static void
+event_kill_children(CuTest *tc)
+{
+	int ret;
+	struct testvars vars;
+
+	event_setup(&vars);
+
+	fork_children(&vars);
+	fork_agent(&vars, kill_child);
+	ret = event_base_dispatch(vars.event_base);
+
+	CuAssert(tc, "", ret != -1);
+
+	for(int i = 0; i < NUM_CHILDREN; i++) {
+		CuAssert(tc, "", !WIFEXITED(vars.children[i].wstatus));
+		CuAssert(tc, "", (vars.children[i].events & EV_SIGNAL));
+	}
+
+	event_teardown(&vars);
+}
+
+CuSuite *reg_cutest_event(void)
+{
+	CuSuite *suite = CuSuiteNew();
+	SUITE_ADD_TEST(suite, &event_wait_for_children);
+	SUITE_ADD_TEST(suite, &event_terminate_children);
+	SUITE_ADD_TEST(suite, &event_kill_children);
+	return suite;
+}

--- a/tpkg/cutest/cutest_iter.c
+++ b/tpkg/cutest/cutest_iter.c
@@ -1,0 +1,204 @@
+/*
+	test zone_rr_iter
+*/
+#include "config.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "nsd.h"
+#include "options.h"
+#include "namedb.h"
+
+#include "tpkg/cutest/cutest.h"
+
+static struct namedb *
+create_namedb(void)
+{
+	struct namedb *db;
+
+        if((db = namedb_open(NULL, NULL)) == NULL) {
+                fprintf(stderr, "failed to create namedb\n");
+                exit(1);
+        }
+
+        return db;
+}
+
+static void
+destroy_namedb(struct namedb *db)
+{
+	namedb_close(db);
+}
+
+static void
+create_zone(struct namedb *db, const char *name, const char *data)
+{
+	struct nsd nsd;
+	struct nsd_options *options;
+	struct region *region;
+	char zonefile[512];
+	struct zone_options *zone;
+	FILE *zonefh;
+	size_t datalen;
+
+	assert(db != NULL);
+	assert(name != NULL);
+	assert(data != NULL);
+
+	memset(&nsd, 0, sizeof(nsd));
+	nsd.db = db;
+	region = region_create(xalloc, free);
+	options = nsd_options_create(region);
+	snprintf(zonefile, sizeof(zonefile), "%szone", name);
+	zone = zone_options_create(region);
+	memset(zone, 0, sizeof(*zone));
+	zone->name = region_strdup(region, name);
+	zone->pattern = pattern_options_create(region);
+	zone->pattern->pname = zone->name;
+	zone->pattern->zonefile = region_strdup(region, zonefile);
+	zone->pattern->request_xfr = (void*)-1; /* dummy value to make zonec not error */
+
+	if(!nsd_options_insert_zone(options, zone)) {
+		fprintf(stderr, "failed to create zone %s\n", name);
+		exit(1);
+	}
+	if((zonefh = fopen(zonefile, "w")) == NULL) {
+		fprintf(stderr, "failed to open %s: %s\n", zonefile, strerror(errno));
+		exit(1);
+	}
+	datalen = strlen(data);
+	if(fwrite(data, 1, datalen, zonefh) != datalen) {
+		fprintf(stderr, "failed to write %s: %s\n", zonefile, strerror(errno));
+	}
+	fclose(zonefh);
+
+	namedb_check_zonefiles(&nsd, options, NULL, NULL);
+	unlink(zonefile);
+	nsd_options_destroy(options);
+}
+
+static const char bar_foo[] = "bar.foo.";
+static const char bar_foo_zone[] =
+"$ORIGIN bar.foo.\n"
+"@    IN  SOA        ns1.bar.foo. hostmaster.bar.foo. 2019103100 28800 7200 604800 3600\n"
+"     IN  NS         ns1.bar.foo.\n"
+"     IN  NS         ns2.bar.foo.\n"
+"     IN  MX     10  mx1.bar.foo.\n"
+"     IN  MX     10  mx2.bar.foo.\n"
+"     IN  A          10.20.30.40\n"
+"ns1  IN  A          11.12.13.14\n"
+"ns2  IN  A          19.18.17.16\n"
+"mx1  IN  A          11.12.13.14\n"
+"mx2  IN  A          19.18.17.16\n"
+"web  IN  A          10.20.30.40\n"
+"www  IN  CNAME      web\n"
+"baz  IN  NS         ns1.baz.bar.foo\n"
+"baz  IN  NS         ns2.baz.bar.foo\n";
+
+static const char baz_bar_foo[] = "baz.bar.foo.";
+static const char baz_bar_foo_zone[] =
+"$ORIGIN baz.bar.foo.\n"
+"@    IN  SOA        ns1.baz.bar.foo. hostmaster.bar.foo. 2020120100 28800 7200 604800 3600\n"
+"     IN  NS         ns1.baz.bar.foo.\n"
+"     IN  NS         ns2.baz.bar.foo.\n"
+"     IN  MX     10  mx1.baz.baz.foo.\n"
+"     IN  MX     10  mx2.baz.baz.foo.\n"
+"     IN  A          10.20.30.40\n"
+"ns1  IN  NS         11.12.13.14\n"
+"ns2  IN  NS         19.18.17.16\n"
+"mx1  IN  A          11.12.13.14\n"
+"mx2  IN  A          19.18.17.16\n"
+"web  IN  A          10.20.30.40\n"
+"www  IN  CNAME      web\n";
+
+static const char baz_foo[] = "baz.foo.";
+static const char baz_foo_zone[] =
+"$ORIGIN baz.foo.\n"
+"@    IN  SOA        ns1.bar.foo. hostmaster.bar.foo. 2019103100 28800 7200 604800 3600\n"
+"     IN  NS         ns1.bar.foo.\n"
+"     IN  NS         ns2.bar.foo.\n"
+"     IN  MX     10  mx1.baz.foo.\n"
+"     IN  MX     10  mx2.baz.foo.\n"
+"     IN  A          20.30.40.50\n"
+"mx1  IN  A          21.22.23.24\n"
+"mx2  IN  A          29.28.27.26\n"
+"web  IN  CNAME      web.bar.foo.\n"
+"www  IN  CNAME      web\n";
+
+static void iterate_zone(CuTest *tc)
+{
+	int eq;
+	struct namedb *db;
+	const struct dname *dname;
+	struct zone *zone;
+	struct zone_rr_iter iter;
+	struct rr *rr;
+	size_t a, ns, mx, cname;
+
+	db = create_namedb();
+	/* create two zones to ensure zone boundaries are respected */
+	create_zone(db, bar_foo, bar_foo_zone);
+	create_zone(db, baz_foo, baz_foo_zone);
+	create_zone(db, baz_bar_foo, baz_bar_foo_zone);
+
+	dname = dname_parse(db->region, bar_foo);
+	zone = namedb_find_zone(db, dname);
+	CuAssert(tc, "", zone != NULL);
+
+	zone_rr_iter_init(&iter, zone);
+
+	a = ns = mx = cname = 0;
+
+	/* verify soa rr is returned first */
+	rr = zone_rr_iter_next(&iter);
+	CuAssert(tc, "", rr != NULL);
+	eq = dname_compare(dname, domain_dname(rr->owner));
+	CuAssert(tc, "", eq == 0);
+	CuAssert(tc, "", rr->type == TYPE_SOA);
+
+	while((rr = zone_rr_iter_next(&iter)) != NULL) {
+		/* verify soa rr is not returned again */
+		CuAssert(tc, "", rr->type != TYPE_SOA);
+		if((eq = dname_compare(dname, domain_dname(rr->owner))) != 0) {
+			eq = !dname_is_subdomain(domain_dname(rr->owner),
+			                         dname);
+		}
+		CuAssert(tc, "", eq == 0);
+		switch(rr->type) {
+		case TYPE_A:
+			a++;
+			break;
+		case TYPE_NS:
+			ns++;
+			break;
+		case TYPE_MX:
+			mx++;
+			break;
+		case TYPE_CNAME:
+			cname++;
+			break;
+		default:
+			break;
+		}
+	}
+
+	/* verify all records were there */
+	CuAssert(tc, "", a == 6);
+	CuAssert(tc, "", ns == 4);
+	CuAssert(tc, "", mx == 2);
+	CuAssert(tc, "", cname == 1);
+
+	destroy_namedb(db);
+}
+
+CuSuite *reg_cutest_iter(void)
+{
+	CuSuite *suite = CuSuiteNew();
+	SUITE_ADD_TEST(suite, iterate_zone);
+	return suite;
+}
+

--- a/tpkg/cutest/cutest_popen3.c
+++ b/tpkg/cutest/cutest_popen3.c
@@ -1,0 +1,187 @@
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include "config.h"
+#include "popen3.h"
+
+#include "tpkg/cutest/cutest.h"
+
+#define use_stdin(x) (x & (1<<0))
+#define use_stdout(x) (x & (1<<1))
+#define use_stderr(x) (x & (1<<2))
+
+static int popen3_echo(const char *str, int fds)
+{
+	int ret, wret, wstatus, status;
+	FILE *fin, *fout, *ferr;
+	FILE **finptr, **foutptr, **ferrptr;
+	char *ptr, *cmd[] = { NULL, NULL };
+	pid_t pid;
+	char *buf = NULL;
+	size_t len, size = 128;
+
+	ret = -1;
+	fin = fout = ferr = NULL;
+	finptr = (use_stdin(fds) ? &fin : NULL);
+	foutptr = (use_stdout(fds) ? &fout : NULL);
+	ferrptr = (use_stderr(fds) ? &ferr : NULL);
+
+	if((cmd[0] = getenv("POPEN3_ECHO")) == NULL) {
+		cmd[0] = "./popen3_echo";
+	}
+
+	if((len = strlen(str)) > size) {
+		size = len;
+	}
+
+	if((buf = malloc(size + 1)) == NULL) {
+		fprintf(stderr, "%s: malloc: %s\n", __func__, strerror(errno));
+		goto bail;
+	}
+
+	if((pid = popen3(cmd, finptr, foutptr, ferrptr)) == -1) {
+		fprintf(stderr, "%s: popen3: %s\n", __func__, strerror(errno));
+		goto bail;
+	}
+
+	if((use_stdin(fds) && fin == NULL) ||
+	   (use_stdout(fds) && fout == NULL) ||
+	   (use_stderr(fds) && ferr == NULL))
+	{
+		fprintf(stderr, "%s: Opened pipes do not match requested\n", __func__);
+		goto bail;
+	}
+
+	if(use_stdin(fds)) {
+		if (fputs(str, fin) == EOF) {
+			fprintf(stderr, "%s: fputs: %s\n", __func__, strerror(errno));
+			goto bail;
+		}
+		fflush(fin);
+	}
+	/* wait for popen3_echo to terminate */
+
+	if((wret = waitpid(pid, &wstatus, 0)) == -1) {
+		fprintf(stderr, "%s: waitpid: %s\n", __func__, strerror(errno));
+		goto bail;
+	} else if (wret == pid) {
+		if(WIFEXITED(wstatus)) {
+			status = WEXITSTATUS(wstatus);
+		} else {
+			fprintf(stderr, "%s: Subprocess exited abnormally\n", __func__);
+			goto bail;
+		}
+	} else { /* should not happen */
+		fprintf(stderr, "%s: waitpid: Unknown error\n", __func__);
+		goto bail;
+	}
+
+	if(status != fds) {
+		fprintf(stderr, "%s: Unexpected exit code\n", __func__);
+		goto bail;
+	}
+
+	if(use_stdout(fds)) {
+		if((ptr = fgets(buf, size, fout)) == NULL) {
+			fprintf(stderr, "%s: Could not read header from stdout\n", __func__);
+			goto bail;
+		}
+		if(fread(buf, 1, size, fout) != len || strncmp(buf, str, len) != 0) {
+			fprintf(stderr, "%s: Output on stdout did not match input\n", __func__);
+			goto bail;
+		}
+	}
+
+	if(use_stderr(fds)) {
+		if((ptr = fgets(buf, size, ferr)) == NULL) {
+			fprintf(stderr, "%s: Could not read header from stderr\n", __func__);
+			goto bail;
+		}
+		if(fread(buf, 1, size, ferr) != len || strncmp(buf, str, len) != 0) {
+			fprintf(stderr, "%s: Output on stderr did not match input\n", __func__);
+			goto bail;
+		}
+	}
+
+	ret = 0;
+bail:
+	if(buf != NULL) {
+		free(buf);
+	}
+	if(fin != NULL) {
+		fclose(fin);
+	}
+	if(fout != NULL) {
+		fclose(fout);
+	}
+	if(ferr != NULL) {
+		fclose(ferr);
+	}
+	return ret;
+}
+
+static void popen3_non_existing(CuTest *tc)
+{
+	char *command[] = { "./foobarbaz", NULL };
+	FILE *fin, *fout, *ferr;
+	pid_t pid;
+
+	fin = fout = ferr = NULL;
+
+	pid = popen3(command, &fin, &fout, &ferr);
+	CuAssert(tc, "", pid == -1);
+	CuAssert(tc, "", fin == NULL);
+	CuAssert(tc, "", fout == NULL);
+	CuAssert(tc, "", ferr == NULL);
+}
+
+static void popen3_all_opened(CuTest *tc)
+{
+	int fds = (1<<0) + (1<<1) + (1<<2); /* stdin, stdout and stderr */
+	const char str[] = "foobarbaz\n";
+        CuAssert(tc, "", popen3_echo(str, fds) == 0);
+}
+
+static void popen3_all_closed(CuTest *tc)
+{
+	int fds = 0;
+	const char str[] = "foobarbaz\n";
+	CuAssert(tc, "", popen3_echo(str, fds) == 0);
+}
+
+static void popen3_stdin_only(CuTest *tc)
+{
+	int fds = (1<<0);
+	const char str[] = "foobarbaz\n";
+	CuAssert(tc, "", popen3_echo(str, fds) == 0);
+}
+
+static void popen3_stdout_only(CuTest *tc)
+{
+	int fds = (1<<0) + (1<<1);
+	const char str[] = "foobarbaz\n";
+	CuAssert(tc, "", popen3_echo(str, fds) == 0);
+}
+
+static void popen3_stderr_only(CuTest *tc)
+{
+	int fds = (1<<0) + (1<<2);
+	const char str[] = "foobarbaz\n";
+	CuAssert(tc, "", popen3_echo(str, fds) == 0);
+}
+
+CuSuite *reg_cutest_popen3(void)
+{
+	CuSuite *suite = CuSuiteNew();
+	SUITE_ADD_TEST(suite, popen3_non_existing);
+	SUITE_ADD_TEST(suite, popen3_all_opened);
+	SUITE_ADD_TEST(suite, popen3_all_closed);
+	SUITE_ADD_TEST(suite, popen3_stdin_only);
+	SUITE_ADD_TEST(suite, popen3_stdout_only);
+	SUITE_ADD_TEST(suite, popen3_stderr_only);
+	return suite;
+}
+

--- a/tpkg/cutest/cutest_rbtree.c
+++ b/tpkg/cutest/cutest_rbtree.c
@@ -568,7 +568,7 @@ static void test_add_remove(CuTest *tc, rbtree_type* tree, const int* insert, co
 		CuAssert(tc, "rbtree_search(tree, &insert[remove[i]]) == 0", (rbtree_search(tree, &insert[remove[i]]) == 0));
 
 		/* stop on any errors */
-		if(tc->failed > 0) {
+		if(tc->result == CuFailed) {
 			printf("Errors, stop \n");
 			tree_print(tc, tree);
 			return;
@@ -699,7 +699,7 @@ static void rbtree_9(CuTest *tc)
 			{
 				test_add_remove(tc, t, perm[i], perm[j]);
 				/* stop on any errors */
-				if (tc->failed > 0) {
+				if (tc->result == CuFailed) {
 					printf("Errors, stop \n");
 					return;
 				}

--- a/tpkg/cutest/cutest_run.c
+++ b/tpkg/cutest/cutest_run.c
@@ -29,6 +29,7 @@ CuSuite * reg_cutest_bitset(void);
 #ifdef RATELIMIT
 CuSuite * reg_cutest_rrl(void);
 #endif
+CuSuite * reg_cutest_popen3(void);
 
 /* dummy functions to link */
 struct nsd nsd;

--- a/tpkg/cutest/cutest_run.c
+++ b/tpkg/cutest/cutest_run.c
@@ -31,6 +31,7 @@ CuSuite * reg_cutest_rrl(void);
 #endif
 CuSuite * reg_cutest_popen3(void);
 CuSuite * reg_cutest_iter(void);
+CuSuite * reg_cutest_event(void);
 
 /* dummy functions to link */
 struct nsd nsd;
@@ -83,6 +84,7 @@ int runalltests(const char *regex)
 	CuSuiteAddSuite(suite, reg_cutest_bitset());
 	CuSuiteAddSuite(suite, reg_cutest_popen3());
 	CuSuiteAddSuite(suite, reg_cutest_iter());
+	CuSuiteAddSuite(suite, reg_cutest_event());
 
 	if(CuSuiteRunRegexDisplay(suite, regex, disp_callback) == -1) {
 		fprintf(stderr, "invalid regular expression");

--- a/tpkg/cutest/cutest_run.c
+++ b/tpkg/cutest/cutest_run.c
@@ -3,6 +3,7 @@
 	log
 	31 jan 06 (WW): created file.
 	21 feb 06 (MG): reworked for cutest
+	28 oct 19 (JK): run tests based on pattern
 */
 #include "config.h"
 #include <stdio.h>
@@ -46,14 +47,16 @@ void sig_handler(int ATTR_UNUSED(sig))
 {
 }
 
-void disp_callback(int failed)
+void disp_callback(CuTestResult result)
 {
-	if(failed)
+	if(result == CuFailed)
 		fprintf(stderr, "F");
+	else if(result == CuSkipped)
+		fprintf(stderr, "S");
 	else	fprintf(stderr, ".");
 }
 
-int runalltests(void)
+int runalltests(const char *regex)
 {
 	CuSuite *suite = CuSuiteNew();
 	CuString *output = CuStringNew();
@@ -76,8 +79,11 @@ int runalltests(void)
 	CuSuiteAddSuite(suite, reg_cutest_rrl());
 #endif
 	CuSuiteAddSuite(suite, reg_cutest_bitset());
+	CuSuiteAddSuite(suite, reg_cutest_popen3());
 
-	CuSuiteRunDisplay(suite, disp_callback);
+	if(CuSuiteRunRegexDisplay(suite, regex, disp_callback) == -1) {
+		fprintf(stderr, "invalid regular expression");
+	}
 	fprintf(stderr, "\n");
 
  	/* CuSuiteSummary(suite, output); */
@@ -119,8 +125,9 @@ int main(int argc, char* argv[])
 	char* config = NULL, *qfile=NULL;
 	int verb=0;
 	unsigned seed;
+	char *regex = ".*";
 	log_init("cutest");
-	while((c = getopt(argc, argv, "c:hq:tv")) != -1) {
+	while((c = getopt(argc, argv, "c:hq:r:tv")) != -1) {
 		switch(c) {
 		case 't':
 			return check_inet_ntop();
@@ -133,6 +140,9 @@ int main(int argc, char* argv[])
 		case 'v':
 			verb++;
 			break;
+		case 'r':
+			regex = optarg;
+			break;
 		case 'h':
 		default:
 			printf("usage: %s [opts]\n", argv[0]);
@@ -141,6 +151,7 @@ int main(int argc, char* argv[])
 			printf("-c config: specify nsd.conf file\n");
 			printf("-t test inet_ntop for string comparisons.\n");
 			printf("-v verbose, -vv, -vvv\n");
+			printf("-r regex: run only tests that match regex.\n");
 			printf("-h show help\n");
 			return 1;
 		}
@@ -155,7 +166,7 @@ int main(int argc, char* argv[])
 	fprintf(stderr, "srandom(%u)\n", seed);
 	srandom(seed);
 
-	if(runalltests() > 0)
+	if(runalltests(regex) > 0)
 		return 1;
 	else return 0;
 }

--- a/tpkg/cutest/cutest_run.c
+++ b/tpkg/cutest/cutest_run.c
@@ -30,6 +30,7 @@ CuSuite * reg_cutest_bitset(void);
 CuSuite * reg_cutest_rrl(void);
 #endif
 CuSuite * reg_cutest_popen3(void);
+CuSuite * reg_cutest_iter(void);
 
 /* dummy functions to link */
 struct nsd nsd;
@@ -81,6 +82,7 @@ int runalltests(const char *regex)
 #endif
 	CuSuiteAddSuite(suite, reg_cutest_bitset());
 	CuSuiteAddSuite(suite, reg_cutest_popen3());
+	CuSuiteAddSuite(suite, reg_cutest_iter());
 
 	if(CuSuiteRunRegexDisplay(suite, regex, disp_callback) == -1) {
 		fprintf(stderr, "invalid regular expression");

--- a/tpkg/cutest/popen3_echo.c
+++ b/tpkg/cutest/popen3_echo.c
@@ -1,0 +1,48 @@
+/* simple program to test popen3 works as expected */
+#include <assert.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+int main(int argc, char *argv[])
+{
+	int fds = 0;
+	char buf[512], hdr[512], *ptr;
+	struct { FILE *fh; const char *str; } io[3] = {
+		{ stdin, "stdin" }, { stdout, "stdout" }, { stderr, "stderr" }
+	};
+
+	(void)argc;
+	(void)argv;
+
+	hdr[0] = '\0';
+	setbuf(stdin, NULL);
+	setbuf(stdout, NULL);
+
+	for(int i = 0; i < 3; i++) {
+		char str[32];
+		int fd = fileno(io[i].fh);
+		assert(fd == i);
+		if(fcntl(fd, F_GETFD) != -1) {
+			fds |= (1<<fd);
+		}
+		(void)snprintf(str, sizeof(str), "%s%s%s", i == 0 ? "" : ",", (fds & (1<<fd)) ? "" : "!", io[i].str);
+		memcpy(hdr + strlen(hdr), str, strlen(str) + 1);
+	}
+
+	if((ptr = fgets(buf, sizeof(buf), stdin)) == NULL) {
+		buf[0] = '\0';
+	}
+	if(fds & (1<<1)) {
+		fprintf(stdout, "%s\n%s", hdr, buf);
+	}
+	if(fds & (1<<2)) {
+		fprintf(stderr, "%s\n%s", hdr, buf);
+	}
+
+	return fds;
+}
+


### PR DESCRIPTION
This PR adds an implementation of `popen3` to execute a process and attach `stdin`, `stdout` and `stderr`. It also extends the suite of unit tests to verify the call works as expected. For easy debugging of unit tests I also extended the `cutest` executable to accept a `-r` parameter to make it possible to run only tests that match the regular expression passed with the `-r` parameter.

Please consider pulling these changes.