### PR TITLE
Fix regression with minimal-responses

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -2,6 +2,9 @@
 	- Fix #52: do not log transient network full errors unless higher
 	  verbosity is set.
 
+27 November 2017 Jeroen
+	- Fix regressions in configparser.y
+
 22 November 2019: Wouter
 	- Fix #48: Add make distclean that removes config.h made by configure.
 	  And add maintainer-clean that removes bison and flex output.

--- a/doc/RELNOTES
+++ b/doc/RELNOTES
@@ -15,6 +15,8 @@ BUG FIXES:
 	- Remove unused variable warning for portability.
 	- Fix #52: do not log transient network full errors unless higher
 	  verbosity is set.
+	- Fix regressions in configparser.y where global variables were not
+	  set for minimal-responses, round-robin and log-time-ascii.
 
 
 4.2.3

--- a/tpkg/minimal_responses.tdir/minimal_responses.conf
+++ b/tpkg/minimal_responses.tdir/minimal_responses.conf
@@ -1,0 +1,15 @@
+server:
+	logfile: "nsd.log"
+	xfrdfile: xfrd.state
+	database: nsd.db
+	pidfile: nsd.pid
+	verbosity: 5
+	ip-address: 127.0.0.1
+	zonesdir: ""
+	username: ""
+	chroot: ""
+	minimal-responses: NSD_MINIMAL_RESPONSES
+
+zone:
+	name: EXAMPLE.NET
+	zonefile: minimal_responses.zone

--- a/tpkg/minimal_responses.tdir/minimal_responses.dsc
+++ b/tpkg/minimal_responses.tdir/minimal_responses.dsc
@@ -1,0 +1,16 @@
+BaseName: minimal_responses
+Version: 1.0
+Description: Test responses are actually minimal with minimal-responses enabled
+CreationDate: Tue Nov 26 13:51:20 CEST 2019
+Maintainer: Jeroen Koekkoek
+Category:
+Component:
+CmdDepends:
+Depends:
+Help:
+Pre: minimal_responses.pre
+Post:
+Test: minimal_responses.test
+AuxFiles: minimal_responses.conf, minimal_responses.zone
+Passed:
+Failure:

--- a/tpkg/minimal_responses.tdir/minimal_responses.pre
+++ b/tpkg/minimal_responses.tdir/minimal_responses.pre
@@ -1,0 +1,24 @@
+# #-- minimal_responses.pre --#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+get_random_port 1
+NSD_PORT=${RND_PORT}
+
+echo "NSD_PORT=${NSD_PORT}" >> .tpkg.var.test
+
+sed -e "s/NSD_PORT/${NSD_PORT}/g" \
+    -e "s/NSD_MINIMAL_RESPONSES/no/g" \
+    minimal_responses.conf > minimal_responses_no.conf
+
+[[ ${?} -eq 0 ]] || exit 1
+
+sed -e "s/NSD_PORT/${NSD_PORT}/g" \
+    -e "s/NSD_MINIMAL_RESPONSES/yes/g" \
+    minimal_responses.conf > minimal_responses_yes.conf
+
+[[ ${?} -eq 0 ]] || exit 1
+

--- a/tpkg/minimal_responses.tdir/minimal_responses.test
+++ b/tpkg/minimal_responses.tdir/minimal_responses.test
@@ -1,0 +1,74 @@
+# #-- minimal_responses.test --#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+NSD="../../nsd"
+
+exit_code=0
+
+${NSD} -c $(pwd)/minimal_responses_no.conf -p ${NSD_PORT} -V 5
+wait_nsd_up nsd.log
+
+dig @127.0.0.1 -p ${NSD_PORT} example.net mx | \
+  sed -e '/^;.*$/d' -e '/^\s*$/d' -e 's/\s\+/ /g' | \
+  sort > minimal_responses_no.dig
+
+ldns-read-zone -e SOA minimal_responses.zone | \
+  sed -e 's/\s\+/ /g' | \
+  sort > minimal_responses_no.ldns-read-zone
+
+if test -f nsd.pid; then
+  kill_pid $(head -n 1 nsd.pid)
+fi
+
+diff minimal_responses_no.dig minimal_responses_no.ldns-read-zone
+if [ ${?} -eq 0 ]; then
+  echo "Response with minimal_responses turned off was correct"
+else
+  exit_code=1
+  echo "Response with minimal_responses turned on was incorrect"
+  echo "dig:"
+  cat minimal_responses_no.dig
+  echo "ldns-read-zone:"
+  cat minimal_responses_no.ldns-read-zone
+fi
+
+# Cleanup left-overs for second run
+rm -f nsd.log nsd.pid
+
+
+${NSD} -c $(pwd)/minimal_responses_yes.conf -p ${NSD_PORT} -V 5
+wait_nsd_up nsd.log
+
+dig @127.0.0.1 -p ${NSD_PORT} example.net mx | \
+  sed -e '/^;.*$/d' -e '/^\s*$/d' -e 's/\s\+/ /g' | \
+  sort > minimal_responses_yes.dig
+
+ldns-read-zone minimal_responses.zone | \
+  sed -n -e 's/\s\+/ /g' -e '/MX/p' | \
+  sort > minimal_responses_yes.ldns-read-zone
+
+if test -f nsd.pid; then
+  kill_pid $(head -n 1 nsd.pid)
+fi
+
+diff minimal_responses_yes.dig minimal_responses_yes.ldns-read-zone
+if [ ${?} -eq 0 ]; then
+  echo "Response with minimal_responses turned on was correct"
+else
+  exit_code=1
+  echo "Response with minimal_responses turned on was incorrect"
+  echo "dig:"
+  cat minimal_responses_yes.dig
+  echo "ldns-read-zone:"
+  cat minimal_responses_yes.ldns-read-zone
+fi
+
+# Cleanup left-overs
+rm -f nsd.log nsd.pid
+
+exit ${exit_code}
+

--- a/tpkg/minimal_responses.tdir/minimal_responses.zone
+++ b/tpkg/minimal_responses.tdir/minimal_responses.zone
@@ -1,0 +1,10 @@
+$ORIGIN example.net.
+$TTL 86400
+@	IN	SOA	ns.example.net. hostmaster.example.net. 1 3 4 3000 5
+	IN	NS	ns.example.net.
+	IN	MX	10	mx.example.net.
+ns	IN	A	1.1.1.1
+ns	IN	AAAA	aaaa:bbbb::1
+mx	IN	A	2.2.2.2
+mx	IN	AAAA	aaaa:bbbb::2
+


### PR DESCRIPTION
This PR fixes NSD behavior wrt to `minimal-repsonses`. I've added a small test case to verify the correct answers are returned with both the option enabled and disabled. It also contains fixes for global static variables not being set for `log-time-ascii` and `round-robin` configuration variables as well some minor cosmetic changes.

Please consider pulling these changes.