### PR TITLE
Turn bindtodevice option into an ip-address attribute

### DIFF
--- a/configlexer.lex
+++ b/configlexer.lex
@@ -203,7 +203,6 @@ ip-address{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_IP_ADDRESS;}
 interface{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_IP_ADDRESS;}
 ip-transparent{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_IP_TRANSPARENT;}
 ip-freebind{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_IP_FREEBIND;}
-bindtodevice{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_BINDTODEVICE; }
 send-buffer-size{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_SEND_BUFFER_SIZE;}
 receive-buffer-size{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_RECEIVE_BUFFER_SIZE;}
 debug-mode{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_DEBUG_MODE;}
@@ -306,6 +305,11 @@ servers={UNQUOTEDLETTER}*	{
 	yyless(yyleng - (yyleng - 8));
 	LEXOUT(("v(%s) ", yytext));
 	return VAR_SERVERS;
+}
+bindtodevice={UNQUOTEDLETTER}*	{
+	yyless(yyleng - (yyleng - 13));
+	LEXOUT(("v(%s) ", yytext));
+	return VAR_BINDTODEVICE;
 }
 setfib={UNQUOTEDLETTER}*	{
 	yyless(yyleng - (yyleng - 7));

--- a/configparser.y
+++ b/configparser.y
@@ -224,8 +224,6 @@ server_option:
     { cfg_parser->opt->ip_transparent = $2; }
   | VAR_IP_FREEBIND boolean
     { cfg_parser->opt->ip_freebind = $2; }
-  | VAR_BINDTODEVICE boolean
-    { cfg_parser->opt->bindtodevice = $2; }
   | VAR_SEND_BUFFER_SIZE number
     { cfg_parser->opt->send_buffer_size = (int)$2; }
   | VAR_RECEIVE_BUFFER_SIZE number
@@ -465,7 +463,10 @@ server_option:
   ;
 
 socket_options:
-  | VAR_SERVERS STRING
+  | socket_options socket_option ;
+
+socket_option:
+    VAR_SERVERS STRING
     {
       char *tok, *ptr, *str;
       struct range_option *servers = NULL;
@@ -492,6 +493,8 @@ socket_options:
         }
       }
     }
+  | VAR_BINDTODEVICE boolean
+    { cfg_parser->ip->dev = $2; }
   | VAR_SETFIB number
     { cfg_parser->ip->fib = $2; }
   ;

--- a/doc/README
+++ b/doc/README
@@ -737,10 +737,10 @@ improves select/poll performance and avoids waking up multiple servers when a
 packet comes in.
 
 
-bindtodevice: yes
+ip-address: x.x.x.x  bindtodevice=yes
 ip-address: x.x.x.x  setfib=<N>
 
-The bindtodevice option on Linux and the setfib ip-addess attribute on
+The bindtodevice attribute on Linux and the setfib ip-address attribute on
 FreeBSD can be used to skip the interface selection process in the kernel. This
 improves performance, and ensures responses written to the socket are pushed
 out the same interface the corresponding query came in on when multiple
@@ -758,10 +758,9 @@ interrupts are best handled by a core not designated to any NSD servers.
 		server-2-cpu-affinity: 1
 		server-3-cpu-affinity: 2
 		xfrd-cpu-affinity: 4
-		ip-address: 1.2.3.11  servers=1 setfib=1
-		ip-address: 1.2.3.12  servers=2 setfib=2
-		ip-address: 1.2.3.13  servers=3 setfib=3
-		bindtodevice: yes
+		ip-address: 1.2.3.11  servers=1 setfib=1 bindtodevice=yes
+		ip-address: 1.2.3.12  servers=2 setfib=2 bindtodevice=yes
+		ip-address: 1.2.3.13  servers=3 setfib=3 bindtodevice=yes
 
 The number of NSD servers to fork and which cores are best used depends
 entirely on the hardware. cpu-affinity options are supported on Linux and

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -48,12 +48,20 @@ server:
 	# ip-address: 1.2.3.4       servers="1-2 3"
 	# ip-address: 1.2.3.4@5678  servers="4-5 6"
 	#
-	# IP addresses take setfib on FreeBSD to ensure responses are pushed
-	# out the same interface the corresponding query came in on when there
-	# are multiple interfaces configured on the same subnet.
+	# When several interfaces are configured to listen on the same subnet,
+	# care must be taken to ensure responses go out the same interface the
+	# corresponding query came in on to avoid problems with load balancers
+	# and VLAN tagged interfaces. Linux offers the SO_BINDTODEVICE socket
+	# option to bind a socket to a specified device. For FreeBSD, to
+	# achieve the same result, specify the routing table to use after the
+	# IP address to use SO_SETFIB.
 	#
-	# ip-address: 1.2.3.4       setfib=0
-	# ip-address: 1.2.3.4@5678  setfib=1
+	# Complement with socket partitioning and CPU affinity for attack
+	# mitigation benefits. i.e. only a single core is maxed out if a
+	# specific IP address is under attack.
+	#
+	# ip-address: 1.2.3.4       setfib=0  bindtodevice=yes
+	# ip-address: 1.2.3.5@6789  setfib=1  bindtodevice=yes
 
 	# Allow binding to non local addresses. Default no.
 	# ip-transparent: no
@@ -63,9 +71,6 @@ server:
 
 	# Use SO_REUSEPORT socket option for performance. Default no.
 	# reuseport: no
-
-	# Use SO_BINDTODEVICE socket option for performance. Default no.
-	# bindtodevice: no
 
 	# override maximum socket send buffer size.  Default of 0 results in
 	# send buffer size being set to 1048576 (bytes).

--- a/nsd.h
+++ b/nsd.h
@@ -113,6 +113,7 @@ typedef	unsigned long stc_type;
 #endif /* USE_ZONE_STATS */
 
 #define NSD_SOCKET_IS_OPTIONAL (1<<0)
+#define NSD_BIND_DEVICE (1<<1)
 
 struct nsd_addrinfo
 {

--- a/options.c
+++ b/options.c
@@ -52,7 +52,6 @@ nsd_options_create(region_type* region)
 	opt->ip_addresses = NULL;
 	opt->ip_transparent = 0;
 	opt->ip_freebind = 0;
-	opt->bindtodevice = 0;
 	opt->send_buffer_size = 0;
 	opt->receive_buffer_size = 0;
 	opt->debug_mode = 0;

--- a/options.h
+++ b/options.h
@@ -65,7 +65,6 @@ struct nsd_options {
 
 	int ip_transparent;
 	int ip_freebind;
-	int bindtodevice;
 	int send_buffer_size;
 	int receive_buffer_size;
 	int debug_mode;
@@ -177,6 +176,7 @@ struct ip_address_option {
 	struct ip_address_option* next;
 	char* address;
 	struct range_option* servers;
+	int dev;
 	int fib;
 };
 

--- a/server.c
+++ b/server.c
@@ -1176,7 +1176,7 @@ open_udp_socket(struct nsd *nsd, struct nsd_socket *sock, int *reuseport_works)
 		(void)set_ip_freebind(sock);
 	if(nsd->options->ip_transparent)
 		(void)set_ip_transparent(sock);
-	if(nsd->options->bindtodevice && set_bindtodevice(sock) == -1)
+	if((sock->flags & NSD_BIND_DEVICE) && set_bindtodevice(sock) == -1)
 		return -1;
 	if(sock->fib != -1 && set_setfib(sock) == -1)
 		return -1;
@@ -1242,7 +1242,7 @@ open_tcp_socket(struct nsd *nsd, struct nsd_socket *sock, int *reuseport_works)
 		(void)set_ip_freebind(sock);
 	if(nsd->options->ip_transparent)
 		(void)set_ip_transparent(sock);
-	if(nsd->options->bindtodevice && set_bindtodevice(sock) == -1)
+	if((sock->flags & NSD_BIND_DEVICE) && set_bindtodevice(sock) == -1)
 		return -1;
 	if(sock->fib != -1 && set_setfib(sock) == -1)
 		return -1;


### PR DESCRIPTION
This PR turns the `bindtodevice` option into an ip-address attribute instead as it could cause issues when binding to wildcard interfaces and might have been set for sockets that didn't need it.