### PR TITLE
Add initial Buildkite pipeline.yml

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,7 @@
+steps:
+  - label: Build
+    commands:
+    - autoconf && autoheader
+    - ./configure --enable-checking --disable-flto
+    - make
+    - make cutest && ./cutest


### PR DESCRIPTION
This PR adds an initial build pipeline for Buildkite, which will allow us to test on platforms that aren't supported by Cloud based CI environments like Travis and GitHub Actions.