### PR TITLE
Use reallocarr on NetBSD (GH #80)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -790,6 +790,25 @@ AC_REPLACE_FUNCS(b64_ntop)
 AC_REPLACE_FUNCS(pselect)
 AC_REPLACE_FUNCS(memmove)
 AC_REPLACE_FUNCS(setproctitle)
+
+AC_MSG_CHECKING([for reallocarr])
+AC_LINK_IFELSE([AC_LANG_SOURCE(AC_INCLUDES_DEFAULT
+[[
+#include <stdlib.h>
+int main(void) {
+	void* p = NULL;
+	int rc;
+	rc = reallocarr(&p, 10, 100);
+	if (p)
+		free(p);
+	return rc;
+}
+]])], [AC_MSG_RESULT(yes)
+	AC_DEFINE(HAVE_REALLOCARR, 1, [If we have reallocarr(3)])
+], [
+	AC_MSG_RESULT(no)
+])
+
 AC_MSG_CHECKING([for reallocarray])
 AC_LINK_IFELSE([AC_LANG_SOURCE(
 [[

--- a/util.c
+++ b/util.c
@@ -270,7 +270,19 @@ xalloc(size_t size)
 void *
 xmallocarray(size_t num, size_t size)
 {
+#if defined(HAVE_REALLOCARR)
+        void *result = NULL;
+        int rc = 0;
+        rc = reallocarr(&result, num, size);
+
+        if (rc) {
+            if (result)
+                free(result);
+            result = NULL;
+        }
+#else
         void *result = reallocarray(NULL, num, size);
+#endif
 
         if (!result) {
                 log_msg(LOG_ERR, "reallocarray failed: %s", strerror(errno));


### PR DESCRIPTION
This PR uses `reallocarr` in `xmallocarray` on NetBSD.

NetBSD 8.1 is not finding the declaration of `reallocarray` even with `_OPENBSD_SOURCE` defined. It is causing a noisy compile. Stepping back a bit, the NetBSD [`reallocarray(3)` man page](https://netbsd.gw.com/cgi-bin/man-cgi?reallocarray+3+NetBSD-current) say to use `reallocarr`. This PR follows the NetBSD advice.

According to NetBSD's man page,  `reallocarr` handles overflow properly. There is no need for the `reallocarray` wrapper:

     The reallocarray() function will return NULL if there was overflow or if
     realloc(3) failed setting errno to EOVERFLOW or preserving the value from
     realloc(3).

Also see Issue 80, [util.c:267:24: warning: implicit declaration of function 'reallocarray'](https://github.com/NLnetLabs/nsd/issues/80).