### PR TITLE
Add hardening to nsd suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
-sudo: false
 language: c
+
+git:
+  depth: 5
+
+addons:
+  apt:
+    update: true
+    packages: [ autoconf automake libtool bison flex libssl-dev libevent-dev clang gcc ]
+  homebrew:
+    update: true
+    packages: [ autoconf automake libtool bison flex openssl libevent ]
 
 linux_gcc: &linux_gcc
   os: linux
@@ -10,10 +20,10 @@ linux_gcc: &linux_gcc
       update: true
       sources:
         - sourceline: 'ppa:ubuntu-toolchain-r/test'
-      packages: [ autoconf bison flex libssl-dev libevent-dev clang gcc-9 ]
-  before_install:
-    - eval "export CC=gcc-9"
-    - eval "export COV_COMPTYPE=gcc COV_PLATFORM=linux64"
+      packages: [ autoconf automake libtool pkg-config bison flex libssl-dev libevent-dev clang gcc-9 ]
+    homebrew:
+      update: true
+      packages: [ autoconf automake libtool openssl libevent ]
 
 install_coverity: &install_coverity
   if [ "${COVERITY_SCAN}" = "true" ]; then
@@ -47,21 +57,150 @@ submit_to_coverity_scan: &submit_to_coverity_scan
 install:
   - *install_coverity
 
+before_script:
+  - |
+    if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+      glibtoolize -ci && autoreconf -fi
+    else
+      libtoolize -ci && autoreconf -fi
+    fi
+
 script:
-  - autoconf && autoheader
-  - ./configure --enable-checking --disable-flto
-  - ${SCAN_BUILD} make
-  - make cutest && ./cutest
-  - (cd tpkg; cd clang-analysis.tdir; bash clang-analysis.test)
+  - |
+    if [[ "${COVERITY_SCAN}" == true ]]; then
+      ./configure ${CONFIG_OPTS}
+      ${SCAN_BUILD} make -j 2
+    elif [[ "${TEST_UBSAN}" == true ]]; then
+      export CFLAGS="-DNDEBUG -g2 -O2 -fsanitize=undefined -fno-sanitize-recover"
+      ./configure ${CONFIG_OPTS}
+      make -j 2 && make cutest && ./cutest
+    elif [[ "${TEST_ASAN}" == true ]]; then
+      export CFLAGS="-DNDEBUG -g2 -O2 -fsanitize=address"
+      ./configure ${CONFIG_OPTS}
+      make -j 2 && make cutest && ./cutest
+    elif [[ "${TEST_CHECKSEC}" == true ]]; then
+      ./configure ${CONFIG_OPTS}
+      make -j 2 check
+    elif [[ "${TEST_ANALYZE}" == true ]]; then
+      ./configure ${CONFIG_OPTS}
+      make -j 2 && make cutest && ./cutest
+      (cd tpkg; cd clang-analysis.tdir; bash clang-analysis.test)
+    else
+      ./configure ${CONFIG_OPTS}
+      make -j 2 && make cutest && ./cutest
+    fi
 
 after_success:
-  - *submit_to_coverity_scan
+  - |
+    if [[ "${COVERITY_SCAN}" == true ]]; then
+      *submit_to_coverity_scan
+    fi
 
 jobs:
   include:
     - <<: *linux_gcc
-      env: [ COVERITY_SCAN=true ]
-      if: type = cron
+      name: Coverity, GCC-9, Linux, Amd64
+      env:
+        - COVERITY_SCAN=true
+        - CC=gcc-9
+        - COV_COMPTYPE=gcc
+        - COV_PLATFORM=linux64
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+      if: env(TRAVIS_EVENT_TYPE) = cron
     - <<: *linux_gcc
-      env: [ COVERITY_SCAN=false ]
-
+      name: No Coverity, GCC-9, Linux, Amd64
+      env:
+        - COVERITY_SCAN=false
+        - CC=gcc-9
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: GCC, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - CONFIG_OPTS=
+    - name: Clang, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: clang
+      env:
+        - CONFIG_OPTS=
+    - name: Clang, OS X, Amd64
+      os: osx
+      compiler: clang
+      env:
+        - CONFIG_OPTS="--with-ssl=/usr/local/opt/openssl --with-libevent=/usr/local/opt/libevent"
+    - name: Checksec, GCC, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - TEST_CHECKSEC=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: Checksec, Clang, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: clang
+      env:
+        - TEST_CHECKSEC=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: UBsan, GCC, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - TEST_UBSAN=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: UBsan, Clang, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: clang
+      env:
+        - TEST_UBSAN=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: UBsan, Clang, OS X, Amd64
+      os: osx
+      compiler: clang
+      env:
+        - TEST_UBSAN=true
+        - CONFIG_OPTS="--enable-checking --disable-flto --with-ssl=/usr/local/opt/openssl --with-libevent=/usr/local/opt/libevent"
+    - name: Asan, GCC, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - TEST_ASAN=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: Asan, Clang, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: clang
+      env:
+        - TEST_ASAN=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: Asan, Clang, OS X, Amd64
+      os: osx
+      compiler: clang
+      env:
+        - TEST_ASAN=true
+        - CONFIG_OPTS="--enable-checking --disable-flto --with-ssl=/usr/local/opt/openssl --with-libevent=/usr/local/opt/libevent"
+    - name: Anazlyze, GCC, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - TEST_ANALYZE=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: Anazlyze, Clang, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: clang
+      env:
+        - TEST_ANALYZE=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: Anazlyze, Clang, OS X, Amd64
+      os: osx
+      compiler: clang
+      env:
+        - TEST_ANALYZE=true
+        - CONFIG_OPTS="--enable-checking --disable-flto --with-ssl=/usr/local/opt/openssl --with-libevent=/usr/local/opt/libevent"

--- a/Makefile.in
+++ b/Makefile.in
@@ -36,7 +36,7 @@ DNSTAP_OBJ=@DNSTAP_OBJ@
 # K&R C compilers), but causes problems if $U is defined in the env).
 U=
 
-CC		= @CC@
+CC      	= @CC@
 CPPFLAGS	= @CPPFLAGS@
 CFLAGS		= @CFLAGS@
 LDFLAGS		= @LDFLAGS@
@@ -47,12 +47,20 @@ INSTALL		= $(srcdir)/install-sh -c
 INSTALL_PROGRAM	= $(INSTALL)
 INSTALL_DATA	= $(INSTALL) -m 644
 
+# hardening flags set in configure.ac
+NSD_CPPFLAGS	= @NSD_CPPFLAGS@
+NSD_CFLAGS		= @NSD_CFLAGS@
+NSD_ASFLAGS		= @NSD_ASFLAGS@
+NSD_LDFLAGS		= @NSD_LDFLAGS@
+BIN_CFLAGS		= @BIN_CFLAGS@
+BIN_LDFLAGS		= @BIN_LDFLAGS@
+
 YACC		= @YACC@
 LEX		= @LEX@
 PROTOC_C	= @PROTOC_C@
 
-COMPILE		= $(CC) $(CPPFLAGS) $(CFLAGS)
-LINK		= $(CC) $(CFLAGS) $(LDFLAGS)
+COMPILE		= $(CC) $(NSD_CPPFLAGS) $(CPPFLAGS) $(NSD_CFLAGS) $(BIN_CFLAGS) $(NSD_ASFLAGS) $(CFLAGS)
+LINK		= $(CC) $(NSD_ASFLAGS) $(BIN_CFLAGS) $(CFLAGS) $(BIN_LDFLAGS) $(NSD_LDFLAGS) $(LDFLAGS)
 EDIT		= sed \
 			-e 's,@prefix\@,$(prefix),g' \
 			-e 's,@exec_prefix\@,$(exec_prefix),g' \
@@ -91,7 +99,7 @@ $(ALL_OBJ):
 nsd-control-setup.sh:	$(srcdir)/nsd-control-setup.sh.in config.h
 	rm -f nsd-control-setup.sh
 	$(EDIT) $(srcdir)/nsd-control-setup.sh.in > nsd-control-setup.sh
-	chmod +x nsd-control-setup.sh
+	chmod a+x nsd-control-setup.sh
 
 nsd.conf.sample:	$(srcdir)/nsd.conf.sample.in config.h
 	rm -f nsd.conf.sample
@@ -175,6 +183,18 @@ xfr-inspect:	xfr-inspect.o $(COMMON_OBJ) $(LIBOBJS)
 
 popen3_echo: popen3.o popen3_echo.o
 	$(LINK) -o $@ popen3.o popen3_echo.o
+
+checksec: nsd
+	wget -q -O checksec https://raw.githubusercontent.com/slimm609/checksec.sh/master/checksec \
+	&& chmod a+x checksec
+
+test check: cutest checksec nsd nsd-checkconf nsd-checkzone nsd-control nsd-mem
+	./cutest
+	./checksec --file=nsd
+	./checksec --file=nsd-checkconf
+	./checksec --file=nsd-checkzone
+	./checksec --file=nsd-control
+	./checksec --file=nsd-mem
 
 clean:
 	rm -f *.o $(TARGETS) $(MANUALS) cutest popen3_echo udb-inspect xfr-inspect nsd-mem

--- a/configure.ac
+++ b/configure.ac
@@ -2,14 +2,16 @@ dnl
 dnl Some global settings
 dnl
 
-sinclude(acx_nlnetlabs.m4)
-sinclude(dnstap/dnstap.m4)
-
 AC_INIT(NSD,4.3.1,nsd-bugs@nlnetlabs.nl)
 AC_CONFIG_HEADER([config.h])
 
-CFLAGS="$CFLAGS"
 AC_AIX
+AC_LANG([C])
+
+sinclude(acx_nlnetlabs.m4)
+sinclude(dnstap/dnstap.m4)
+
+CFLAGS="$CFLAGS"
 if test "$ac_cv_header_minix_config_h" = "yes"; then
 	AC_DEFINE(_NETBSD_SOURCE,1, [Enable for compile on Minix])
 fi
@@ -112,21 +114,21 @@ AC_DEFINE_UNQUOTED(ZONESDIR, ["`eval echo $zonesdir`"], [NSD default location fo
 
 # default xfrd file location.
 xfrdfile=${dbdir}/xfrd.state
-AC_ARG_WITH([xfrdfile], AC_HELP_STRING([--with-xfrdfile=path], 
+AC_ARG_WITH([xfrdfile], AC_HELP_STRING([--with-xfrdfile=path],
 	[Pathname to the NSD xfrd zone timer state file]), [xfrdfile=$withval])
 AC_DEFINE_UNQUOTED(XFRDFILE, ["`eval echo $xfrdfile`"], [Pathname to the NSD xfrd zone timer state file.])
 AC_SUBST(xfrdfile)
 
 # default zonelist file location.
 zonelistfile=${dbdir}/zone.list
-AC_ARG_WITH([zonelistfile], AC_HELP_STRING([--with-zonelistfile=path], 
+AC_ARG_WITH([zonelistfile], AC_HELP_STRING([--with-zonelistfile=path],
 	[Pathname to the NSD zone list file]), [zonelistfile=$withval])
 AC_DEFINE_UNQUOTED(ZONELISTFILE, ["`eval echo $zonelistfile`"], [Pathname to the NSD zone list file.])
 AC_SUBST(zonelistfile)
 
 # default xfr dir location.
 xfrdir="/tmp"
-AC_ARG_WITH([xfrdir], AC_HELP_STRING([--with-xfrdir=path], 
+AC_ARG_WITH([xfrdir], AC_HELP_STRING([--with-xfrdir=path],
 	[Pathname to where the NSD transfer dir is created]), [xfrdir=$withval])
 AC_DEFINE_UNQUOTED(XFRDIR, ["`eval echo $xfrdir`"], [Pathname to where the NSD transfer dir is created.])
 AC_SUBST(xfrdir)
@@ -163,7 +165,269 @@ AC_ARG_WITH([user],
 AC_SUBST(user)
 AC_DEFINE_UNQUOTED(USER, ["$user"], [the user name to drop privileges to])
 
+#
+# Determine if hardening should be applied
+# Hardening is applied by default. Also see https://wiki.debian.org/Hardening and
+# https://developers.redhat.com/blog/2018/03/21/compiler-and-linker-flags-gcc/
+# The tests also strip unneeded functions so bad guys cannot use them in
+# ROP gadgets in pre-CET environments.
+#
+AC_ARG_ENABLE([hardening],
+    AS_HELP_STRING([--disable-hardening], [Disable server hardening]))
+
+AS_IF([test "x$enable_hardening" != "xno"], [
+  BAKCPPFLAGS="$CPPFLAGS"
+  BAKCFLAGS="$CFLAGS"
+  BAKASFLAGS="$ASFLAGS"
+  BAKLDFLAGS="$LDFLAGS"
+
+  # Some tests below should fail if not on Darwin. Unfortunately,
+  # Autotools drops the ball and does not detect the error.
+  is_darwin=`uname -s 2>/dev/null | grep -i -c darwin`
+  has_readelf=`command -v readelf 2>/dev/null | grep -i -c readelf`
+
+  if test "$has_readelf" -ne 0;
+  then
+    # This test is tuned for Linux and readelf. The test is a hack because
+    # I don't know how to run objdump or readelf in an AC_LINK_IFELSE test.
+    AC_MSG_CHECKING([for -D_FORTIFY_SOURCE=2])
+    echo '#include <string.h>
+      int main(int argc, char** argv)
+      {
+        [char msg[16];]
+        [strcpy(msg, argv[0]);]
+        [return 0;]
+      }' > fortify_test.c
+
+    if $CC -D_FORTIFY_SOURCE=2 $CPPFLAGS -O2 $CFLAGS fortify_test.c -o fortify_test.exe;
+    then
+      count=`readelf --relocs fortify_test.exe | grep -i -c '_chk'`
+      if test "$count" -ne 0; then
+        AC_MSG_RESULT([yes]); NSD_CPPFLAGS="$NSD_CPPFLAGS -D_FORTIFY_SOURCE=2"
+      else
+        AC_MSG_RESULT([no])
+      fi
+    fi
+
+    rm -rf fortify_test.c fortify_test.exe 2>/dev/null
+  fi
+
+  CPPFLAGS="$BAKCPPFLAGS"; CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -fasynchronous-unwind-tables";
+  AC_MSG_CHECKING([for -fasynchronous-unwind-tables])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); NSD_CFLAGS="$NSD_CFLAGS -fasynchronous-unwind-tables"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -fexceptions";
+  AC_MSG_CHECKING([for -fexceptions])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]);  NSD_CFLAGS="$NSD_CFLAGS -fexceptions"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -fplugin=annobin";
+  AC_MSG_CHECKING([for -fplugin=annobin])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); NSD_CFLAGS="$NSD_CFLAGS -fplugin=annobin"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -fstack-clash-protection";
+  AC_MSG_CHECKING([for -fstack-clash-protection])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); NSD_CFLAGS="$NSD_CFLAGS -fstack-clash-protection"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -fstack-protector-strong";
+  AC_MSG_CHECKING([for -fstack-protector-strong])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); NSD_CFLAGS="$NSD_CFLAGS -fstack-protector-strong"],
+    [AC_MSG_RESULT([no]);  need_stack_protector=yes]
+  )
+
+  # Last try...
+  if test "x$need_stack_protector" = "xyes";
+  then
+    CFLAGS="$BAKCFLAGS";
+    CFLAGS="$CFLAGS -fstack-protector";
+    AC_MSG_CHECKING([for -fstack-protector])
+    AC_LINK_IFELSE(
+      [AC_LANG_SOURCE([int main(void) {return 0;}])],
+      [AC_MSG_RESULT([yes]); NSD_CFLAGS="$NSD_CFLAGS -fstack-protector"],
+      [AC_MSG_RESULT([no])]
+	)
+  fi
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -grecord-gcc-switches";
+  AC_MSG_CHECKING([for -grecord-gcc-switches])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); NSD_CFLAGS="$NSD_CFLAGS -grecord-gcc-switches"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -mcet -fcf-protection";
+  AC_MSG_CHECKING([for -mcet -fcf-protection])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); NSD_CFLAGS="$NSD_CFLAGS -mcet -fcf-protection"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -Werror=format-security";
+  AC_MSG_CHECKING([for -Werror=format-security])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); NSD_CFLAGS="$NSD_CFLAGS -Werror=format-security"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -Werror=implicit-function-declaration";
+  AC_MSG_CHECKING([for -Werror=implicit-function-declaration])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); NSD_CFLAGS="$NSD_CFLAGS -Werror=implicit-function-declaration"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -fdata-sections";
+  AC_MSG_CHECKING([for -fdata-sections])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); NSD_CFLAGS="$NSD_CFLAGS -fdata-sections"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -ffunction-sections";
+  AC_MSG_CHECKING([for -ffunction-sections])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); NSD_CFLAGS="$NSD_CFLAGS -ffunction-sections"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  # -fPIC or -fPIE and -shared or -pie are matched sets
+  # -fPIC can be used in place of -fPIE, but not vice-versa.
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -fPIC";
+  AC_MSG_CHECKING([for -fPIC])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); NSD_CFLAGS="$NSD_CFLAGS -fPIC"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -pie";
+  AC_MSG_CHECKING([for -pie])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); BIN_LDFLAGS="$BIN_LDFLAGS -pie"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  # ASFLAGS passed through compiler
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -Wa,--noexecstack";
+  AC_MSG_CHECKING([for -Wa,--noexecstack])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); NSD_ASFLAGS="$NSD_ASFLAGS -Wa,--noexecstack"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  # LDFLAGS passed through compiler
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -Wl,--gc-sections";
+  AC_MSG_CHECKING([for -Wl,--gc-sections])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); NSD_LDFLAGS="$NSD_LDFLAGS -Wl,--gc-sections"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  if test "$is_darwin" -ne 0; then
+    CFLAGS="$BAKCFLAGS";
+    CFLAGS="$CFLAGS -Wl,-dead_strip";
+    AC_MSG_CHECKING([for -Wl,-dead_strip])
+    AC_LINK_IFELSE(
+      [AC_LANG_SOURCE([int main(void) {return 0;}])],
+      [AC_MSG_RESULT([yes]); NSD_LDFLAGS="$NSD_LDFLAGS -Wl,-dead_strip"],
+      [AC_MSG_RESULT([no])]
+    )
+  fi
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -Wl,--exclude-libs,ALL";
+  AC_MSG_CHECKING([for -Wl,--exclude-libs,ALL])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); NSD_LDFLAGS="$NSD_LDFLAGS -Wl,--exclude-libs,ALL"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -Wl,--as-needed";
+  AC_MSG_CHECKING([for -Wl,--as-needed])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); NSD_LDFLAGS="$NSD_LDFLAGS -Wl,--as-needed"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -Wl,-z,defs";
+  AC_MSG_CHECKING([for -Wl,-z,defs])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); BIN_LDFLAGS="$BIN_LDFLAGS -Wl,-z,defs"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -Wl,-z,relro";
+  AC_MSG_CHECKING([for -Wl,-z,relro])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); BIN_LDFLAGS="$BIN_LDFLAGS -Wl,-z,relro"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  CFLAGS="$BAKCFLAGS";
+  CFLAGS="$CFLAGS -Wl,-z,now";
+  AC_MSG_CHECKING([for -Wl,-z,now])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([int main(void) {return 0;}])],
+    [AC_MSG_RESULT([yes]); BIN_LDFLAGS="$BIN_LDFLAGS -Wl,-z,now"],
+    [AC_MSG_RESULT([no])]
+  )
+
+  CPPFLAGS="$BAKCPPFLAGS"
+  CFLAGS="$BAKCFLAGS"
+  LDFLAGS="$BAKLDFLAGS"
+])
+
+#
 # Checks for programs.
+#
 AC_PROG_AWK
 AC_PROG_CC
 AC_PROG_LN_S
@@ -350,12 +614,12 @@ AC_DEFUN([CHECK_SSL], [
                 fi
                 break;
             fi
-        done 
+        done
         if test x_$found_ssl != x_yes; then
             AC_MSG_ERROR(Cannot find the SSL libraries in $withval)
         else
             AC_MSG_RESULT(found in $ssldir)
-            HAVE_SSL=yes 
+            HAVE_SSL=yes
             if test x_$ssldir != x_/usr; then
                 LDFLAGS="$LDFLAGS -L$ssldir/lib";
             fi
@@ -390,14 +654,14 @@ if test x_$withval = x_yes -o x_$withval != x_no; then
         if test x_$found_libevent != x_yes; then
 		if test -f "$dir/event.h" -a \( -f "$dir/libevent.la" -o -f "$dir/libev.la" \) ; then
 			# libevent source directory
-            		AC_MSG_RESULT(found in $thedir)
-                	CPPFLAGS="$CPPFLAGS -I$thedir -I$thedir/include"
+			AC_MSG_RESULT(found in $thedir)
+			CPPFLAGS="$CPPFLAGS -I$thedir -I$thedir/include"
 			# remove evdns from linking
 			ev_files_o=`ls $thedir/*.o | grep -v evdns\.o | grep -v bufferevent_openssl\.o`
 			cp $ev_files_o .
 			LDFLAGS="$ev_files_o $LDFLAGS -lm"
 		else
-            		AC_MSG_ERROR([Cannot find the libevent library.
+			AC_MSG_ERROR([Cannot find the libevent library.
 You can restart ./configure --with-libevent=no to use a builtin alternative.])
 		fi
         else
@@ -505,7 +769,7 @@ if test c${cross_compiling} = cno; then
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #define _XOPEN_SOURCE 600
 #include <time.h>
-int main(void) { struct tm tm; char *res; 
+int main(void) { struct tm tm; char *res;
 res = strptime("20070207111842", "%Y%m%d%H%M%S", &tm);
 if (!res) return 1; return 0; }
 ]])] , [eval "ac_cv_c_strptime_works=yes"], [eval "ac_cv_c_strptime_works=no"])
@@ -588,7 +852,7 @@ if test $ac_cv_type_$1 = no; then
 fi
 ])
 
-AC_LIBGTOP_CHECK_TYPE(int8_t, char) 
+AC_LIBGTOP_CHECK_TYPE(int8_t, char)
 AC_LIBGTOP_CHECK_TYPE(int16_t, short)
 AC_LIBGTOP_CHECK_TYPE(int32_t, int)
 AC_LIBGTOP_CHECK_TYPE(int64_t, long long)
@@ -643,7 +907,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <sys/socket.h>
 #include <errno.h>
 int main(void)
-{ 
+{
 	int s = socket(AF_INET, SOCK_DGRAM, 0);
 	int r = recvmmsg(s, 0, 0, 0, 0) == -1 && errno == ENOSYS;
 	close(s);
@@ -659,7 +923,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <sys/socket.h>
 #include <errno.h>
 int main(void)
-{ 
+{
 	int s = socket(AF_INET, SOCK_DGRAM, 0);
 	int r = sendmmsg(s, 0, 0, 0) == -1 && errno == ENOSYS;
 	close(s);
@@ -741,11 +1005,11 @@ int main(void) {
 ])
 
 AC_MSG_CHECKING(for pselect prototype in sys/select.h)
-AC_EGREP_HEADER([[^a-zA-Z_]*pselect[^a-zA-Z_]], sys/select.h, AC_DEFINE(HAVE_PSELECT_PROTO, 1, 
+AC_EGREP_HEADER([[^a-zA-Z_]*pselect[^a-zA-Z_]], sys/select.h, AC_DEFINE(HAVE_PSELECT_PROTO, 1,
 	[if sys/select.h provides pselect prototype]) AC_MSG_RESULT(yes), AC_MSG_RESULT(no))
 
 AC_MSG_CHECKING(for ctime_r prototype in time.h)
-AC_EGREP_HEADER([[^a-zA-Z_]*ctime_r[^a-zA-Z_]], time.h, AC_DEFINE(HAVE_CTIME_R_PROTO, 1, 
+AC_EGREP_HEADER([[^a-zA-Z_]*ctime_r[^a-zA-Z_]], time.h, AC_DEFINE(HAVE_CTIME_R_PROTO, 1,
 	[if time.h provides ctime_r prototype]) AC_MSG_RESULT(yes), AC_MSG_RESULT(no))
 
 AC_CHECK_TYPE([struct timespec], AC_DEFINE(HAVE_STRUCT_TIMESPEC, 1, [If time.h has a struct timespec (for pselect).]), [], [
@@ -901,7 +1165,7 @@ if test x$HAVE_SSL = x"yes"; then
 	])
 	LIBS="$BAKLIBS"
 
-	if test -n "$ssldir"; then 
+	if test -n "$ssldir"; then
             AC_CHECK_LIB(crypto, HMAC_Update,, [
                     AC_MSG_ERROR([OpenSSL found in $ssldir, but version 0.9.7 or higher is required])
                 ])
@@ -1056,7 +1320,7 @@ AH_BOTTOM([
 #  endif
 #  ifndef __EXTENSIONS__
 #    define __EXTENSIONS__ 1
-#  endif 
+#  endif
 #  ifndef _STDC_C99
 #    define _STDC_C99 1
 #  endif
@@ -1190,11 +1454,11 @@ void* reallocarray(void *ptr, size_t nmemb, size_t size);
 #endif
 #ifndef HAVE_STRPTIME
 #define HAVE_STRPTIME 1
-char *strptime(const char *s, const char *format, struct tm *tm); 
+char *strptime(const char *s, const char *format, struct tm *tm);
 #endif
 #ifndef STRPTIME_WORKS
 #define STRPTIME_WORKS 1
-char *nsd_strptime(const char *s, const char *format, struct tm *tm); 
+char *nsd_strptime(const char *s, const char *format, struct tm *tm);
 #define strptime(a,b,c) nsd_strptime((a),(b),(c))
 #endif
 #if (HAVE_CPU_SET_T || HAVE_CPUSET_T)
@@ -1246,6 +1510,14 @@ if test "$enable_checking" = "yes"; then
         echo "*                                              *"
         echo "************************************************"
 fi
+
+# set the hardening flags we set
+AC_SUBST([NSD_CPPFLAGS])
+AC_SUBST([NSD_CFLAGS])
+AC_SUBST([NSD_ASFLAGS])
+AC_SUBST([NSD_LDFLAGS])
+AC_SUBST([BIN_CFLAGS])
+AC_SUBST([BIN_LDFLAGS])
 
 AC_CONFIG_FILES([Makefile $dnstap_config])
 AC_OUTPUT


### PR DESCRIPTION
This PR increases Travis coverage and adds hardening to the nsd suite.

Hardening is needed for forward facing servers that open sockets and consume attacker data. It is just a way of life nowadays. Most (all?) modern distros apply the full specturm of hardening without user intervention. Also see https://wiki.debian.org/Hardening and https://developers.redhat.com/blog/2018/03/21/compiler-and-linker-flags-gcc/.

There are several corner cases where it is needed. The first is older platforms, and the second is new compilers on older platforms. For example, up until several years ago, executable stacks were the norm. The third is the Linux from Scratch group who may not be as security savvy as Debian or Red Hat.

The changes also applies several options that distros don't use. They include dead code stripping. Stripping dead code reduces attack surface for ROP chains. An attacker cannot build a ROP gadget with code that is not present.

The hardening changes include:

* `--disable-hardening` option. Hardening is on by default. A user must intentionally turn it off. The platform may still apply some of the options. (The user must work hard to get into an insecure state).
* `_FORTIFY_SOURCE=2`
* `-fasynchronous-unwind-tables`
* `-fexceptions`
* `-fplugin=annobin` plugin. Upcoming option. See the Watermark specification..
* `-fstack-clash-protection`
* `-fstack-protector-strong` or `-fstack-protector`
* `-grecord-gcc-switches`
* `-mcet -fcf-protection` option. Control Flow Technology (shadow stacks)
* `-Werror=format-security`
* `-Werror=implicit-function-declaration`
* `-fdata-sections` and `-ffunction-sections` options for dead code stripping
* `-fPIC` and `-pie` for ASLR
* `-Wa,--noexecstack` option. For the longest time executable stacks were the norm with Linux. We could not convince maintainers otherwise. It took years for them to adopt nx stacks.
* `-Wl,--gc-sections` and `-Wl,-dead_strip` linker options for dead code stripping
* `-Wl,--exclude-libs,ALL` option. Don't re-export anything. It keeps the ELF executable smaller.
* `-Wl,--as-needed` option. Remove unneeded libraries. It removes unneeded code and keeps the ELF executable smaller.
* `-Wl,-z,relro` and `-Wl,-z,now` options. Early bind the PLT, and make the PLT and GOT read-only.
* `-Wl,-z,defs` option. Detect missing symbols at link time.

The Travis changes are the usual suspects. They include GCC and Clang testing on Linux, and Clang testing on OS X. I don't think there's a need for Android or iOS because these are server components. [Corrections, please.]

The first two bullets below covering GCC-9 and Coverity were existing. The tests were retained.

* Retain Coverity GCC-9 test. According to the [Travis folks](https://travis-ci.community/t/run-extended-test-job-if-build-started-from-cron/7625), the CRON condition is `if: env(TRAVIS_EVENT_TYPE) = cron`.
* Retain non-Coverity GCC-9 test.
* Add GCC/Linux, Clang/Linux and Clang OSX tests with no options. Most users will configure like this.
* Add GCC/Linux, Clang/Linux testing using an updated version of Tobias Klien's [Checksec script](https://github.com/slimm609/checksec.sh). It verifies hardening has been applied to an executable.
* Add GCC/Linux, Clang/Linux and Clang OSX UBSan tests.
* Add GCC/Linux, Clang/Linux and Clang OSX ASan tests.
* Add GCC/Linux, Clang/Linux and Clang OSX Analyze tests.

The builds [test OK on Travis](https://travis-ci.com/github/noloader/nsd/builds/153861135).

-----

The new feature test blocks looks like the following.

```
checking for -D_FORTIFY_SOURCE=2... yes
checking for -fasynchronous-unwind-tables... yes
checking for -fexceptions... yes
checking for -fplugin=annobin... no
checking for -fstack-clash-protection... no
checking for -fstack-protector-strong... yes
checking for -grecord-gcc-switches... yes
checking for -mcet -fcf-protection... no
checking for -Werror=format-security... yes
checking for -Werror=implicit-function-declaration... yes
checking for -fdata-sections... yes
checking for -ffunction-sections... yes
checking for -fPIC... yes
checking for -pie... yes
checking for -Wa,--noexecstack... yes
checking for -Wl,--gc-sections... yes
checking for -Wl,--exclude-libs,ALL... yes
checking for -Wl,--as-needed... yes
checking for -Wl,-z,defs... yes
checking for -Wl,-z,relro... yes
checking for -Wl,-z,now... yes
```

Checksec audits look like the following. We can't fortify all functions, and that is normal. I think some of them are coming from glibc, but I have not researched it in a long time. Others are coming from nsd. The nsd ones are because the compiler cannot deduce the size of a destination buffer. In this case, the code should be changed to play well with GCC's or Clang's object size checker.

```
./checksec --file=nsd
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH	Symbols		FORTIFY	Fortified	Fortifiable  FILE
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   1343 Symbols     Yes	9		20	nsd
./checksec --file=nsd-checkconf
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH	Symbols		FORTIFY	Fortified	Fortifiable  FILE
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   318 Symbols     Yes	6		10	nsd-checkconf
./checksec --file=nsd-checkzone
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH	Symbols		FORTIFY	Fortified	Fortifiable  FILE
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   562 Symbols     Yes	6		12	nsd-checkzone
./checksec --file=nsd-control
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH	Symbols		FORTIFY	Fortified	Fortifiable  FILE
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   344 Symbols     Yes	6		12	nsd-control
./checksec --file=nsd-mem
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH	Symbols		FORTIFY	Fortified	Fortifiable  FILE
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   727 Symbols     Yes	7		14	nsd-mem
```