### PR TITLE
Increase Travis testing coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
-sudo: false
 language: c
+
+git:
+  depth: 5
+
+addons:
+  apt:
+    update: true
+    packages: [ autoconf automake libtool bison flex libssl-dev libevent-dev clang gcc ]
+  homebrew:
+    update: true
+    packages: [ autoconf automake libtool bison flex openssl libevent ]
 
 linux_gcc: &linux_gcc
   os: linux
@@ -10,10 +20,10 @@ linux_gcc: &linux_gcc
       update: true
       sources:
         - sourceline: 'ppa:ubuntu-toolchain-r/test'
-      packages: [ autoconf bison flex libssl-dev libevent-dev clang gcc-9 ]
-  before_install:
-    - eval "export CC=gcc-9"
-    - eval "export COV_COMPTYPE=gcc COV_PLATFORM=linux64"
+      packages: [ autoconf automake libtool pkg-config bison flex libssl-dev libevent-dev clang gcc-9 ]
+    homebrew:
+      update: true
+      packages: [ autoconf automake libtool openssl libevent ]
 
 install_coverity: &install_coverity
   if [ "${COVERITY_SCAN}" = "true" ]; then
@@ -47,21 +57,150 @@ submit_to_coverity_scan: &submit_to_coverity_scan
 install:
   - *install_coverity
 
+before_script:
+  - |
+    if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+      autoreconf
+    else
+      autoreconf
+    fi
+
 script:
-  - autoconf && autoheader
-  - ./configure --enable-checking --disable-flto
-  - ${SCAN_BUILD} make
-  - make cutest && ./cutest
-  - (cd tpkg; cd clang-analysis.tdir; bash clang-analysis.test)
+  - |
+    if [[ "${COVERITY_SCAN}" == true ]]; then
+      ./configure ${CONFIG_OPTS}
+      ${SCAN_BUILD} make -j 2
+    elif [[ "${TEST_UBSAN}" == true ]]; then
+      export CFLAGS="-DNDEBUG -g2 -O2 -fsanitize=undefined -fno-sanitize-recover"
+      ./configure ${CONFIG_OPTS}
+      make -j 2 && make cutest && ./cutest
+    elif [[ "${TEST_ASAN}" == true ]]; then
+      export CFLAGS="-DNDEBUG -g2 -O2 -fsanitize=address"
+      ./configure ${CONFIG_OPTS}
+      make -j 2 && make cutest && ./cutest
+    elif [[ "${TEST_CHECKSEC}" == true ]]; then
+      ./configure ${CONFIG_OPTS}
+      make -j 2 audit
+    elif [[ "${TEST_ANALYZE}" == true ]]; then
+      ./configure ${CONFIG_OPTS}
+      make -j 2 && make cutest && ./cutest
+      (cd tpkg; cd clang-analysis.tdir; bash clang-analysis.test)
+    else
+      ./configure ${CONFIG_OPTS}
+      make -j 2 && make cutest && ./cutest
+    fi
 
 after_success:
-  - *submit_to_coverity_scan
+  - |
+    if [[ "${COVERITY_SCAN}" == true ]]; then
+      *submit_to_coverity_scan
+    fi
 
 jobs:
   include:
     - <<: *linux_gcc
-      env: [ COVERITY_SCAN=true ]
-      if: type = cron
+      name: Coverity, GCC-9, Linux, Amd64
+      env:
+        - COVERITY_SCAN=true
+        - CC=gcc-9
+        - COV_COMPTYPE=gcc
+        - COV_PLATFORM=linux64
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+      if: env(TRAVIS_EVENT_TYPE) = cron
     - <<: *linux_gcc
-      env: [ COVERITY_SCAN=false ]
-
+      name: No Coverity, GCC-9, Linux, Amd64
+      env:
+        - COVERITY_SCAN=false
+        - CC=gcc-9
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: GCC, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - CONFIG_OPTS=
+    - name: Clang, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: clang
+      env:
+        - CONFIG_OPTS=
+    - name: Clang, OS X, Amd64
+      os: osx
+      compiler: clang
+      env:
+        - CONFIG_OPTS="--with-ssl=/usr/local/opt/openssl --with-libevent=/usr/local/opt/libevent"
+    - name: Checksec, GCC, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - TEST_CHECKSEC=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: Checksec, Clang, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: clang
+      env:
+        - TEST_CHECKSEC=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: UBsan, GCC, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - TEST_UBSAN=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: UBsan, Clang, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: clang
+      env:
+        - TEST_UBSAN=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: UBsan, Clang, OS X, Amd64
+      os: osx
+      compiler: clang
+      env:
+        - TEST_UBSAN=true
+        - CONFIG_OPTS="--enable-checking --disable-flto --with-ssl=/usr/local/opt/openssl --with-libevent=/usr/local/opt/libevent"
+    - name: Asan, GCC, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - TEST_ASAN=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: Asan, Clang, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: clang
+      env:
+        - TEST_ASAN=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: Asan, Clang, OS X, Amd64
+      os: osx
+      compiler: clang
+      env:
+        - TEST_ASAN=true
+        - CONFIG_OPTS="--enable-checking --disable-flto --with-ssl=/usr/local/opt/openssl --with-libevent=/usr/local/opt/libevent"
+    - name: Anazlyze, GCC, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - TEST_ANALYZE=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: Anazlyze, Clang, Linux, Amd64
+      os: linux
+      dist: bionic
+      compiler: clang
+      env:
+        - TEST_ANALYZE=true
+        - CONFIG_OPTS="--enable-checking --disable-flto"
+    - name: Anazlyze, Clang, OS X, Amd64
+      os: osx
+      compiler: clang
+      env:
+        - TEST_ANALYZE=true
+        - CONFIG_OPTS="--enable-checking --disable-flto --with-ssl=/usr/local/opt/openssl --with-libevent=/usr/local/opt/libevent"

--- a/Makefile.in
+++ b/Makefile.in
@@ -176,6 +176,20 @@ xfr-inspect:	xfr-inspect.o $(COMMON_OBJ) $(LIBOBJS)
 popen3_echo: popen3.o popen3_echo.o
 	$(LINK) -o $@ popen3.o popen3_echo.o
 
+checksec:
+	wget -q -O checksec https://raw.githubusercontent.com/slimm609/checksec.sh/master/checksec
+	-chmod a+x checksec && xattr -d com.apple.quarantine checksec 2>/dev/null
+
+audit: nsd nsd-checkconf nsd-checkzone nsd-control nsd-mem checksec
+	./checksec --file=nsd
+	./checksec --file=nsd-checkconf
+	./checksec --file=nsd-checkzone
+	./checksec --file=nsd-control
+	./checksec --file=nsd-mem
+
+test check: cutest
+	./cutest
+
 clean:
 	rm -f *.o $(TARGETS) $(MANUALS) cutest popen3_echo udb-inspect xfr-inspect nsd-mem
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,5 +1,6 @@
 23 March 2020: Wouter
 	- Fix unterminated ifdef in nsd.h.
+	- Fix unknown u_long in util.c for Issue #80 .
 
 20 March 2020: Wouter
 	- Merge PR #83 from noloader: Fix GNU HURD sched_setaffinity compile.

--- a/doc/RELNOTES
+++ b/doc/RELNOTES
@@ -16,6 +16,7 @@ BUG FIXES:
 	- Fix #78: Fix SO_SETFIB error on FreeBSD.
 	- Merge PR #83 from noloader: Fix GNU HURD sched_setaffinity compile.
 	- Fix #80: NetBSD and implicit declaration of reallocarray.
+	- Fix unknown u_long in util.c for Issue #80 .
 
 
 4.3.0

--- a/util.c
+++ b/util.c
@@ -840,7 +840,7 @@ mktime_from_utc(const struct tm *tm)
    http://www.tsfr.org/~orc/Code/bsd/bsd-current/cksum/crc.c.
    or http://gobsd.com/code/freebsd/usr.bin/cksum/crc.c
    The polynomial is 0x04c11db7L. */
-static u_long crctab[] = {
+static uint32_t crctab[] = {
 	0x0,
 	0x04c11db7, 0x09823b6e, 0x0d4326d9, 0x130476dc, 0x17c56b6b,
 	0x1a864db2, 0x1e475005, 0x2608edb8, 0x22c9f00f, 0x2f8ad6d6,


### PR DESCRIPTION
This PR increases Travis testing coverage.

The Travis changes are the usual suspects. They include GCC and Clang testing on Linux, and Clang testing on OS X. I don't think there's a need for Android or iOS because these are server components. [Corrections, please.]

The first two bullets below covering GCC-9 and Coverity were existing. The tests were retained.

* Retain Coverity GCC-9 test. According to the [Travis folks](https://travis-ci.community/t/run-extended-test-job-if-build-started-from-cron/7625), the CRON condition is `if: env(TRAVIS_EVENT_TYPE) = cron`.
* Retain non-Coverity GCC-9 test.
* Add GCC/Linux, Clang/Linux and Clang OSX tests with no options. Most users will configure like this.
* Add GCC/Linux, Clang/Linux testing using an updated version of Tobias Klien's [Checksec script](https://github.com/slimm609/checksec.sh). It verifies hardening has been applied to an executable.
* Add GCC/Linux, Clang/Linux and Clang OSX UBSan tests.
* Add GCC/Linux, Clang/Linux and Clang OSX ASan tests.
* Add GCC/Linux, Clang/Linux and Clang OSX Analyze tests.
* Add Makefile recipe for `make test`. The recipe also downloads `checksec` and audits the final binaries.

According to the Travis build logs, the current Coverity syntax is deprecated. I think folks are expected to move to the newer style for Coverity. I don't have experience setting up Coverity from Travis so I did not want to change anything.

The builds [test OK on Travis](https://travis-ci.com/github/noloader/nsd/builds/153914506).