### PR TITLE
Make xfrd keep valid transfers on failed reload

### DIFF
--- a/dbaccess.c
+++ b/dbaccess.c
@@ -276,6 +276,7 @@ namedb_zone_create(namedb_type* db, const dname_type* dname,
 	zone->zonestatid = 0;
 	zone->is_secure = 0;
 	zone->is_changed = 0;
+	zone->is_updated = 0;
 	zone->is_ok = 1;
 	return zone;
 }
@@ -532,10 +533,10 @@ namedb_read_zonefile(struct nsd* nsd, struct zone* zone, udb_base* taskudb,
 		if(nonexist) {
 			VERBOSITY(2, (LOG_INFO, "zonefile %s does not exist",
 				fname));
-		} else
+		} else {
 			log_msg(LOG_ERR, "zonefile %s: %s",
 				fname, strerror(errno));
-		if(taskudb) task_new_soainfo(taskudb, last_task, zone, 0);
+		}
 		return;
 	} else {
 		const char* zone_fname = zone->filename;
@@ -593,7 +594,10 @@ namedb_read_zonefile(struct nsd* nsd, struct zone* zone, udb_base* taskudb,
 			if(!udb_zone_search(nsd->db->udb, &z, dname_name(domain_dname(
 				zone->apex)), domain_dname(zone->apex)->name_size)) {
 				/* tell that zone contents has been lost */
-				if(taskudb) task_new_soainfo(taskudb, last_task, zone, 0);
+				if(taskudb) {
+					task_new_soainfo(
+						taskudb, last_task, zone, 0U, xfrd_xfr_new);
+				}
 				return;
 			}
 			/* read from udb */
@@ -619,6 +623,7 @@ namedb_read_zonefile(struct nsd* nsd, struct zone* zone, udb_base* taskudb,
 			zone->opts->name));
 		zone->is_ok = 1;
 		zone->is_changed = 0;
+		zone->is_updated = 0;
 		/* store zone into udb */
 		if(nsd->db->udb) {
 			if(!write_zone_to_udb(nsd->db->udb, zone, &mtime,
@@ -640,7 +645,9 @@ namedb_read_zonefile(struct nsd* nsd, struct zone* zone, udb_base* taskudb,
 			zone->logstr = NULL;
 		}
 	}
-	if(taskudb) task_new_soainfo(taskudb, last_task, zone, 0);
+	if(taskudb) {
+		task_new_soainfo(taskudb, last_task, zone, 0U, xfrd_xfr_new);
+	}
 #ifdef NSEC3
 	prehash_zone_complete(nsd->db, zone);
 #endif

--- a/difffile.c
+++ b/difffile.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "difffile.h"
+#include "xfrd.h"
 #include "xfrd-disk.h"
 #include "util.h"
 #include "packet.h"
@@ -101,6 +102,35 @@ diff_write_packet(const char* zone, const char* pat, uint32_t old_serial,
 }
 
 void
+diff_update_commit(
+	const char* zone, struct nsd* nsd, uint8_t commit, uint64_t filenumber)
+{
+	FILE *df;
+
+	assert(zone != NULL);
+	assert(nsd != NULL);
+	assert(commit == DIFF_NOT_COMMITTED ||
+	       commit == DIFF_COMMITTED ||
+	       commit == DIFF_CORRUPT ||
+	       commit == DIFF_INCONSISTENT);
+
+	df = xfrd_open_xfrfile(nsd, filenumber, "r+");
+	if(!df) {
+		log_msg(LOG_ERR, "could not open transfer %s file %lld: %s",
+			zone, (long long)filenumber, strerror(errno));
+		return;
+	}
+	if(!write_32(df, DIFF_PART_XFRF) || !write_8(df, commit)) {
+		log_msg(LOG_ERR, "could not write transfer %s file %lld: %s",
+			zone, (long long)filenumber, strerror(errno));
+		fclose(df);
+		return;
+	}
+	fflush(df);
+	fclose(df);
+}
+
+void
 diff_write_commit(const char* zone, uint32_t old_serial, uint32_t new_serial,
 	uint32_t num_parts, uint8_t commit, const char* log_str,
 	struct nsd* nsd, uint64_t filenumber)
@@ -180,11 +210,11 @@ diff_read_32(FILE *in, uint32_t* result)
 int
 diff_read_8(FILE *in, uint8_t* result)
 {
-        if (fread(result, sizeof(*result), 1, in) == 1) {
-                return 1;
-        } else {
-                return 0;
-        }
+	if (fread(result, sizeof(*result), 1, in) == 1) {
+		return 1;
+	} else {
+		return 0;
+	}
 }
 
 int
@@ -1262,10 +1292,9 @@ check_for_bad_serial(namedb_type* db, const char* zone_str, uint32_t old_serial)
 	return 0;
 }
 
-static int
+static xfrd_xfr_state_type
 apply_ixfr_for_zone(nsd_type* nsd, zone_type* zonedb, FILE* in,
-	struct nsd_options* opt, udb_base* taskudb, udb_ptr* last_task,
-	uint32_t xfrfilenr)
+	udb_base* taskudb, udb_ptr* last_task, uint64_t xfrfilenr)
 {
 	char zone_buf[3072];
 	char log_buf[5120];
@@ -1277,159 +1306,171 @@ apply_ixfr_for_zone(nsd_type* nsd, zone_type* zonedb, FILE* in,
 	uint8_t committed;
 	uint32_t i;
 	int num_bytes = 0;
+
+	int is_axfr=0, delete_mode=0, rr_count=0, softfail=0;
+	const dname_type* apex = domain_dname_const(zonedb->apex);
+	udb_ptr z;
+
+	(void)last_task;
 	assert(zonedb);
 
 	/* read zone name and serial */
 	if(!diff_read_32(in, &type)) {
 		log_msg(LOG_ERR, "diff file too short");
-		return 0;
+		return xfrd_xfr_corrupt;
 	}
 	if(type != DIFF_PART_XFRF) {
 		log_msg(LOG_ERR, "xfr file has wrong format");
-		return 0;
-
+		return xfrd_xfr_corrupt;
 	}
+
 	/* committed and num_parts are first because they need to be
 	 * updated once the rest is written.  The log buf is not certain
 	 * until its done, so at end of file.  The patname is in case a
 	 * new zone is created, we know what the options-pattern is */
 	if(!diff_read_8(in, &committed) ||
-		!diff_read_32(in, &num_parts) ||
-		!diff_read_64(in, &time_end_0) ||
-		!diff_read_32(in, &time_end_1) ||
-		!diff_read_32(in, &old_serial) ||
-		!diff_read_32(in, &new_serial) ||
-		!diff_read_64(in, &time_start_0) ||
-		!diff_read_32(in, &time_start_1) ||
-		!diff_read_str(in, zone_buf, sizeof(zone_buf)) ||
-		!diff_read_str(in, patname_buf, sizeof(patname_buf))) {
+	   !diff_read_32(in, &num_parts) ||
+	   !diff_read_64(in, &time_end_0) ||
+	   !diff_read_32(in, &time_end_1) ||
+	   !diff_read_32(in, &old_serial) ||
+	   !diff_read_32(in, &new_serial) ||
+	   !diff_read_64(in, &time_start_0) ||
+	   !diff_read_32(in, &time_start_1) ||
+	   !diff_read_str(in, zone_buf, sizeof(zone_buf)) ||
+	   !diff_read_str(in, patname_buf, sizeof(patname_buf)))
+	{
 		log_msg(LOG_ERR, "diff file bad commit part");
-		return 0;
+		return xfrd_xfr_corrupt;
 	}
 
 	/* has been read in completely */
 	if(strcmp(zone_buf, domain_to_string(zonedb->apex)) != 0) {
 		log_msg(LOG_ERR, "file %s does not match task %s",
 			zone_buf, domain_to_string(zonedb->apex));
-		return 0;
+		return xfrd_xfr_corrupt;
 	}
-	if(!committed) {
+	switch(committed) {
+	case DIFF_NOT_COMMITTED:
 		log_msg(LOG_ERR, "diff file %s was not committed", zone_buf);
-		return 0;
+		return xfrd_xfr_corrupt;
+	case DIFF_CORRUPT:
+		log_msg(LOG_ERR, "diff file %s was corrupt", zone_buf);
+		return xfrd_xfr_corrupt;
+	case DIFF_INCONSISTENT:
+		log_msg(LOG_ERR, "diff file %s was inconsistent", zone_buf);
+		return xfrd_xfr_inconsistent;
+	default:
+		assert(committed == DIFF_COMMITTED);
+		break;
 	}
 	if(num_parts == 0) {
 		log_msg(LOG_ERR, "diff file %s was not completed", zone_buf);
-		return 0;
+		return xfrd_xfr_corrupt;
 	}
 	if(check_for_bad_serial(nsd->db, zone_buf, old_serial)) {
 		DEBUG(DEBUG_XFRD,1, (LOG_ERR,
 			"skipping diff file commit with bad serial"));
-		return 1;
+		return xfrd_xfr_corrupt;
 	}
 
-	if(committed)
-	{
-		int is_axfr=0, delete_mode=0, rr_count=0, softfail=0;
-		const dname_type* apex = domain_dname_const(zonedb->apex);
-		udb_ptr z;
-
-		DEBUG(DEBUG_XFRD,1, (LOG_INFO, "processing xfr: %s", zone_buf));
-		memset(&z, 0, sizeof(z)); /* if udb==NULL, have &z defined */
-		if(nsd->db->udb) {
-			if(udb_base_get_userflags(nsd->db->udb) != 0) {
-				log_msg(LOG_ERR, "database corrupted, cannot update");
-				xfrd_unlink_xfrfile(nsd, xfrfilenr);
-				exit(1);
-			}
-			/* all parts were checked by xfrd before commit */
-			if(!udb_zone_search(nsd->db->udb, &z, dname_name(apex),
+	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "processing xfr: %s", zone_buf));
+	memset(&z, 0, sizeof(z)); /* if udb==NULL, have &z defined */
+	if(nsd->db->udb) {
+		if(udb_base_get_userflags(nsd->db->udb) != 0) {
+			log_msg(LOG_ERR, "database corrupted, cannot update");
+			diff_update_commit(
+				zone_buf, nsd, DIFF_CORRUPT, xfrfilenr);
+			exit(1);
+		}
+		/* all parts were checked by xfrd before commit */
+		if(!udb_zone_search(nsd->db->udb, &z, dname_name(apex),
+			apex->name_size)) {
+			/* create it */
+			if(!udb_zone_create(nsd->db->udb, &z, dname_name(apex),
 				apex->name_size)) {
-				/* create it */
-				if(!udb_zone_create(nsd->db->udb, &z, dname_name(apex),
-					apex->name_size)) {
-					/* out of disk space perhaps */
-					log_msg(LOG_ERR, "could not udb_create_zone "
-						"%s, disk space full?", log_buf);
-					return 0;
-				}
-			}
-			/* set the udb dirty until we are finished applying changes */
-			udb_base_set_userflags(nsd->db->udb, 1);
-		}
-		/* read and apply all of the parts */
-		for(i=0; i<num_parts; i++) {
-			int ret;
-			DEBUG(DEBUG_XFRD,2, (LOG_INFO, "processing xfr: apply part %d", (int)i));
-			ret = apply_ixfr(nsd->db, in, zone_buf, new_serial, opt,
-				i, num_parts, &is_axfr, &delete_mode,
-				&rr_count, (nsd->db->udb?&z:NULL), &zonedb,
-				patname_buf, &num_bytes, &softfail);
-			assert(zonedb);
-			if(ret == 0) {
-				log_msg(LOG_ERR, "bad ixfr packet part %d in diff file for %s", (int)i, zone_buf);
-				xfrd_unlink_xfrfile(nsd, xfrfilenr);
-				/* the udb is still dirty, it is bad */
-				exit(1);
-			} else if(ret == 2) {
-				break;
+				/* out of disk space perhaps */
+				log_msg(LOG_ERR, "could not udb_create_zone "
+					"%s, disk space full?", log_buf);
+				return xfrd_xfr_corrupt;
 			}
 		}
-		if(nsd->db->udb)
-			udb_base_set_userflags(nsd->db->udb, 0);
-		/* read the final log_str: but do not fail on it */
-		if(!diff_read_str(in, log_buf, sizeof(log_buf))) {
-			log_msg(LOG_ERR, "could not read log for transfer %s",
-				zone_buf);
-			snprintf(log_buf, sizeof(log_buf), "error reading log");
+		/* set the udb dirty until we are finished applying changes */
+		udb_base_set_userflags(nsd->db->udb, 1);
+	}
+	/* read and apply all of the parts */
+	for(i=0; i<num_parts; i++) {
+		int ret;
+		DEBUG(DEBUG_XFRD,2, (LOG_INFO, "processing xfr: apply part %d", (int)i));
+		ret = apply_ixfr(nsd->db, in, zone_buf, new_serial, nsd->options,
+			i, num_parts, &is_axfr, &delete_mode,
+			&rr_count, (nsd->db->udb?&z:NULL), &zonedb,
+			patname_buf, &num_bytes, &softfail);
+		assert(zonedb);
+		if(ret == 0) {
+			log_msg(LOG_ERR, "bad ixfr packet part %d in diff file for %s", (int)i, zone_buf);
+			diff_update_commit(
+				zone_buf, nsd, DIFF_CORRUPT, xfrfilenr);
+			/* the udb is still dirty, it is bad */
+			exit(1);
+		} else if(ret == 2) {
+			break;
 		}
+	}
+	if(nsd->db->udb)
+		udb_base_set_userflags(nsd->db->udb, 0);
+	/* read the final log_str: but do not fail on it */
+	if(!diff_read_str(in, log_buf, sizeof(log_buf))) {
+		log_msg(LOG_ERR, "could not read log for transfer %s",
+			zone_buf);
+		snprintf(log_buf, sizeof(log_buf), "error reading log");
+	}
 #ifdef NSEC3
-		if(zonedb) prehash_zone(nsd->db, zonedb);
+	if(zonedb) prehash_zone(nsd->db, zonedb);
 #endif /* NSEC3 */
-		zonedb->is_changed = 1;
-		if(nsd->db->udb) {
-			assert(z.base);
-			ZONE(&z)->is_changed = 1;
-			ZONE(&z)->mtime = time_end_0;
-			ZONE(&z)->mtime_nsec = time_end_1*1000;
-			udb_zone_set_log_str(nsd->db->udb, &z, log_buf);
-			udb_zone_set_file_str(nsd->db->udb, &z, NULL);
-			udb_ptr_unlink(&z, nsd->db->udb);
-		} else {
-			zonedb->mtime.tv_sec = time_end_0;
-			zonedb->mtime.tv_nsec = time_end_1*1000;
-			if(zonedb->logstr)
-				region_recycle(nsd->db->region, zonedb->logstr,
-					strlen(zonedb->logstr)+1);
-			zonedb->logstr = region_strdup(nsd->db->region, log_buf);
-			if(zonedb->filename)
-				region_recycle(nsd->db->region, zonedb->filename,
-					strlen(zonedb->filename)+1);
-			zonedb->filename = NULL;
-		}
-		if(softfail && taskudb && !is_axfr) {
-			log_msg(LOG_ERR, "Failed to apply IXFR cleanly "
-				"(deletes nonexistent RRs, adds existing RRs). "
-				"Zone %s contents is different from master, "
-				"starting AXFR. Transfer %s", zone_buf, log_buf);
-			/* add/del failures in IXFR, get an AXFR */
-			task_new_soainfo(taskudb, last_task, zonedb, 1);
-		} else {
-			if(taskudb)
-				task_new_soainfo(taskudb, last_task, zonedb, 0);
-		}
+	zonedb->is_changed = 1;
+	zonedb->is_updated = 1;
+	if(nsd->db->udb) {
+		assert(z.base);
+		ZONE(&z)->is_changed = 1;
+		ZONE(&z)->mtime = time_end_0;
+		ZONE(&z)->mtime_nsec = time_end_1*1000;
+		udb_zone_set_log_str(nsd->db->udb, &z, log_buf);
+		udb_zone_set_file_str(nsd->db->udb, &z, NULL);
+		udb_ptr_unlink(&z, nsd->db->udb);
+	} else {
+		zonedb->mtime.tv_sec = time_end_0;
+		zonedb->mtime.tv_nsec = time_end_1*1000;
+		if(zonedb->logstr)
+			region_recycle(nsd->db->region, zonedb->logstr,
+				strlen(zonedb->logstr)+1);
+		zonedb->logstr = region_strdup(nsd->db->region, log_buf);
+		if(zonedb->filename)
+			region_recycle(nsd->db->region, zonedb->filename,
+				strlen(zonedb->filename)+1);
+		zonedb->filename = NULL;
+	}
+	if(softfail && taskudb && !is_axfr) {
+		log_msg(LOG_ERR, "Failed to apply IXFR cleanly "
+			"(deletes nonexistent RRs, adds existing RRs). "
+			"Zone %s contents is different from master, "
+			"starting AXFR. Transfer %s", zone_buf, log_buf);
+		/* add/del failures in IXFR, get an AXFR */
+		diff_update_commit(
+			zone_buf, nsd, DIFF_INCONSISTENT, xfrfilenr);
+		exit(1);
+	} else if(taskudb) {
+		return xfrd_xfr_ok;
+	}
 
-		if(1 <= verbosity) {
-			double elapsed = (double)(time_end_0 - time_start_0)+
-				(double)((double)time_end_1
-				-(double)time_start_1) / 1000000.0;
-			VERBOSITY(1, (LOG_INFO, "zone %s %s of %d bytes in %g seconds",
-				zone_buf, log_buf, num_bytes, elapsed));
-		}
+	if(1 <= verbosity) {
+		double elapsed = (double)(time_end_0 - time_start_0)+
+			(double)((double)time_end_1
+			-(double)time_start_1) / 1000000.0;
+		VERBOSITY(1, (LOG_INFO, "zone %s %s of %d bytes in %g seconds",
+			zone_buf, log_buf, num_bytes, elapsed));
 	}
-	else {
-	 	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "skipping xfr: %s", log_buf));
-	}
-	return 1;
+
+	return xfrd_xfr_ok;
 }
 
 struct udb_base* task_file_create(const char* file)
@@ -1464,8 +1505,9 @@ task_create_new_elem(struct udb_base* udb, udb_ptr* last, udb_ptr* e,
 	return 1;
 }
 
-void task_new_soainfo(struct udb_base* udb, udb_ptr* last, struct zone* z,
-	int gone)
+void task_new_soainfo(
+	struct udb_base* udb, udb_ptr* last, struct zone* z, uint32_t serial,
+	xfrd_xfr_state_type state)
 {
 	/* calculate size */
 	udb_ptr e;
@@ -1478,13 +1520,20 @@ void task_new_soainfo(struct udb_base* udb, udb_ptr* last, struct zone* z,
 		domain_to_string(z->apex)));
 	apex = domain_dname(z->apex);
 	sz = sizeof(struct task_list_d) + dname_total_size(apex);
-	if(z->soa_rrset && !gone) {
+	if(z->soa_rrset && state != xfrd_xfr_corrupt &&
+	                   state != xfrd_xfr_inconsistent)
+	{
 		ns = domain_dname(rdata_atom_domain(
 			z->soa_rrset->rrs[0].rdatas[0]));
 		em = domain_dname(rdata_atom_domain(
 			z->soa_rrset->rrs[0].rdatas[1]));
 		sz += sizeof(uint32_t)*6 + sizeof(uint8_t)*2
 			+ ns->name_size + em->name_size;
+		if (!serial) {
+			memmove(&serial,
+			        rdata_atom_data(z->soa_rrset->rrs[0].rdatas[2]),
+				sizeof(uint32_t));
+		}
 	} else {
 		ns = 0;
 		em = 0;
@@ -1495,9 +1544,13 @@ void task_new_soainfo(struct udb_base* udb, udb_ptr* last, struct zone* z,
 		log_msg(LOG_ERR, "tasklist: out of space, cannot add SOAINFO");
 		return;
 	}
+	TASKLIST(&e)->newserial = serial;
 	TASKLIST(&e)->task_type = task_soa_info;
+	TASKLIST(&e)->yesno = (uint64_t)state;
 
-	if(z->soa_rrset && !gone) {
+	if(z->soa_rrset && state != xfrd_xfr_corrupt &&
+	                   state != xfrd_xfr_inconsistent)
+	{
 		uint32_t ttl = htonl(z->soa_rrset->rrs[0].ttl);
 		uint8_t* p = (uint8_t*)TASKLIST(&e)->zname;
 		p += dname_total_size(apex);
@@ -2011,6 +2064,8 @@ task_process_apply_xfr(struct nsd* nsd, udb_base* udb, udb_ptr *last_task,
 	 * appends soa_info which may remap and change the pointer. */
 	zone_type* zone;
 	FILE* df;
+	xfrd_xfr_state_type state;
+
 	DEBUG(DEBUG_IPC,1, (LOG_INFO, "applyxfr task %s", dname_to_string(
 		TASKLIST(task)->zname, NULL)));
 	zone = namedb_find_zone(nsd->db, TASKLIST(task)->zname);
@@ -2031,16 +2086,30 @@ task_process_apply_xfr(struct nsd* nsd, udb_base* udb, udb_ptr *last_task,
 		return;
 	}
 	/* read and apply zone transfer */
-	if(!apply_ixfr_for_zone(nsd, zone, df, nsd->options, udb,
-		last_task, TASKLIST(task)->yesno)) {
-		/* there is no reply to xfrd failed-update,
-		 * because xfrd has a scan for apply-failures. */
+	state = apply_ixfr_for_zone(
+		nsd, zone, df, udb, last_task, TASKLIST(task)->yesno);
+	switch(state) {
+	case xfrd_xfr_corrupt:
+	case xfrd_xfr_inconsistent:
+		diff_update_commit(
+			dname_to_string(TASKLIST(task)->zname, NULL),
+			nsd,
+			state == xfrd_xfr_corrupt ? DIFF_CORRUPT :
+			                            DIFF_INCONSISTENT,
+			TASKLIST(task)->yesno);
+		task_new_soainfo(
+			udb, last_task, zone, TASKLIST(task)->newserial, state);
+		break;
+	default:
+		assert(state == xfrd_xfr_ok);
+		/* successfully committed zone transfers are communicated from
+		   server_reload. after verification (if enabled) because a
+		   zone may still fail verification */
+		break;
 	}
 
 	fclose(df);
-	xfrd_unlink_xfrfile(nsd, TASKLIST(task)->yesno);
 }
-
 
 void task_process_in_reload(struct nsd* nsd, udb_base* udb, udb_ptr *last_task,
         udb_ptr* task)

--- a/difffile.h
+++ b/difffile.h
@@ -13,11 +13,17 @@
 #include "namedb.h"
 #include "options.h"
 #include "udb.h"
+#include "xfrd.h"
 struct nsd;
 struct nsdst;
 
 #define DIFF_PART_XXFR ('X'<<24 | 'X'<<16 | 'F'<<8 | 'R')
 #define DIFF_PART_XFRF ('X'<<24 | 'F'<<16 | 'R'<<8 | 'F')
+
+#define DIFF_NOT_COMMITTED (0u) /* XFR not (yet) committed to disk */
+#define DIFF_COMMITTED (1u<<0) /* XFR committed to disk */
+#define DIFF_CORRUPT (1u<<1) /* XFR corrupt */
+#define DIFF_INCONSISTENT (1u<<2) /* IXFR cannot be applied */
 
 /* write an xfr packet data to the diff file, type=IXFR.
    The diff file is created if necessary, with initial header(notcommitted). */
@@ -33,6 +39,12 @@ void diff_write_commit(const char* zone, uint32_t old_serial,
 	uint32_t new_serial, uint32_t num_parts, uint8_t commit,
 	const char* log_msg, struct nsd* nsd, uint64_t filenumber);
 
+/*
+ * Overwrite committed value of diff file with discarded to ensure diff
+ * file is not reapplied on reload.
+ */
+void diff_write_commit_status(const char* zone, struct nsd* nsd,
+	uint8_t commit, uint64_t filenumber);
 /*
  * These functions read parts of the diff file.
  */
@@ -106,7 +118,9 @@ struct udb_base* task_file_create(const char* file);
 void task_remap(udb_base* udb);
 void task_process_sync(udb_base* udb);
 void task_clear(udb_base* udb);
-void task_new_soainfo(udb_base* udb, udb_ptr* last, struct zone* z, int gone);
+
+void task_new_soainfo(udb_base* udb, udb_ptr* last, struct zone* z,
+	uint32_t serial, xfrd_xfr_state_type state);
 void task_new_expire(udb_base* udb, udb_ptr* last,
 	const struct dname* z, int expired);
 void* task_new_stat_info(udb_base* udb, udb_ptr* last, struct nsdst* stat,

--- a/namedb.h
+++ b/namedb.h
@@ -142,8 +142,9 @@ struct zone
 	struct timespec mtime; /* time of last modification */
 	unsigned     zonestatid; /* array index for zone stats */
 	unsigned     is_secure : 1; /* zone uses DNSSEC */
-	unsigned     is_ok : 1; /* zone has not expired. */
-	unsigned     is_changed : 1; /* zone was changed by AXFR */
+	unsigned     is_ok : 1; /* zone has not expired */
+	unsigned     is_changed : 1; /* zone changes must be written to disk */
+	unsigned     is_updated : 1; /* zone was changed by XFR */
 } ATTR_PACKED;
 
 /* a RR in DNS */

--- a/nsd.h
+++ b/nsd.h
@@ -67,6 +67,13 @@ struct dt_collector;
  * port53 is free when all of nsd's processes have exited at shutdown time
  */
 #define NSD_QUIT_CHILD 11
+/*
+ * This is the exit code of a nsd "new master" child process to indicate to
+ * the master process that some zones failed verification and that it should
+ * reload again, reprocessing the difffiles. The master process will resend
+ * the command to xfrd so it will not reload from xfrd yet.
+ */
+#define NSD_RELOAD_FAILED 14
 
 #define NSD_SERVER_MAIN 0x0U
 #define NSD_SERVER_UDP  0x1U

--- a/remote.c
+++ b/remote.c
@@ -970,7 +970,7 @@ force_transfer_zone(xfrd_zone_type* zone)
 		xfrd_udp_release(zone);
 	/* pretend we not longer have it and force any
 	 * zone to be downloaded (even same serial, w AXFR) */
-	zone->soa_disk_acquired = 0;
+	zone->soa_xfr_acquired = 0;
 	zone->soa_nsd_acquired = 0;
 	xfrd_handle_notify_and_start_xfr(zone, NULL);
 }
@@ -1059,8 +1059,8 @@ print_zonestatus(RES* ssl, xfrd_state_type* xfrd, struct zone_options* zo)
 	if(!print_soa_status(ssl, "served-serial", &xz->soa_nsd,
 		xz->soa_nsd_acquired))
 		return 0;
-	if(!print_soa_status(ssl, "commit-serial", &xz->soa_disk,
-		xz->soa_disk_acquired))
+	if(!print_soa_status(ssl, "commit-serial", &xz->soa_xfr,
+		xz->soa_xfr_acquired))
 		return 0;
 	if(xz->round_num != -1) {
 		if(!print_soa_status(ssl, "notified-serial", &xz->soa_notified,

--- a/tpkg/ixfr_faildel.tdir/ixfr_faildel.pre
+++ b/tpkg/ixfr_faildel.tdir/ixfr_faildel.pre
@@ -25,3 +25,4 @@ echo "export TESTNS_PID=$TESTNS_PID" >> .tpkg.var.test
 
 $TPKG_NSD -c edit.conf -u $LOGNAME -p $TPKG_PORT
 wait_nsd_up nsd.log
+wait_logfile nsd.log "serial 0 is updated to 3" 30

--- a/tpkg/ixfr_retry.tdir/ixfr_retry.conf
+++ b/tpkg/ixfr_retry.tdir/ixfr_retry.conf
@@ -1,0 +1,31 @@
+server:
+	logfile: "nsd.log"
+	difffile: ixfr.db
+	xfrdfile: xfrd.state
+	zonesdir: ""
+	username: ""
+	chroot: ""
+	pidfile: nsd.pid
+	database: ""
+	verbosity: 5
+
+pattern:
+	name: acls
+	request-xfr: UDP 127.0.0.1@TESTNS_PORT NOKEY
+	allow-notify: 0.0.0.0/0 NOKEY
+	allow-notify: 127.0.0.1 NOKEY
+	allow-notify: ::1 NOKEY
+	provide-xfr: 127.0.0.1 NOKEY
+	provide-xfr: ::1 NOKEY
+	min-refresh-time: 0
+	min-retry-time: 0
+
+zone:
+	name: bar.foo.
+	zonefile: ixfr_retry.zone
+	include-pattern: acls
+
+zone:
+	name: baz.foo.
+	zonefile: ixfr_retry.zone
+	include-pattern: acls

--- a/tpkg/ixfr_retry.tdir/ixfr_retry.datafile
+++ b/tpkg/ixfr_retry.tdir/ixfr_retry.datafile
@@ -1,0 +1,65 @@
+$ORIGIN bar.foo.
+$TTL 7200
+
+ENTRY_BEGIN
+MATCH opcode qtype qname serial=1
+REPLY QUERY
+REPLY NOERROR
+REPLY AA AD
+ADJUST copy_id
+SECTION QUESTION
+baz.foo. IN IXFR
+SECTION ANSWER
+baz.foo. IN SOA    ns.baz.foo. hostmaster.baz.foo. 2 300 4 3000 5
+; deleted items
+baz.foo. IN SOA    ns.baz.foo. hostmaster.baz.foo. 1 3   4 3000 5
+baz.foo. IN SOA    ns.baz.foo. hostmaster.baz.foo. 2 300 4 3000 5
+; added items
+web1     IN A      4.5.6.7
+web2     IN A      5.6.7.8
+baz.foo. IN SOA    ns.baz.foo. hostmaster.baz.foo. 2 300 4 3000 5
+ENTRY_END
+
+
+$ORIGIN baz.foo.
+$TTL 7200
+
+ENTRY_BEGIN
+; bad IXFR to trigger AXFR for bar.foo.
+MATCH opcode qtype qname serial=1
+REPLY QUERY
+REPLY NOERROR
+REPLY AA AD
+ADJUST copy_id
+SECTION QUESTION
+bar.foo. IN IXFR
+SECTION ANSWER
+bar.foo. IN SOA    ns.bar.foo. hostmaster.bar.foo. 2 300 4 3000 5
+; deleted items
+bar.foo. IN SOA    ns.bar.foo. hostmaster.bar.foo. 1 3   4 3000 5
+www      IN A      1.2.3.4
+bar.foo. IN SOA    ns.bar.foo. hostmaster.bar.foo. 2 300 4 3000 5
+; added items
+web1     IN A      4.5.6.8
+web2     IN A      5.6.7.8
+bar.foo. IN SOA    ns.bar.foo. hostmaster.bar.foo. 2 300 4 3000 5
+ENTRY_END
+
+ENTRY_BEGIN
+MATCH opcode qtype qname
+REPLY QUERY
+REPLY NOERROR
+REPLY AA AD
+ADJUST copy_id
+SECTION QUESTION
+bar.foo. IN AXFR
+SECTION ANSWER
+bar.foo. IN SOA    ns.bar.foo. hostmaster.bar.foo. 2 300 4 3000 5
+         IN NS     ns.bar.foo.
+         IN MX  10 mx.bar.foo.
+ns       IN A      1.2.3.4
+mx       IN A      2.3.4.5
+web1     IN A      3.4.5.6
+web2     IN A      5.6.7.8
+bar.foo. IN SOA    ns.bar.foo. hostmaster.bar.foo. 2 300 4 3000 5
+ENTRY_END

--- a/tpkg/ixfr_retry.tdir/ixfr_retry.dsc
+++ b/tpkg/ixfr_retry.tdir/ixfr_retry.dsc
@@ -1,0 +1,16 @@
+BaseName: ixfr_retry
+Version: 1.0
+Description: Verify correct transfers are kept for reload and inconsistent transfers are discarded
+CreationDate: Thu Feb 13 03:43:15 CEST 2020
+Maintainer: Jeroen Koekkoek
+Category:
+Component:
+CmdDepends:
+Depends:
+Help:
+Pre: ixfr_retry.pre
+Post: ixfr_retry.post
+Test: ixfr_retry.test
+AuxFiles: ixfr_retry.conf, ixfr_retry.zone, ixfr_retry.datafile
+Passed:
+Failure:

--- a/tpkg/ixfr_retry.tdir/ixfr_retry.post
+++ b/tpkg/ixfr_retry.tdir/ixfr_retry.post
@@ -1,0 +1,13 @@
+# #-- ixfr_retry.post --#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# source the test var file when it's there
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+kill_pid ${TESTNS_PID}
+
+# do your teardown here
+if test -e nsd.pid; then
+  kill_pid $(head -n 1 nsd.pid)
+fi

--- a/tpkg/ixfr_retry.tdir/ixfr_retry.pre
+++ b/tpkg/ixfr_retry.tdir/ixfr_retry.pre
@@ -1,0 +1,20 @@
+# #-- xfr_retry.pre --#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+get_random_port 2
+NSD_PORT=${RND_PORT}
+TESTNS_PORT=$((${RND_PORT} + 1))
+
+# start ldns-testns, be extra verbose
+ldns-testns -v -p ${TESTNS_PORT} ixfr_retry.datafile >testns.log 2>&1 &
+
+# share the vars
+echo "export NSD_PORT=${NSD_PORT}" >> .tpkg.var.test
+echo "export TESTNS_PID=${!}" >> .tpkg.var.test
+echo "export TESTNS_PORT=${TESTNS_PORT}" >> .tpkg.var.test
+
+sed -e "s/TESTNS_PORT/${TESTNS_PORT}/g" ixfr_retry.conf > nsd.conf

--- a/tpkg/ixfr_retry.tdir/ixfr_retry.test
+++ b/tpkg/ixfr_retry.tdir/ixfr_retry.test
@@ -1,0 +1,62 @@
+# #-- ixfr_retry.test --#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+# ixfr_retry uses two zones bar.foo. and baz.foo. NSD consistently issues IXFR
+# requests for baz.foo. before bar.foo. This ensures that changes are
+# processed in the same order. This behavior is used to the advantage of this
+# test because the initial reload must discard the set of changes for the
+# second zone to verify whether the set of changes for the first zone are kept
+# around.
+
+NSD="../../nsd"
+
+#valgrind $NSD -c nsd.conf -L 5 -F 0xFFFF -p $NSD_PORT
+$NSD -c nsd.conf -L 5 -F 0xFFFF -p $NSD_PORT
+wait_nsd_up nsd.log
+wait_logfile nsd.log 'SOAINFO for bar.foo. 2' 45
+sleep 2 # allow some extra time to finish up reload
+
+# verify events happened in the right order
+while IFS='' read -r line; do
+  case $line in
+    *:\ info:\ SOAINFO\ for\ bar.foo.\ 1)
+      EVENTS="${EVENTS}1"
+      ;;
+    *:\ info:\ SOAINFO\ for\ baz.foo.\ 1)
+      EVENTS="${EVENTS}2"
+      ;;
+    *:\ info:\ reloading...)
+      EVENTS="${EVENTS}R"
+      ;;
+    *:\ error:\ *\ bar.foo.\ contents\ is\ different\ from\ master*)
+      EVENTS="${EVENTS}3"
+      ;;
+    # reload
+    *:\ error:\ diff\ file\ bar.foo.\ was\ inconsistent)
+      EVENTS="${EVENTS}4"
+      ;;
+    *:\ info:\ SOAINFO\ for\ bar.foo.\ lost\ zone)
+      EVENTS="${EVENTS}5"
+      ;;
+    *:\ info:\ SOAINFO\ for\ baz.foo.\ 2)
+      EVENTS="${EVENTS}6"
+      ;;
+    # reload
+    *:\ info:\ SOAINFO\ for\ bar.foo.\ 2)
+      EVENTS="${EVENTS}7"
+      ;;
+  esac
+done < nsd.log
+
+if [ "${EVENTS}" != "12R3R456R7R" ]; then
+  echo "Expected events did not happen, or happened out of order"
+  echo "Events: '${EVENTS}', Expected events: '12R3R456R7R'"
+  cat nsd.log testns.log
+  exit 1
+fi
+
+echo "Expected events happened in the right order"

--- a/tpkg/ixfr_retry.tdir/ixfr_retry.zone
+++ b/tpkg/ixfr_retry.tdir/ixfr_retry.zone
@@ -1,0 +1,6 @@
+@  IN SOA    ns hostmaster 1 5 4 3000 5
+   IN NS     ns
+   IN MX  10 mx
+   IN A      1.2.3.4
+ns IN A      2.3.4.5
+mx IN A      3.4.5.6

--- a/tpkg/long/ixfr_remove_unknown.tdir/ixfr_remove_unknown.test
+++ b/tpkg/long/ixfr_remove_unknown.tdir/ixfr_remove_unknown.test
@@ -62,6 +62,11 @@ setup_miniserver ixfr_remove_unknown.qs_1
 notify_slave 2
 sleep $WAITTIME
 
-check_slave_zone 2 ixfr_remove_unknown.zone_2
+check_slave_zone 1 ixfr_remove_unknown.zone_1
+# Behaviour for so-called inconsistent updates, updates that remove records
+# that do not exist or add records that do exists, has changed. NSD now aborts
+# the reload, discards the update and requests an AXFR. Previously xfrd
+# requested an AXFR too, but the reload would continue.
+#check_slave_zone 2 ixfr_remove_unknown.zone_2
 
 exit 0

--- a/tpkg/nodb.tdir/nodb.test
+++ b/tpkg/nodb.tdir/nodb.test
@@ -17,8 +17,9 @@ echo "export TPKG_PORT=$TPKG_PORT" >> .tpkg.var.test
 echo "export TPKG_NSD_PID=$TPKG_NSD_PID" >> .tpkg.var.test
 echo port: $TPKG_PORT
 
-$TPKG_NSD -c nsd_1.conf -u $LOGNAME -p $TPKG_PORT -P $TPKG_NSD_PID -V 5
+$TPKG_NSD -c nsd_1.conf -u $LOGNAME -p $TPKG_PORT -P $TPKG_NSD_PID -L 5 -F 0xFFFF
 wait_nsd_up nsd.log
+wait_logfile nsd.log "serial 1 is updated to 2" 5
 
 # query for the master and the slave zone.
 dig @127.0.0.1 -p $TPKG_PORT example.com SOA | tee result

--- a/tpkg/nodb_write.tdir/nodb_write.test
+++ b/tpkg/nodb_write.tdir/nodb_write.test
@@ -17,8 +17,9 @@ echo "export TPKG_PORT=$TPKG_PORT" >> .tpkg.var.test
 echo "export TPKG_NSD_PID=$TPKG_NSD_PID" >> .tpkg.var.test
 echo port: $TPKG_PORT
 
-$TPKG_NSD -c nsd_1.conf -u $LOGNAME -p $TPKG_PORT -P $TPKG_NSD_PID -V 5
+$TPKG_NSD -c nsd_1.conf -u $LOGNAME -p $TPKG_PORT -P $TPKG_NSD_PID -L 5 -F 0xFFFF
 wait_nsd_up nsd.log
+wait_logfile nsd.log "zonefiles write timer (nothing)" 5
 
 # wait for it if necessary
 if grep "192.0.2.6" nodb_write.zone; then : ; else sleep 1; fi

--- a/tpkg/xfr_udp.tdir/xfr_udp.conf
+++ b/tpkg/xfr_udp.tdir/xfr_udp.conf
@@ -1,5 +1,5 @@
 server:
-	logfile: "/dev/stdout"
+	logfile: "nsd.log"
 	difffile: ixfr.db
 	xfrdfile: xfrd.state
 	zonesdir: ""

--- a/tpkg/xfr_udp.tdir/xfr_udp.test
+++ b/tpkg/xfr_udp.tdir/xfr_udp.test
@@ -16,24 +16,24 @@ TPKG_NSD="$PRE/nsd"
 echo "export TPKG_PORT=$TPKG_PORT" >> .tpkg.var.test
 echo "export TPKG_NSD_PID=$TPKG_NSD_PID" >> .tpkg.var.test
 
+exit_code=0
+
 $TPKG_NSD -c nsd_udp.conf -u $LOGNAME -p $TPKG_PORT -P $TPKG_NSD_PID -f xfr_udp.db
 
-sleep 3
+wait_nsd_up nsd.log
+wait_logfile nsd.log "serial 1 is updated to 2" 45
 
-# now query for the update I sent and compare that with a known good one
 echo port: $TPKG_PORT
-dig @127.0.0.1 -p $TPKG_PORT a www.example.net 
-dig @127.0.0.1 -p $TPKG_PORT a www.example.net |grep "^www.example.net" > xfr_udp.current
-
-echo "CURRENT:"
-cat xfr_udp.current
-
-echo "KNOWN GOOD:"
-cat xfr_udp.known_good
-
-diff -u xfr_udp.current xfr_udp.known_good
-if [[ $? -ne 0 ]]; then
-        exit 1
+dig @127.0.0.1 -p $TPKG_PORT a www.example.net > xfr_udp.query
+if [ ${?} -eq 0 ] && grep '^www\.example\.net\.' xfr_udp.query >/dev/null 2>&1; then
+  echo "Query result is correct. www.example.net exists"
 else
-        exit 0
+  echo "Query result is incorrect. www.example.net does not exist"
+  echo "dig:"
+  cat xfr_udp.query
+  exit_code=1
 fi
+
+cat nsd.log
+
+exit ${exit_code}

--- a/tpkg/zone_expire_restart.tdir/zone_expire_restart.test
+++ b/tpkg/zone_expire_restart.tdir/zone_expire_restart.test
@@ -18,7 +18,7 @@ echo "export TPKG_PORT=$TPKG_PORT" >> .tpkg.var.test
 $TPKG_NSD -c nsd.conf -p $TPKG_PORT $NSD_OPTS
 wait_nsd_up nsd.log
 # example.net should be expired
-sleep 2
+wait_logfile nsd.log "zone example.net has expired" 10
 
 echo port: $TPKG_PORT
 dig @127.0.0.1 -p $TPKG_PORT example.net SOA | tee data
@@ -32,7 +32,10 @@ fi
 
 echo "stop server"
 kill_pid `cat nsd.pid`
-sleep 1
+
+# cleanup left-overs
+rm -f nsd.log nsd.pid
+
 echo "xfrd.state"
 cat xfrd.state
 # now start the server again and check the zone is expired
@@ -40,7 +43,7 @@ echo "restart server"
 $TPKG_NSD -c nsd.conf -p $TPKG_PORT $NSD_OPTS
 wait_nsd_up nsd.log
 # wait for a second to have the expire propagate
-sleep 2
+wait_logfile nsd.log "zone example.net has expired" 10
 
 dig @127.0.0.1 -p $TPKG_PORT example.net SOA | tee data
 if grep SERVFAIL data; then

--- a/xfrd-tcp.c
+++ b/xfrd-tcp.c
@@ -24,6 +24,7 @@
 #include "xfrd.h"
 #include "xfrd-disk.h"
 #include "util.h"
+#include "difffile.h"
 
 /* sort tcppipe, first on IP address, for an IPaddresss, sort on num_unused */
 static int
@@ -593,14 +594,17 @@ void
 xfrd_tcp_setup_write_packet(struct xfrd_tcp_pipeline* tp, xfrd_zone_type* zone)
 {
 	struct xfrd_tcp* tcp = tp->tcp_w;
+
 	assert(zone->tcp_conn != -1);
 	assert(zone->tcp_waiting == 0);
+
 	/* start AXFR or IXFR for the zone */
-	if(zone->soa_disk_acquired == 0 || zone->master->use_axfr_only ||
-		zone->master->ixfr_disabled ||
+	if(zone->master->use_axfr_only || zone->master->ixfr_disabled ||
+		(zone->state == xfrd_zone_expired && zone->round_num != 0) ||
+		(zone->soa_xfr_acquired == 0 && zone->soa_nsd_acquired == 0))
+	{
 		/* if zone expired, after the first round, do not ask for
 		 * IXFR any more, but full AXFR (of any serial number) */
-		(zone->state == xfrd_zone_expired && zone->round_num != 0)) {
 		DEBUG(DEBUG_XFRD,1, (LOG_INFO, "request full zone transfer "
 						"(AXFR) for %s to %s",
 			zone->apex_str, zone->master->ip_address_spec));
@@ -608,6 +612,13 @@ xfrd_tcp_setup_write_packet(struct xfrd_tcp_pipeline* tp, xfrd_zone_type* zone)
 		xfrd_setup_packet(tcp->packet, TYPE_AXFR, CLASS_IN, zone->apex,
 			zone->query_id);
 	} else {
+		xfrd_soa_type *soa;
+		if(zone->soa_xfr_acquired != 0) {
+			soa = &zone->soa_xfr;
+		} else {
+			soa = &zone->soa_nsd;
+		}
+
 		DEBUG(DEBUG_XFRD,1, (LOG_INFO, "request incremental zone "
 						"transfer (IXFR) for %s to %s",
 			zone->apex_str, zone->master->ip_address_spec));
@@ -615,15 +626,13 @@ xfrd_tcp_setup_write_packet(struct xfrd_tcp_pipeline* tp, xfrd_zone_type* zone)
 		xfrd_setup_packet(tcp->packet, TYPE_IXFR, CLASS_IN, zone->apex,
 			zone->query_id);
         	NSCOUNT_SET(tcp->packet, 1);
-		xfrd_write_soa_buffer(tcp->packet, zone->apex, &zone->soa_disk);
+		xfrd_write_soa_buffer(tcp->packet, zone->apex, soa);
 	}
-	/* old transfer needs to be removed still? */
-	if(zone->msg_seq_nr)
-		xfrd_unlink_xfrfile(xfrd->nsd, zone->xfrfilenumber);
-	zone->msg_seq_nr = 0;
-	zone->msg_rr_count = 0;
+
+	xfrd_prepare_zone_xfr(zone);
 	if(zone->master->key_options && zone->master->key_options->tsig_key) {
-		xfrd_tsig_sign_request(tcp->packet, &zone->tsig, zone->master);
+		xfrd_tsig_sign_request(
+			tcp->packet, &zone->latest_xfr->tsig, zone->master);
 	}
 	buffer_flip(tcp->packet);
 	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "sent tcp query with ID %d", zone->query_id));

--- a/xfrd.c
+++ b/xfrd.c
@@ -98,6 +98,19 @@ static int find_same_master_notify(xfrd_zone_type* zone, int acl_num_nfy);
 /* set the write timer to activate */
 static void xfrd_write_timer_set(void);
 
+static void xfrd_discard_zone_xfr(xfrd_zone_type* zone, xfrd_xfr_type* xfr);
+
+static void xfrd_discard_zone_xfrs(xfrd_zone_type *zone);
+
+static int xfrd_schedule_zone_xfr(
+	xfrd_zone_type *zone, xfrd_xfr_type *xfr);
+
+static int xfrd_schedule_zone_xfrs(
+	xfrd_zone_type *zone, xfrd_xfr_type *last_xfr, int committed);
+
+static void xfrd_process_zone_xfrs(
+	xfrd_zone_type *zone, int committed);
+
 static void
 xfrd_signal_callback(int sig, short event, void* ATTR_UNUSED(arg))
 {
@@ -165,6 +178,7 @@ xfrd_init(int socket, struct nsd* nsd, int shortsoa, int reload_active,
 	xfrd->reload_added = 0;
 	xfrd->reload_timeout.tv_sec = 0;
 	xfrd->reload_cmd_last_sent = xfrd->xfrd_start_time;
+	xfrd->reload_cmd_first_sent = 0;
 	xfrd->can_send_reload = !reload_active;
 	xfrd->reload_pid = nsd_pid;
 	xfrd->child_timer_added = 0;
@@ -286,9 +300,12 @@ xfrd_sig_process(void)
 	/* collect children that exited. */
 	xfrd->nsd->signal_hint_child = 0;
 	while((child_pid = waitpid(-1, &status, WNOHANG)) != -1 && child_pid != 0) {
-		if(status != 0) {
+		if(WIFEXITED(status)) {
 			log_msg(LOG_ERR, "process %d exited with status %d",
-				(int)child_pid, status);
+				(int)child_pid, WEXITSTATUS(status));
+		} else {
+			log_msg(LOG_ERR, "process %d exited abnormally",
+				(int)child_pid);
 		}
 	}
 	if(!xfrd->child_timer_added) {
@@ -394,8 +411,7 @@ xfrd_shutdown()
 	/* unlink xfr files for running transfers */
 	RBTREE_FOR(zone, xfrd_zone_type*, xfrd->zones)
 	{
-		if(zone->msg_seq_nr)
-			xfrd_unlink_xfrfile(xfrd->nsd, zone->xfrfilenumber);
+		xfrd_discard_zone_xfrs(zone);
 	}
 	/* unlink xfr files in not-yet-done task file */
 	xfrd_clean_pending_tasks(xfrd->nsd, xfrd->nsd->task[xfrd->nsd->mytask]);
@@ -412,12 +428,6 @@ xfrd_shutdown()
 	/* process-exit cleans up memory used by xfrd process */
 	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd shutdown complete"));
 #ifdef MEMCLEAN /* OS collects memory pages */
-	if(xfrd->zones) {
-		xfrd_zone_type* z;
-		RBTREE_FOR(z, xfrd_zone_type*, xfrd->zones) {
-			tsig_delete_record(&z->tsig, NULL);
-		}
-	}
 	if(xfrd->notify_zones) {
 		struct notify_zone* n;
 		RBTREE_FOR(n, struct notify_zone*, xfrd->notify_zones) {
@@ -482,15 +492,15 @@ xfrd_init_slave_zone(xfrd_state_type* xfrd, struct zone_options* zone_opt)
 	xzone->fresh_xfr_timeout = XFRD_TRANSFER_TIMEOUT_START;
 
 	xzone->soa_nsd_acquired = 0;
-	xzone->soa_disk_acquired = 0;
+	xzone->soa_xfr_acquired = 0;
 	xzone->soa_notified_acquired = 0;
 	/* [0]=1, [1]=0; "." domain name */
 	xzone->soa_nsd.prim_ns[0] = 1;
 	xzone->soa_nsd.email[0] = 1;
-	xzone->soa_disk.prim_ns[0]=1;
-	xzone->soa_disk.email[0]=1;
-	xzone->soa_notified.prim_ns[0]=1;
-	xzone->soa_notified.email[0]=1;
+	xzone->soa_xfr.prim_ns[0] = 1;
+	xzone->soa_xfr.email[0] = 1;
+	xzone->soa_notified.prim_ns[0] = 1;
+	xzone->soa_notified.email[0] = 1;
 
 	xzone->zone_handler.ev_fd = -1;
 	xzone->zone_handler_flags = 0;
@@ -503,7 +513,6 @@ xfrd_init_slave_zone(xfrd_state_type* xfrd, struct zone_options* zone_opt)
 
 	xzone->multi_master_first_master = -1;
 	xzone->multi_master_update_check = -1;
-	tsig_create_record_custom(&xzone->tsig, NULL, 0, 0, 4);
 
 	/* set refreshing anyway, if we have data it may be old */
 	xfrd_set_refresh_now(xzone);
@@ -545,13 +554,21 @@ static void
 xfrd_process_soa_info_task(struct task_list_d* task)
 {
 	xfrd_soa_type soa;
-	xfrd_soa_type* soa_ptr = &soa;
+	xfrd_soa_type *soa_ptr = &soa;
 	xfrd_zone_type* zone;
+	uint32_t serial;
+	size_t soa_info_min_size;
 	DEBUG(DEBUG_IPC,1, (LOG_INFO, "xfrd: process SOAINFO %s",
 		dname_to_string(task->zname, 0)));
 	zone = (xfrd_zone_type*)rbtree_search(xfrd->zones, task->zname);
-	if(task->size <= sizeof(struct task_list_d)+dname_total_size(
-		task->zname)+sizeof(uint32_t)*6 + sizeof(uint8_t)*2) {
+
+	soa_info_min_size = sizeof(struct task_list_d) +
+	                    dname_total_size(task->zname) +
+	                    sizeof(uint32_t) * 6 +
+	                    sizeof(uint8_t) * 2;
+	serial = htonl(task->newserial);
+
+	if(task->size <= soa_info_min_size) {
 		/* NSD has zone without any info */
 		DEBUG(DEBUG_IPC,1, (LOG_INFO, "SOAINFO for %s lost zone",
 			dname_to_string(task->zname,0)));
@@ -594,10 +611,11 @@ xfrd_process_soa_info_task(struct task_list_d* task)
 		DEBUG(DEBUG_IPC,1, (LOG_INFO, "xfrd: zone %s master zone updated",
 			dname_to_string(task->zname,0)));
 		notify_handle_master_zone_soainfo(xfrd->notify_zones,
-			task->zname, soa_ptr);
+			task->zname, &soa);
 		return;
 	}
-	xfrd_handle_incoming_soa(zone, soa_ptr, xfrd_time());
+	xfrd_handle_incoming_soa(
+		zone, soa_ptr, serial, xfrd_time(), task->yesno);
 }
 
 static void
@@ -627,9 +645,10 @@ xfrd_receive_soa(int socket, int shortsoa)
 		}
 	}
 
-	/* receive RELOAD_DONE to get SOAINFO tasklist */
+	/* receive RELOAD_DONE or RELOAD_FAILED to get SOAINFO tasklist */
 	if(block_read(&nsd, socket, &cmd, sizeof(cmd), -1) != sizeof(cmd) ||
-		cmd != NSD_RELOAD_DONE) {
+		(cmd != NSD_RELOAD_DONE && cmd != NSD_RELOAD_FAILED))
+	{
 		if(nsd.signal_hint_shutdown)
 			return;
 		log_msg(LOG_ERR, "did not get start signal from main");
@@ -662,7 +681,8 @@ xfrd_receive_soa(int socket, int shortsoa)
 		 * to the other, empty, tasklist) */
 		if(block_read(NULL, socket, &cmd, sizeof(cmd), -1) !=
 			sizeof(cmd) ||
-			cmd != NSD_RELOAD_DONE) {
+			(cmd != NSD_RELOAD_DONE && cmd != NSD_RELOAD_FAILED))
+		{
 			log_msg(LOG_ERR, "did not get start signal 2 from "
 				"main");
 			exit(1);
@@ -738,11 +758,7 @@ xfrd_del_slave_zone(xfrd_state_type* xfrd, const dname_type* dname)
 		xfrd_udp_release(z);
 	} else if(z->event_added)
 		event_del(&z->zone_handler);
-	if(z->msg_seq_nr)
-		xfrd_unlink_xfrfile(xfrd->nsd, z->xfrfilenumber);
-
-	/* tsig */
-	tsig_delete_record(&z->tsig, NULL);
+	xfrd_discard_zone_xfrs(z);
 
 	/* z->dname is recycled when the zone_options is removed */
 	region_recycle(xfrd->region, z, sizeof(*z));
@@ -763,22 +779,22 @@ xfrd_set_timer_refresh(xfrd_zone_type* zone)
 	time_t set_expire;
 	time_t set_min;
 	time_t set;
-	if(zone->soa_disk_acquired == 0 || zone->state != xfrd_zone_ok) {
+	if(zone->soa_nsd_acquired == 0 || zone->state != xfrd_zone_ok) {
 		xfrd_set_timer_retry(zone);
 		return;
 	}
 	/* refresh or expire timeout, whichever is earlier */
-	set_refresh = ntohl(zone->soa_disk.refresh);
+	set_refresh = ntohl(zone->soa_nsd.refresh);
 	if (set_refresh > (time_t)zone->zone_options->pattern->max_refresh_time)
 		set_refresh = zone->zone_options->pattern->max_refresh_time;
 	else if (set_refresh < (time_t)zone->zone_options->pattern->min_refresh_time)
 		set_refresh = zone->zone_options->pattern->min_refresh_time;
-	set_refresh += zone->soa_disk_acquired;
-	set_expire = zone->soa_disk_acquired + ntohl(zone->soa_disk.expire);
+	set_refresh += zone->soa_nsd_acquired;
+	set_expire = zone->soa_nsd_acquired + ntohl(zone->soa_nsd.expire);
 	if(set_refresh < set_expire)
 		set = set_refresh;
 	else set = set_expire;
-	set_min = zone->soa_disk_acquired + XFRD_LOWERBOUND_REFRESH;
+	set_min = zone->soa_nsd_acquired + XFRD_LOWERBOUND_REFRESH;
 	if(set < set_min)
 		set = set_min;
 	if(set < xfrd_time())
@@ -807,16 +823,15 @@ xfrd_set_timer_retry(xfrd_zone_type* zone)
 	if(mult == 0) mult = 1;
 
 	/* set timer for next retry or expire timeout if earlier. */
-	if(zone->soa_disk_acquired == 0) {
+	if(zone->soa_nsd_acquired == 0) {
 		/* if no information, use reasonable timeout */
 		xfrd_set_timer(zone, zone->fresh_xfr_timeout
 			+ random_generate(zone->fresh_xfr_timeout));
 	} else if(zone->state == xfrd_zone_expired ||
-		xfrd_time() + (time_t)ntohl(zone->soa_disk.retry)*mult <
-		zone->soa_disk_acquired + (time_t)ntohl(zone->soa_disk.expire))
+		xfrd_time() + (time_t)ntohl(zone->soa_nsd.retry)*mult <
+		zone->soa_nsd_acquired + (time_t)ntohl(zone->soa_nsd.expire))
 	{
-		set_retry = ntohl(zone->soa_disk.retry);
-		set_retry *= mult;
+		set_retry = ntohl(zone->soa_nsd.retry) * mult;
 		if(set_retry > (time_t)zone->zone_options->pattern->max_retry_time)
 			set_retry = zone->zone_options->pattern->max_retry_time;
 		else if(set_retry < (time_t)zone->zone_options->pattern->min_retry_time)
@@ -825,13 +840,13 @@ xfrd_set_timer_retry(xfrd_zone_type* zone)
 			set_retry = XFRD_LOWERBOUND_RETRY;
 		xfrd_set_timer(zone, set_retry);
 	} else {
-		set_retry = ntohl(zone->soa_disk.expire);
-		if(set_retry < XFRD_LOWERBOUND_RETRY)
+		set_retry = ntohl(zone->soa_nsd.expire);
+		if(set_retry < XFRD_LOWERBOUND_RETRY) {
 			xfrd_set_timer(zone, XFRD_LOWERBOUND_RETRY);
-		else {
-			if(zone->soa_disk_acquired + set_retry < xfrd_time())
+		} else {
+			if(zone->soa_nsd_acquired + set_retry < xfrd_time())
 				xfrd_set_timer(zone, XFRD_LOWERBOUND_RETRY);
-			else xfrd_set_timer(zone, zone->soa_disk_acquired +
+			else xfrd_set_timer(zone, zone->soa_nsd_acquired +
 				set_retry - xfrd_time());
 		}
 	}
@@ -880,16 +895,18 @@ xfrd_handle_zone(int ATTR_UNUSED(fd), short event, void* arg)
 		return;
 	}
 
-	if(zone->soa_disk_acquired)
-	{
-		if (zone->state != xfrd_zone_expired &&
-			xfrd_time() >= zone->soa_disk_acquired + (time_t)ntohl(zone->soa_disk.expire)) {
+	if(zone->soa_nsd_acquired) {
+		time_t elapsed = xfrd_time() - zone->soa_nsd_acquired;
+
+		if(zone->state != xfrd_zone_expired &&
+		   elapsed >= (time_t)ntohl(zone->soa_nsd.expire))
+		{
 			/* zone expired */
 			log_msg(LOG_ERR, "xfrd: zone %s has expired", zone->apex_str);
 			xfrd_set_zone_state(zone, xfrd_zone_expired);
-		}
-		else if(zone->state == xfrd_zone_ok &&
-			xfrd_time() >= zone->soa_disk_acquired + (time_t)ntohl(zone->soa_disk.refresh)) {
+		} else if(zone->state == xfrd_zone_ok &&
+		          elapsed >= (time_t)ntohl(zone->soa_nsd.refresh))
+		{
 			/* zone goes to refreshing state. */
 			DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: zone %s is refreshing", zone->apex_str));
 			xfrd_set_zone_state(zone, xfrd_zone_refreshing);
@@ -983,9 +1000,9 @@ xfrd_make_request(xfrd_zone_type* zone)
 	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd zone %s make request round %d mr %d nx %d",
 		zone->apex_str, zone->round_num, zone->master_num, zone->next_master));
 	/* perform xfr request */
-	if (!zone->master->use_axfr_only && zone->soa_disk_acquired > 0 &&
-		!zone->master->ixfr_disabled) {
-
+	if (!zone->master->use_axfr_only && !zone->master->ixfr_disabled &&
+		(zone->soa_nsd_acquired > 0 || zone->soa_xfr_acquired > 0))
+	{
 		if (zone->master->allow_udp) {
 			xfrd_set_timer(zone, XFRD_UDP_TIMEOUT);
 			xfrd_udp_obtain(zone);
@@ -995,7 +1012,9 @@ xfrd_make_request(xfrd_zone_type* zone)
 			xfrd_tcp_obtain(xfrd->tcp_set, zone);
 		}
 	}
-	else if (zone->master->use_axfr_only || zone->soa_disk_acquired <= 0) {
+	else if (zone->master->use_axfr_only ||
+		(zone->soa_nsd_acquired <= 0 && zone->soa_xfr_acquired <= 0))
+	{
 		xfrd_set_timer(zone, xfrd->tcp_set->tcp_timeout);
 		xfrd_tcp_obtain(xfrd->tcp_set, zone);
 	}
@@ -1171,86 +1190,62 @@ xfrd_set_timer(xfrd_zone_type* zone, time_t t)
 }
 
 void
-xfrd_handle_incoming_soa(xfrd_zone_type* zone,
-	xfrd_soa_type* soa, time_t acquired)
+xfrd_handle_incoming_soa(
+	xfrd_zone_type* zone,
+	xfrd_soa_type* soa,
+	uint32_t serial,
+	time_t acquired,
+	xfrd_xfr_state_type state)
 {
+	xfrd_xfr_type *xfr = zone->latest_xfr;
+
 	if(soa == NULL) {
-		/* nsd no longer has a zone in memory */
-		zone->soa_nsd_acquired = 0;
-		xfrd_set_zone_state(zone, xfrd_zone_refreshing);
-		xfrd_set_refresh_now(zone);
-		return;
-	}
-	if(zone->soa_nsd_acquired && soa->serial == zone->soa_nsd.serial)
-		return;
-
-	if(zone->soa_disk_acquired && soa->serial == zone->soa_disk.serial)
-	{
-		/* soa in disk has been loaded in memory */
-		log_msg(LOG_INFO, "zone %s serial %u is updated to %u",
-			zone->apex_str, (unsigned)ntohl(zone->soa_nsd.serial),
-			(unsigned)ntohl(soa->serial));
-		zone->soa_nsd = zone->soa_disk;
-		zone->soa_nsd_acquired = zone->soa_disk_acquired;
-		xfrd->write_zonefile_needed = 1;
-		/* reset exponential backoff, we got a normal timer now */
-		zone->fresh_xfr_timeout = 0;
-		if(xfrd_time() - zone->soa_disk_acquired
-			< (time_t)ntohl(zone->soa_disk.refresh))
-		{
-			/* zone ok, wait for refresh time */
-			xfrd_set_zone_state(zone, xfrd_zone_ok);
-			zone->round_num = -1;
-			xfrd_set_timer_refresh(zone);
-		} else if(xfrd_time() - zone->soa_disk_acquired
-			< (time_t)ntohl(zone->soa_disk.expire))
-		{
-			/* zone refreshing */
-			xfrd_set_zone_state(zone, xfrd_zone_refreshing);
-			xfrd_set_refresh_now(zone);
-		}
-		if(xfrd_time() - zone->soa_disk_acquired
-			>= (time_t)ntohl(zone->soa_disk.expire)) {
-			/* zone expired */
-			xfrd_set_zone_state(zone, xfrd_zone_expired);
-			xfrd_set_refresh_now(zone);
+		/* soa information is missing if a zone transfer is corrupt, or
+		   a zone was read from disk. if a zone transfer corrupts the
+		   database the new server "aborts", in which case the difffile
+		   is marked discarded and is skipped next reload */
+		if(xfr == NULL) {
+			assert(serial == 0);
+			assert(state == xfrd_xfr_new);
+			zone->soa_nsd_acquired = 0;
+			memset(&zone->soa_nsd, 0, sizeof(xfrd_soa_type));
+			return;
 		}
 
-		if(zone->soa_notified_acquired != 0 &&
-			(zone->soa_notified.serial == 0 ||
-		   	compare_serial(ntohl(zone->soa_disk.serial),
-				ntohl(zone->soa_notified.serial)) >= 0))
-		{	/* read was in response to this notification */
-			zone->soa_notified_acquired = 0;
-		}
-		if(zone->soa_notified_acquired && zone->state == xfrd_zone_ok)
+		assert(state == xfrd_xfr_corrupt ||
+		       state == xfrd_xfr_inconsistent);
+		while(xfr && 0 != compare_serial(ntohl(xfr->soa.serial),
+		                                 ntohl(serial)))
 		{
-			/* refresh because of notification */
-			xfrd_set_zone_state(zone, xfrd_zone_refreshing);
-			xfrd_set_refresh_now(zone);
+			xfr = xfr->prev;
 		}
-		xfrd_send_notify(xfrd->notify_zones, zone->apex, &zone->soa_nsd);
+		assert(xfr != NULL);
+		assert(xfr->acquired <= xfrd->reload_cmd_first_sent);
+		xfr->state = state;
+
+		/* whether or not a zone needs a refresh is determined when all
+		   incoming soas have been processed */
+		return;
+	} else if(state == xfrd_xfr_new) {
+		zone->soa_nsd_acquired = acquired;
+		zone->soa_nsd = *soa;
+		xfrd_set_zone_state(zone, xfrd_zone_ok);
 		return;
 	}
 
-	/* user must have manually provided zone data */
-	DEBUG(DEBUG_XFRD,1, (LOG_INFO,
-		"xfrd: zone %s serial %u from zonefile. refreshing",
-		zone->apex_str, (unsigned)ntohl(soa->serial)));
-	zone->soa_nsd = *soa;
-	zone->soa_disk = *soa;
-	zone->soa_nsd_acquired = acquired;
-	zone->soa_disk_acquired = acquired;
-	if(zone->soa_notified_acquired != 0 &&
-		(zone->soa_notified.serial == 0 ||
-	   	compare_serial(ntohl(zone->soa_disk.serial),
-			ntohl(zone->soa_notified.serial)) >= 0))
-	{	/* user provided in response to this notification */
-		zone->soa_notified_acquired = 0;
+	assert(state == xfrd_xfr_ok);
+	/* soa information available, as such the information can be related
+	   to a specific zone transfer (the last zone transfer sent, since soa
+	   information is communicated after verification) and transfer state
+	   must be either xfrd_xfr_ok or xfrd_xfr_drop, though the latter only
+	   occurs if zone verification is actually enabled */
+	while(xfr && 0 != compare_serial(ntohl(xfr->soa.serial), ntohl(soa->serial))) {
+		xfr = xfr->prev;
 	}
-	xfrd_set_zone_state(zone, xfrd_zone_refreshing);
-	xfrd_set_refresh_now(zone);
-	xfrd_send_notify(xfrd->notify_zones, zone->apex, &zone->soa_nsd);
+
+	assert(xfr != NULL);
+	assert(xfr->acquired <= xfrd->reload_cmd_last_sent);
+	xfr->state = state;
 }
 
 void
@@ -1379,7 +1374,7 @@ xfrd_udp_read(xfrd_zone_type* zone)
 				xfrd_make_request(zone);
 				break;
 			}
-			/* fallthrough */
+			/* fall through */
 		case xfrd_packet_newlease:
 			/* nothing more to do */
 			assert(zone->round_num == -1);
@@ -1575,6 +1570,7 @@ static int
 xfrd_send_ixfr_request_udp(xfrd_zone_type* zone)
 {
 	int fd;
+	xfrd_soa_type *soa;
 
 	/* make sure we have a master to query the ixfr request to */
 	assert(zone->master);
@@ -1585,20 +1581,25 @@ xfrd_send_ixfr_request_udp(xfrd_zone_type* zone)
 			zone->apex_str);
 		return -1;
 	}
-	xfrd_setup_packet(xfrd->packet, TYPE_IXFR, CLASS_IN, zone->apex,
-		qid_generate());
+
+	xfrd_setup_packet(
+		xfrd->packet, TYPE_IXFR, CLASS_IN, zone->apex, qid_generate());
+	xfrd_prepare_zone_xfr(zone);
 	zone->query_id = ID(xfrd->packet);
-	/* delete old xfr file? */
-	if(zone->msg_seq_nr)
-		xfrd_unlink_xfrfile(xfrd->nsd, zone->xfrfilenumber);
-	zone->msg_seq_nr = 0;
-	zone->msg_rr_count = 0;
+
 	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "sent query with ID %d", zone->query_id));
         NSCOUNT_SET(xfrd->packet, 1);
-	xfrd_write_soa_buffer(xfrd->packet, zone->apex, &zone->soa_disk);
+
+	if(zone->soa_xfr_acquired != 0) {
+		soa = &zone->soa_xfr;
+	} else {
+		soa = &zone->soa_nsd;
+	}
+
+	xfrd_write_soa_buffer(xfrd->packet, zone->apex, soa);
 	/* if we have tsig keys, sign the ixfr query */
 	if(zone->master->key_options && zone->master->key_options->tsig_key) {
-		xfrd_tsig_sign_request(xfrd->packet, &zone->tsig, zone->master);
+		xfrd_tsig_sign_request(xfrd->packet, &zone->latest_xfr->tsig, zone->master);
 	}
 	buffer_flip(xfrd->packet);
 	xfrd_set_timer(zone, XFRD_UDP_TIMEOUT);
@@ -1609,7 +1610,7 @@ xfrd_send_ixfr_request_udp(xfrd_zone_type* zone)
 
 	DEBUG(DEBUG_XFRD,1, (LOG_INFO,
 		"xfrd sent udp request for ixfr=%u for zone %s to %s",
-		(unsigned)ntohl(zone->soa_disk.serial),
+		(unsigned)ntohl(soa->serial),
 		zone->apex_str, zone->master->ip_address_spec));
 	return fd;
 }
@@ -1662,7 +1663,7 @@ xfrd_xfr_check_rrs(xfrd_zone_type* zone, buffer_type* packet, size_t count,
 	domain_table_type* owners;
 	rdata_atom_type* rdatas;
 
-	for(i=0; i<count; ++i,++zone->msg_rr_count)
+	for(i=0; i<count; ++i,++zone->latest_xfr->msg_rr_count)
 	{
 		if (*done) {
 			DEBUG(DEBUG_XFRD,1, (LOG_ERR, "xfrd: zone %s xfr has "
@@ -1708,35 +1709,42 @@ xfrd_xfr_check_rrs(xfrd_zone_type* zone, buffer_type* packet, size_t count,
 					"unable to parse soainfo", zone->apex_str));
 				return 0;
 			}
-			if(zone->msg_rr_count == 1 &&
-				ntohl(soa->serial) != zone->msg_new_serial) {
+			if(zone->latest_xfr->msg_rr_count == 1 &&
+			   zone->latest_xfr->msg_new_serial != ntohl(soa->serial))
+			{
 				/* 2nd RR is SOA with lower serial, this is an IXFR */
-				zone->msg_is_ixfr = 1;
-				if(!zone->soa_disk_acquired) {
+				zone->latest_xfr->msg_is_ixfr = 1;
+				if(zone->soa_xfr_acquired == 0 &&
+				   zone->soa_nsd_acquired == 0)
+				{
 					DEBUG(DEBUG_XFRD,1, (LOG_ERR, "xfrd: zone %s xfr "
 						"got ixfr but need axfr", zone->apex_str));
 					return 0; /* got IXFR but need AXFR */
 				}
-				if(ntohl(soa->serial) != ntohl(zone->soa_disk.serial)) {
+				if((zone->soa_xfr_acquired != 0 &&
+					ntohl(soa->serial) != ntohl(zone->soa_xfr.serial)) ||
+				   (zone->soa_nsd_acquired != 0 &&
+					ntohl(soa->serial) != ntohl(zone->soa_nsd.serial)))
+				{
 					DEBUG(DEBUG_XFRD,1, (LOG_ERR, "xfrd: zone %s xfr "
 						"bad start serial", zone->apex_str));
 					return 0; /* bad start serial in IXFR */
 				}
-				zone->msg_old_serial = ntohl(soa->serial);
+				zone->latest_xfr->msg_old_serial = ntohl(soa->serial);
 				tmp_serial = ntohl(soa->serial);
 			}
-			else if(ntohl(soa->serial) == zone->msg_new_serial) {
+			else if(ntohl(soa->serial) == zone->latest_xfr->msg_new_serial) {
 				/* saw another SOA of new serial. */
-				if(zone->msg_is_ixfr == 1) {
-					zone->msg_is_ixfr = 2; /* seen middle SOA in ixfr */
+				if(zone->latest_xfr->msg_is_ixfr == 1) {
+					zone->latest_xfr->msg_is_ixfr = 2; /* seen middle SOA in ixfr */
 				} else {
 					/* 2nd SOA for AXFR or 3rd newSOA for IXFR */
 					*done = 1;
 				}
 			}
-			else if (zone->msg_is_ixfr) {
+			else if (zone->latest_xfr->msg_is_ixfr) {
 				/* some additional checks */
-				if(ntohl(soa->serial) > zone->msg_new_serial) {
+				if(ntohl(soa->serial) > zone->latest_xfr->msg_new_serial) {
 					DEBUG(DEBUG_XFRD,1, (LOG_ERR, "xfrd: zone %s xfr "
 						"bad middle serial", zone->apex_str));
 					return 0; /* bad middle serial in IXFR */
@@ -1763,30 +1771,30 @@ xfrd_xfr_process_tsig(xfrd_zone_type* zone, buffer_type* packet)
 	int have_tsig = 0;
 	assert(zone && zone->master && zone->master->key_options
 		&& zone->master->key_options->tsig_key && packet);
-	if(!tsig_find_rr(&zone->tsig, packet)) {
+	if(!tsig_find_rr(&zone->latest_xfr->tsig, packet)) {
 		log_msg(LOG_ERR, "xfrd: zone %s, from %s: malformed tsig RR",
 			zone->apex_str, zone->master->ip_address_spec);
 		return 0;
 	}
-	if(zone->tsig.status == TSIG_OK) {
+	if(zone->latest_xfr->tsig.status == TSIG_OK) {
 		have_tsig = 1;
-		if (zone->tsig.error_code != TSIG_ERROR_NOERROR) {
+		if (zone->latest_xfr->tsig.error_code != TSIG_ERROR_NOERROR) {
 			log_msg(LOG_ERR, "xfrd: zone %s, from %s: tsig error "
 				"(%s)", zone->apex_str,
 				zone->master->ip_address_spec,
-				tsig_error(zone->tsig.error_code));
+				tsig_error(zone->latest_xfr->tsig.error_code));
 		}
 	}
 	if(have_tsig) {
 		/* strip the TSIG resource record off... */
-		buffer_set_limit(packet, zone->tsig.position);
+		buffer_set_limit(packet, zone->latest_xfr->tsig.position);
 		ARCOUNT_SET(packet, ARCOUNT(packet) - 1);
 	}
 
 	/* keep running the TSIG hash */
-	tsig_update(&zone->tsig, packet, buffer_limit(packet));
+	tsig_update(&zone->latest_xfr->tsig, packet, buffer_limit(packet));
 	if(have_tsig) {
-		if (!tsig_verify(&zone->tsig)) {
+		if (!tsig_verify(&zone->latest_xfr->tsig)) {
 			log_msg(LOG_ERR, "xfrd: zone %s, from %s: bad tsig signature",
 				zone->apex_str, zone->master->ip_address_spec);
 			return 0;
@@ -1794,9 +1802,9 @@ xfrd_xfr_process_tsig(xfrd_zone_type* zone, buffer_type* packet)
 		DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: zone %s, from %s: good tsig signature",
 			zone->apex_str, zone->master->ip_address_spec));
 		/* prepare for next tsigs */
-		tsig_prepare(&zone->tsig);
+		tsig_prepare(&zone->latest_xfr->tsig);
 	}
-	else if(zone->tsig.updates_since_last_prepare > XFRD_TSIG_MAX_UNSIGNED) {
+	else if(zone->latest_xfr->tsig.updates_since_last_prepare > XFRD_TSIG_MAX_UNSIGNED) {
 		/* we allow a number of non-tsig signed packets */
 		log_msg(LOG_INFO, "xfrd: zone %s, from %s: too many consecutive "
 			"packets without TSIG", zone->apex_str,
@@ -1804,7 +1812,7 @@ xfrd_xfr_process_tsig(xfrd_zone_type* zone, buffer_type* packet)
 		return 0;
 	}
 
-	if(!have_tsig && zone->msg_seq_nr == 0) {
+	if(!have_tsig && zone->latest_xfr->msg_seq_nr == 0) {
 		log_msg(LOG_ERR, "xfrd: zone %s, from %s: no tsig in first packet of reply",
 			zone->apex_str, zone->master->ip_address_spec);
 		return 0;
@@ -1892,7 +1900,7 @@ xfrd_parse_received_xfr_packet(xfrd_zone_type* zone, buffer_type* packet,
 			return xfrd_packet_bad;
 		}
 	}
-	if(zone->msg_rr_count == 0 && ancount == 0) {
+	if(zone->latest_xfr->msg_rr_count == 0 && ancount == 0) {
 		if(zone->tcp_conn == -1 && TC(packet)) {
 			DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: TC flagged"));
 			return xfrd_packet_tcp;
@@ -1914,9 +1922,21 @@ xfrd_parse_received_xfr_packet(xfrd_zone_type* zone, buffer_type* packet,
 	ancount_todo = ancount;
 
 	tempregion = region_create(xalloc, free);
-	if(zone->msg_rr_count == 0) {
+	if(zone->latest_xfr->msg_rr_count == 0) {
+		time_t *last_soa_acquired;
+		xfrd_soa_type *last_soa;
+
 		const dname_type* soaname = dname_make_from_packet(tempregion,
 			packet, 1, 1);
+
+		if(zone->soa_xfr_acquired > 0) {
+			last_soa_acquired = &zone->soa_xfr_acquired;
+			last_soa = &zone->soa_xfr;
+		} else {
+			last_soa_acquired = &zone->soa_nsd_acquired;
+			last_soa = &zone->soa_nsd;
+		}
+
 		if(!soaname) { /* parse failure */
 			DEBUG(DEBUG_XFRD,1, (LOG_ERR, "xfrd: zone %s, from %s: "
 				"parse error in SOA record",
@@ -1941,9 +1961,13 @@ xfrd_parse_received_xfr_packet(xfrd_zone_type* zone, buffer_type* packet,
 			region_destroy(tempregion);
 			return xfrd_packet_bad;
 		}
-		if(zone->soa_disk_acquired != 0 &&
-			zone->state != xfrd_zone_expired /* if expired - accept anything */ &&
-			compare_serial(ntohl(soa->serial), ntohl(zone->soa_disk.serial)) < 0) {
+
+		if(zone->state == xfrd_zone_expired || *last_soa_acquired <= 0)
+		{
+			/* accept anything if expired */ ;
+		} else if(compare_serial(ntohl(soa->serial),
+		                         ntohl(last_soa->serial)) < 0)
+		{
 			DEBUG(DEBUG_XFRD,1, (LOG_INFO,
 				"xfrd: zone %s ignoring old serial from %s",
 				zone->apex_str, zone->master->ip_address_spec));
@@ -1952,16 +1976,14 @@ xfrd_parse_received_xfr_packet(xfrd_zone_type* zone, buffer_type* packet,
 				zone->apex_str, zone->master->ip_address_spec));
 			region_destroy(tempregion);
 			return xfrd_packet_bad;
-		}
-		if(zone->soa_disk_acquired != 0 && zone->soa_disk.serial == soa->serial) {
-			DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: zone %s got "
-						       "update indicating "
-						       "current serial",
+		} else if(compare_serial(ntohl(soa->serial),
+		                         ntohl(last_soa->serial)) == 0)
+		{
+			DEBUG(DEBUG_XFRD,1, (LOG_INFO,
+				"xfrd: zone %s got update indicating current serial",
 				zone->apex_str));
 			/* (even if notified) the lease on the current soa is renewed */
-			zone->soa_disk_acquired = xfrd_time();
-			if(zone->soa_nsd.serial == soa->serial)
-				zone->soa_nsd_acquired = xfrd_time();
+			*last_soa_acquired = xfrd_time();
 			xfrd_set_zone_state(zone, xfrd_zone_ok);
  			DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: zone %s is ok",
 				zone->apex_str));
@@ -1974,14 +1996,17 @@ xfrd_parse_received_xfr_packet(xfrd_zone_type* zone, buffer_type* packet,
 				zone->round_num = -1; /* next try start a new round */
 				xfrd_set_timer_refresh(zone);
 				region_destroy(tempregion);
+				xfrd_discard_zone_xfr(zone, zone->latest_xfr);
 				return xfrd_packet_newlease;
 			}
 			/* try next master */
 			region_destroy(tempregion);
 			return xfrd_packet_drop;
 		}
-		DEBUG(DEBUG_XFRD,1, (LOG_INFO, "IXFR reply has ok serial (have \
-%u, reply %u).", (unsigned)ntohl(zone->soa_disk.serial), (unsigned)ntohl(soa->serial)));
+		DEBUG(DEBUG_XFRD,1, (LOG_INFO,
+			"IXFR reply has ok serial (have %u, reply %u).",
+			(unsigned)ntohl(last_soa->serial),
+			(unsigned)ntohl(soa->serial)));
 		/* serial is newer than soa_disk */
 		if(ancount == 1) {
 			/* single record means it is like a notify */
@@ -1992,12 +2017,14 @@ xfrd_parse_received_xfr_packet(xfrd_zone_type* zone, buffer_type* packet,
 			/* this AXFR/IXFR notifies me that an even newer serial exists */
 			zone->soa_notified.serial = soa->serial;
 		}
-		zone->msg_new_serial = ntohl(soa->serial);
-		zone->msg_rr_count = 1;
-		zone->msg_is_ixfr = 0;
-		if(zone->soa_disk_acquired)
-			zone->msg_old_serial = ntohl(zone->soa_disk.serial);
-		else zone->msg_old_serial = 0;
+		zone->latest_xfr->msg_new_serial = ntohl(soa->serial);
+		zone->latest_xfr->msg_rr_count = 1;
+		zone->latest_xfr->msg_is_ixfr = 0;
+		if(*last_soa_acquired >= 0) {
+			zone->latest_xfr->msg_old_serial = ntohl(last_soa->serial);
+		} else {
+			zone->latest_xfr->msg_old_serial = 0;
+		}
 		ancount_todo = ancount - 1;
 	}
 
@@ -2035,7 +2062,7 @@ xfrd_parse_received_xfr_packet(xfrd_zone_type* zone, buffer_type* packet,
 	if(done == 0)
 		return xfrd_packet_more;
 	if(zone->master->key_options) {
-		if(zone->tsig.updates_since_last_prepare != 0) {
+		if(zone->latest_xfr->tsig.updates_since_last_prepare != 0) {
 			log_msg(LOG_INFO, "xfrd: last packet of reply has no "
 					 		  "TSIG");
 			return xfrd_packet_bad;
@@ -2054,12 +2081,109 @@ xfrd_pretty_time(time_t v)
 	return buf;
 }
 
+static int
+xfrd_zone_xfr_is_complete(xfrd_zone_type *zone, xfrd_xfr_type *xfr)
+{
+	assert(zone != NULL);
+	assert(xfr != NULL);
+	return (xfr->msg_seq_nr == 0 && xfr->acquired != 0);
+}
+
+xfrd_xfr_type *
+xfrd_prepare_zone_xfr(xfrd_zone_type* zone)
+{
+	xfrd_xfr_type *xfr;
+
+	assert(zone != NULL);
+
+	if(zone->latest_xfr != NULL &&
+	   xfrd_zone_xfr_is_complete(zone, zone->latest_xfr) == 0)
+	{
+		xfr = zone->latest_xfr;
+		/* discard tsig state */
+		tsig_delete_record(&xfr->tsig, xfrd->region);
+		/* incomplete XFR, reuse memory and remove file */
+		xfrd_unlink_xfrfile(xfrd->nsd, zone->latest_xfr->filenr);
+	} else {
+		/* allocate memory for XFR bookkeeping */
+		xfr = region_alloc(xfrd->region, sizeof(*xfr));
+		if((xfr->prev = zone->latest_xfr) != NULL) {
+			xfr->prev->next = xfr;
+		}
+	}
+
+	xfr->next = NULL;
+	zone->latest_xfr = xfr;
+	tsig_create_record_custom(&zone->latest_xfr->tsig, NULL, 0, 0, 4);
+	/* (re)set zone xfr state */
+	xfr->acquired = 0;
+	memset(&xfr->soa, 0, sizeof(xfrd_soa_type));
+	xfr->msg_seq_nr = 0;
+	xfr->msg_old_serial = xfr->msg_new_serial = 0;
+	xfr->msg_rr_count = 0;
+	xfr->msg_is_ixfr = 0;
+	xfr->filenr = 0;
+	xfr->state = xfrd_xfr_new;
+
+	return xfr;
+}
+
+static void
+xfrd_discard_zone_xfr(xfrd_zone_type* zone, xfrd_xfr_type* xfr)
+{
+	assert(zone != NULL);
+
+	if(xfr == NULL) {
+		return;
+	}
+
+	assert(zone->latest_xfr != NULL);
+
+	if(xfr == zone->latest_xfr) {
+		assert(!xfr->next);
+		if((zone->latest_xfr = xfr->prev) != NULL) {
+			zone->latest_xfr->next = NULL;
+		}
+	} else {
+		if(xfr->next != NULL) {
+			xfr->next->prev = xfr->prev;
+		}
+		if(xfr->prev != NULL) {
+			xfr->prev->next = xfr->next;
+		}
+	}
+
+	tsig_delete_record(&xfr->tsig, xfrd->region);
+	if(xfr->msg_seq_nr != 0 || xfr->acquired) {
+		xfrd_unlink_xfrfile(xfrd->nsd, xfr->filenr);
+		xfr->filenr = 0;
+	}
+	assert(xfr->filenr == 0);
+	region_recycle(xfrd->region, xfr, sizeof(*xfr));
+}
+
+static void
+xfrd_discard_zone_xfrs(xfrd_zone_type *zone)
+{
+	xfrd_xfr_type *xfr;
+
+	assert(zone != NULL);
+
+	for(xfr = zone->latest_xfr; xfr; xfr = zone->latest_xfr) {
+		xfrd_discard_zone_xfr(zone, xfr);
+	}
+}
+
 enum xfrd_packet_result
 xfrd_handle_received_xfr_packet(xfrd_zone_type* zone, buffer_type* packet)
 {
 	xfrd_soa_type soa;
 	enum xfrd_packet_result res;
-        uint64_t xfrfile_size;
+	uint64_t xfrfile_size;
+
+	/* xfr metadata allocated when xfr request is sent */
+	assert(zone != NULL);
+	assert(zone->latest_xfr != NULL);
 
 	/* parse and check the packet - see if it ends the xfr */
 	switch((res=xfrd_parse_received_xfr_packet(zone, packet, &soa)))
@@ -2078,21 +2202,21 @@ xfrd_handle_received_xfr_packet(xfrd_zone_type* zone, buffer_type* packet)
 		default:
 		{
 			/* rollback */
-			if(zone->msg_seq_nr > 0) {
+			if(zone->latest_xfr->msg_seq_nr > 0) {
 				/* do not process xfr - if only one part simply ignore it. */
 				/* delete file with previous parts of commit */
-				xfrd_unlink_xfrfile(xfrd->nsd, zone->xfrfilenumber);
+				xfrd_unlink_xfrfile(xfrd->nsd, zone->latest_xfr->filenr);
 				VERBOSITY(1, (LOG_INFO, "xfrd: zone %s "
 					"reverted transfer %u from %s",
-					zone->apex_str, zone->msg_rr_count?
-					(int)zone->msg_new_serial:0,
+					zone->apex_str,
+					zone->latest_xfr->msg_rr_count ? (int)zone->latest_xfr->msg_new_serial : 0,
 					zone->master->ip_address_spec));
-				zone->msg_seq_nr = 0;
+				zone->latest_xfr->msg_seq_nr = 0;
 			} else if (res == xfrd_packet_bad) {
 				VERBOSITY(1, (LOG_INFO, "xfrd: zone %s "
 					"bad transfer %u from %s",
-					zone->apex_str, zone->msg_rr_count?
-					(int)zone->msg_new_serial:0,
+					zone->apex_str,
+					zone->latest_xfr->msg_rr_count ? (int)zone->latest_xfr->msg_new_serial : 0,
 					zone->master->ip_address_spec));
 			}
 			if (res == xfrd_packet_notimpl)
@@ -2105,20 +2229,30 @@ xfrd_handle_received_xfr_packet(xfrd_zone_type* zone, buffer_type* packet)
 	/* dump reply on disk to diff file */
 	/* if first part, get new filenumber.  Numbers can wrap around, 64bit
 	 * is enough so we do not collide with older-transfers-in-progress */
-	if(zone->msg_seq_nr == 0)
-		zone->xfrfilenumber = xfrd->xfrfilenumber++;
+	if(zone->latest_xfr->msg_seq_nr == 0) {
+		/* never use 0 (zero) as a file number. there must be at least
+		   one illegal identifier so that a transfer file is only ever
+		   removed if something has actually been written */
+		if(xfrd->xfrfilenumber == 0) {
+			xfrd->xfrfilenumber++;
+		}
+		zone->latest_xfr->filenr = xfrd->xfrfilenumber++;
+	}
 	diff_write_packet(dname_to_string(zone->apex,0),
 		zone->zone_options->pattern->pname,
-		zone->msg_old_serial, zone->msg_new_serial, zone->msg_seq_nr,
+		zone->latest_xfr->msg_old_serial,
+		zone->latest_xfr->msg_new_serial,
+		zone->latest_xfr->msg_seq_nr,
 		buffer_begin(packet), buffer_limit(packet), xfrd->nsd,
-		zone->xfrfilenumber);
+		zone->latest_xfr->filenr);
 	VERBOSITY(3, (LOG_INFO,
 		"xfrd: zone %s written received XFR packet from %s with serial %u to "
 		"disk", zone->apex_str, zone->master->ip_address_spec,
-		(int)zone->msg_new_serial));
-	zone->msg_seq_nr++;
+		(int)zone->latest_xfr->msg_new_serial));
+	zone->latest_xfr->msg_seq_nr++;
 
-        xfrfile_size = xfrd_get_xfrfile_size(xfrd->nsd, zone->xfrfilenumber);
+	xfrfile_size = xfrd_get_xfrfile_size(
+		xfrd->nsd, zone->latest_xfr->filenr);
 	if( zone->zone_options->pattern->size_limit_xfr != 0 &&
 	    xfrfile_size > zone->zone_options->pattern->size_limit_xfr ) {
             /*	    xfrd_unlink_xfrfile(xfrd->nsd, zone->xfrfilenumber);
@@ -2134,36 +2268,36 @@ xfrd_handle_received_xfr_packet(xfrd_zone_type* zone, buffer_type* packet)
 	/* done. we are completely sure of this */
 	buffer_clear(packet);
 	buffer_printf(packet, "received update to serial %u at %s from %s",
-		(unsigned)zone->msg_new_serial, xfrd_pretty_time(xfrd_time()),
+		(unsigned)zone->latest_xfr->msg_new_serial, xfrd_pretty_time(xfrd_time()),
 		zone->master->ip_address_spec);
 	if(zone->master->key_options) {
 		buffer_printf(packet, " TSIG verified with key %s",
 			zone->master->key_options->name);
 	}
 	buffer_flip(packet);
-	diff_write_commit(zone->apex_str, zone->msg_old_serial,
-		zone->msg_new_serial, zone->msg_seq_nr, 1,
-		(char*)buffer_begin(packet), xfrd->nsd, zone->xfrfilenumber);
+	diff_write_commit(zone->apex_str,
+	                  zone->latest_xfr->msg_old_serial,
+	                  zone->latest_xfr->msg_new_serial,
+	                  zone->latest_xfr->msg_seq_nr,
+	                  DIFF_COMMITTED,
+	                  (char*)buffer_begin(packet),
+	                  xfrd->nsd,
+	                  zone->latest_xfr->filenr);
 	VERBOSITY(1, (LOG_INFO, "xfrd: zone %s committed \"%s\"",
 		zone->apex_str, (char*)buffer_begin(packet)));
+	/* update latest transfer serial no. */
+	zone->soa_xfr = zone->latest_xfr->soa = soa;
+	zone->soa_xfr_acquired = zone->latest_xfr->acquired = xfrd_time();
 	/* reset msg seq nr, so if that is nonnull we know xfr file exists */
-	zone->msg_seq_nr = 0;
-	/* now put apply_xfr task on the tasklist */
-	if(!task_new_apply_xfr(xfrd->nsd->task[xfrd->nsd->mytask],
-		xfrd->last_task, zone->apex, zone->msg_old_serial,
-		zone->msg_new_serial, zone->xfrfilenumber)) {
-		/* delete the file and pretend transfer was bad to continue */
-		xfrd_unlink_xfrfile(xfrd->nsd, zone->xfrfilenumber);
-		xfrd_set_reload_timeout();
-		return xfrd_packet_bad;
+	zone->latest_xfr->msg_seq_nr = 0;
+	/* schedule update immediately if no reload is in progress */
+	if(xfrd->can_send_reload) {
+		xfrd_schedule_zone_xfr(zone, zone->latest_xfr);
 	}
-	/* update the disk serial no. */
-	zone->soa_disk_acquired = xfrd_time();
-	zone->soa_disk = soa;
-	if(zone->soa_notified_acquired && (
-		zone->soa_notified.serial == 0 ||
-		compare_serial(htonl(zone->soa_disk.serial),
-		htonl(zone->soa_notified.serial)) >= 0))
+
+	if((zone->soa_notified_acquired) &&
+	   (compare_serial(ntohl(zone->soa_xfr.serial),
+		           ntohl(zone->soa_notified.serial)) >= 0))
 	{
 		zone->soa_notified_acquired = 0;
 	}
@@ -2253,7 +2387,7 @@ xfrd_handle_notify_and_start_xfr(xfrd_zone_type* zone, xfrd_soa_type* soa)
 		/* zones with no content start expbackoff again; this is also
 		 * for nsd-control started transfer commands, and also when
 		 * the master apparently sends notifies (is back up) */
-		if(zone->soa_disk_acquired == 0)
+		if(zone->soa_nsd_acquired == 0)
 			zone->fresh_xfr_timeout = XFRD_TRANSFER_TIMEOUT_START;
 	}
 }
@@ -2321,23 +2455,33 @@ xfrd_handle_passed_packet(buffer_type* packet,
 static int
 xfrd_handle_incoming_notify(xfrd_zone_type* zone, xfrd_soa_type* soa)
 {
-	if(soa && zone->soa_disk_acquired && zone->state != xfrd_zone_expired &&
-	   compare_serial(ntohl(soa->serial),ntohl(zone->soa_disk.serial)) <= 0)
+	time_t last_soa_acquired;
+	xfrd_soa_type *last_soa;
+
+	if(zone->soa_xfr_acquired > 0) {
+		last_soa_acquired = zone->soa_xfr_acquired;
+		last_soa = &zone->soa_xfr;
+	} else {
+		last_soa_acquired = zone->soa_nsd_acquired;
+		last_soa = &zone->soa_nsd;
+	}
+
+	if(soa == NULL) {
+		zone->soa_notified.serial = 0;
+	} else if(last_soa_acquired > 0 && zone->state != xfrd_zone_expired &&
+	          compare_serial(ntohl(soa->serial),
+	                         ntohl(last_soa->serial)) <= 0)
 	{
 		DEBUG(DEBUG_XFRD,1, (LOG_INFO,
 			"xfrd: ignored notify %s %u old serial, zone valid "
 			"(soa disk serial %u)", zone->apex_str,
 			(unsigned)ntohl(soa->serial),
-			(unsigned)ntohl(zone->soa_disk.serial)));
+			(unsigned)ntohl(last_soa->serial)));
 		return 0; /* ignore notify with old serial, we have a valid zone */
-	}
-	if(soa == 0) {
-		zone->soa_notified.serial = 0;
-	}
-	else if (zone->soa_notified_acquired == 0 ||
-		 zone->soa_notified.serial == 0 ||
-		 compare_serial(ntohl(soa->serial),
-			ntohl(zone->soa_notified.serial)) > 0)
+	} else if(zone->soa_notified_acquired == 0 ||
+	          zone->soa_notified.serial   == 0 ||
+	          compare_serial(ntohl(soa->serial),
+	                         ntohl(zone->soa_notified.serial)) > 0)
 	{
 		zone->soa_notified = *soa;
 	}
@@ -2370,78 +2514,261 @@ find_same_master_notify(xfrd_zone_type* zone, int acl_num_nfy)
 	return -1;
 }
 
-void
-xfrd_check_failed_updates()
+static int
+xfrd_schedule_zone_xfr(
+	xfrd_zone_type *zone, xfrd_xfr_type *xfr)
 {
-	/* see if updates have not come through */
-	xfrd_zone_type* zone;
-	RBTREE_FOR(zone, xfrd_zone_type*, xfrd->zones)
-	{
-		/* zone has a disk soa, and no nsd soa or a different nsd soa */
-		if(zone->soa_disk_acquired != 0 &&
-			(zone->soa_nsd_acquired == 0 ||
-			zone->soa_disk.serial != zone->soa_nsd.serial))
-		{
-			if(zone->soa_disk_acquired <
-				xfrd->reload_cmd_last_sent)
-			{
-				/* this zone should have been loaded, since its disk
-				   soa time is before the time of the reload cmd. */
-				xfrd_soa_type dumped_soa = zone->soa_disk;
-				log_msg(LOG_ERR, "xfrd: zone %s: soa serial %u "
-						 		 "update failed, restarting "
-						 		 "transfer (notified zone)",
-					zone->apex_str, (unsigned)ntohl(zone->soa_disk.serial));
-				/* revert the soa; it has not been acquired properly */
-				if(zone->soa_disk_acquired == zone->soa_nsd_acquired) {
-					/* this was the same as served,
-					 * perform force_axfr , re-download
-					 * same serial from master */
-					zone->soa_disk_acquired = 0;
-					zone->soa_nsd_acquired = 0;
-				} else {
-					/* revert soa to the one in server */
-					zone->soa_disk_acquired = zone->soa_nsd_acquired;
-					zone->soa_disk = zone->soa_nsd;
-				}
-				/* pretend we are notified with disk soa.
-				   This will cause a refetch of the data, and reload. */
-				xfrd_handle_incoming_notify(zone, &dumped_soa);
-				xfrd_set_timer_refresh(zone);
-			} else if(zone->soa_disk_acquired >= xfrd->reload_cmd_last_sent) {
-				/* this zone still has to be loaded,
-				   make sure reload is set to be sent. */
-				if(xfrd->need_to_send_reload == 0 &&
-					xfrd->reload_added == 0) {
-					log_msg(LOG_ERR, "xfrd: zone %s: needs "
-									 "to be loaded. reload lost? "
-									 "try again", zone->apex_str);
-					xfrd_set_reload_timeout();
-				}
+	assert(zone != NULL);
+	assert(xfr != NULL);
+
+	return task_new_apply_xfr(
+		xfrd->nsd->task[xfrd->nsd->mytask],
+		xfrd->last_task,
+		zone->apex,
+		xfr->msg_old_serial,
+		xfr->msg_new_serial,
+		xfr->filenr);
+}
+
+static int
+xfrd_schedule_zone_xfrs(
+	xfrd_zone_type *zone, xfrd_xfr_type *last_xfr, int committed)
+{
+	int cnt = 0;
+	xfrd_xfr_type *xfr, *first_xfr;
+
+	assert(zone != NULL);
+
+	if(!last_xfr || !zone->latest_xfr) {
+		return 0;
+	}
+
+	for(xfr = zone->latest_xfr; xfr; xfr = xfr->prev) {
+		/* reset transfer to new */
+		xfr->state = xfrd_xfr_new;
+		first_xfr = xfr;
+	}
+
+	for(xfr = first_xfr; xfr && xfr->prev != last_xfr; xfr = xfr->next) {
+		/* schedule only complete transfers */
+		if(!xfrd_zone_xfr_is_complete(zone, xfr)) {
+			continue;
+		}
+
+		if (xfrd_schedule_zone_xfr(zone, xfr)) {
+			cnt++;
+		} else {
+			/* no space was available, process what was scheduled,
+			   save the rest for later */
+			break;
+		}
+	}
+
+	if(cnt > 0) {
+		log_msg(LOG_INFO, "xfrd: zone %s scheduled to be %s (%d)",
+			zone->apex_str, committed ? "loaded" : "reloaded", cnt);
+		if(!xfrd->need_to_send_reload && !xfrd->reload_added) {
+			if(committed) {
+				xfrd_set_reload_timeout();
+			} else {
+				xfrd_set_reload_now(xfrd);
 			}
 		}
 	}
+
+	return cnt;
 }
 
-void
-xfrd_prepare_zones_for_reload()
+static void
+xfrd_process_zone_xfrs(xfrd_zone_type *zone, int committed)
 {
-	xfrd_zone_type* zone;
+	xfrd_xfr_type *next_xfr, *prev_xfr, *xfr;
+
+	xfr = zone->latest_xfr;
+	/* zones without transfers or no transfers sent to NSD before
+	   reload_cmd_first_sent do not need to be processed. transfers can
+	   remain "new" if transfers that came before corrupted the database
+	   somehow. */
+	while(xfr && xfr->state == xfrd_xfr_new) {
+		xfr = xfr->prev;
+	}
+
+	if(!xfr) {
+		time_t before;
+
+		/* no transfers to post-process. schedule any transfer for
+		   reload if changes were committed. reschedule transfers
+		   acquired before reload if changes were not committed. */
+		before = committed ? xfrd_time() : xfrd->reload_cmd_first_sent;
+		for (xfr = zone->latest_xfr; xfr; xfr = xfr->prev) {
+			if (xfr->acquired && xfr->acquired < before) {
+				xfrd_schedule_zone_xfrs(zone, xfr, committed);
+				return;
+			}
+		}
+		return; /* continue */
+	}
+
+	/* zone transfer list is in descending order. since zone
+	   verification is done after all transfers have been applied,
+	   the state of the most recently tried transfer is the
+	   state for the rest of the list if it was "ok". the same is not
+	   true for "drop" as that may be caused by the most recent
+	   zone transfer (or last). "corrupt" can occur before a
+	   transfer reported as "ok" or "drop" as the transfer itself
+	   may have been "corrupt" */
+
+	/* if the state of the most recent transfer is "corrupt", any
+	   incremental transfer that follows must be discarded and the zone
+	   must be refreshed, unless of course a full transfer is already
+	   awaiting scheduling */
+	if(xfr->state == xfrd_xfr_corrupt ||
+	   xfr->state == xfrd_xfr_inconsistent)
+	{
+		next_xfr = xfr->next;
+		while(next_xfr) {
+			/* transfer must be complete to determine if it is
+			   incremental */
+			if(next_xfr->acquired > 0 && next_xfr->msg_is_ixfr) {
+				xfrd_discard_zone_xfr(zone, next_xfr);
+				next_xfr = xfr->next;
+			} else {
+				break;
+			}
+		}
+		/* refresh if no full transfer was awaiting scheduling */
+		if(xfr->state == xfrd_xfr_inconsistent) {
+			/* reset soa_nsd_acquired to force a full transfer.
+			   a refresh will be scheduled upon return */
+			zone->soa_nsd_acquired = 0;
+			memset(&zone->soa_nsd, 0, sizeof(xfrd_soa_type));
+		}
+	}
+
+	/* discard any leading corrupt transfers. */
+	while(xfr && (xfr->state == xfrd_xfr_corrupt ||
+	              xfr->state == xfrd_xfr_inconsistent))
+	{
+		prev_xfr = xfr->prev;
+		xfrd_discard_zone_xfr(zone, xfr);
+		xfr = prev_xfr;
+	}
+
+	if(!xfr) {
+		/* reset soa_xfr information if no transfers are acquired to
+		   decide if the zone needs a refresh */
+		if((!zone->latest_xfr) ||
+		   (!zone->latest_xfr->prev && !zone->latest_xfr->acquired))
+		{
+			zone->soa_xfr_acquired = 0;
+			memset(&zone->soa_xfr, 0, sizeof(xfrd_soa_type));
+		}
+		if(committed) {
+			xfrd_schedule_zone_xfrs(
+				zone, zone->latest_xfr, committed);
+		}
+		return; /* continue */
+	} else if(!committed) {
+		assert(xfr->state == xfrd_xfr_ok ||
+		       xfr->state == xfrd_xfr_new);
+		if(xfr == zone->latest_xfr) {
+			zone->soa_xfr_acquired = xfr->acquired;
+			zone->soa_xfr = xfr->soa;
+		}
+		xfrd_schedule_zone_xfrs(zone, xfr, committed);
+		return; /* nothing to update yet, continue */
+	}
+
+	assert(committed);
+	assert(xfr && (xfr->state == xfrd_xfr_ok ||
+	               xfr->state == xfrd_xfr_new));
+
+	/* transfer committed to memory */
+	log_msg(LOG_INFO, "zone %s serial %u is updated to %u",
+		zone->apex_str,
+		ntohl(zone->soa_nsd.serial),
+		ntohl(xfr->soa.serial));
+	zone->soa_nsd = xfr->soa;
+	zone->soa_nsd_acquired = xfr->acquired;
+	xfrd->write_zonefile_needed = 1;
+
+	/* discard committed transfers */
+	while(xfr) {
+		prev_xfr = xfr->prev;
+		xfrd_discard_zone_xfr(zone, xfr);
+		xfr = prev_xfr;
+	}
+
+	if((!zone->latest_xfr) ||
+	   (!zone->latest_xfr->prev || !zone->latest_xfr->acquired))
+	{
+		zone->soa_xfr_acquired = 0;
+		memset(&zone->soa_xfr, 0, sizeof(xfrd_soa_type));
+	}
+
+	xfrd_schedule_zone_xfrs(zone, zone->latest_xfr, committed);
+	xfrd_send_notify(xfrd->notify_zones, zone->apex, &zone->soa_nsd);
+}
+
+/* zone transfers must be processed after all soa information returned by nsd
+   has been processed, it is unknown whether difffiles for successful transfers
+   can be discarded otherwise. */
+void
+xfrd_process_xfrs(int committed)
+{
+	xfrd_zone_type *zone;
+
 	RBTREE_FOR(zone, xfrd_zone_type*, xfrd->zones)
 	{
-		/* zone has a disk soa, and no nsd soa or a different nsd soa */
-		if(zone->soa_disk_acquired != 0 &&
-			(zone->soa_nsd_acquired == 0 ||
-			zone->soa_disk.serial != zone->soa_nsd.serial))
+		time_t elapsed;
+
+		/* reloads are scheduled by xfrd_schedule_zone_xfrs if any
+		   transfers are added to the tasklist */
+		xfrd_process_zone_xfrs(zone, committed);
+
+		if(!committed) {
+			continue; /* continue if nothing has been committed */
+		}
+
+		if((zone->soa_notified_acquired != 0 &&
+		    compare_serial(ntohl(zone->soa_notified.serial),
+		                   ntohl(zone->soa_nsd.serial)) <= 0) ||
+		   (zone->soa_notified_acquired < zone->soa_nsd_acquired))
 		{
-			if(zone->soa_disk_acquired == xfrd_time()) {
-				/* antedate by one second.
-				 * this makes sure that the zone time is before
-				 * reload, so that check_failed_zones() is
-				 * certain of the result.
-				 */
-				zone->soa_disk_acquired--;
+			zone->soa_notified_acquired = 0;
+			memset(&zone->soa_notified, 0, sizeof(xfrd_soa_type));
+		}
+
+		/* earlier versions of NSD checked if a transfer was completed
+		   before the reload and concluded that the update must have
+		   failed if the transfer was still around. that isn't possible
+		   anymore since transfers are now checked individually */
+#if 0
+		assert(zone->soa_xfr_acquired == 0 ||
+		       zone->soa_xfr_acquired >= reload_cmd_first_sent);
+#endif
+
+		/* if soa_nsd_acquired was set to 0 (zero) to force a refresh,
+		   elapsed will be set to the current time, ensuring the
+		   refresh is triggered if no transfers are started/complete */
+		elapsed = xfrd_time() - zone->soa_nsd_acquired;
+		if(zone->soa_notified_acquired > zone->soa_xfr_acquired) {
+			/* a notify was received, force refresh */
+			xfrd_set_zone_state(zone, xfrd_zone_refreshing);
+			xfrd_set_refresh_now(zone);
+		} else if(elapsed < (time_t)ntohl(zone->soa_nsd.refresh)) {
+			xfrd_set_zone_state(zone, xfrd_zone_ok);
+			zone->round_num = -1;
+			xfrd_set_timer_refresh(zone);
+		} else if(zone->latest_xfr == NULL) {
+			/* zone must be refreshed or even expired already.
+			   refresh zone if no transfers are in progress */
+			if(elapsed >= (time_t)ntohl(zone->soa_nsd.expire)) {
+				xfrd_set_zone_state(zone, xfrd_zone_expired);
+			} else {
+				xfrd_set_zone_state(zone, xfrd_zone_refreshing);
 			}
+			xfrd_set_refresh_now(zone);
 		}
 	}
 }


### PR DESCRIPTION
This PR prepares NSD a bit for zone verification (previously a separate product called CreDNS) to be merged back.

* Update xfrd to keep zone transfers around until reload succeeds so that updates do not have to fetched again if verification for a single zone fails.