### PR TITLE
Add Cirrus FreeBSD testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,65 @@
+# https://cirrus-ci.org/examples/
+# https://github.com/curl/curl/blob/master/.cirrus.yml
+# https://github.com/weidai11/cryptopp/blob/master/.cirrus.yml
+
+env:
+  CIRRUS_CLONE_DEPTH: 5
+
+task:
+  matrix:
+    - name: Standard build, FreeBSD 12.1
+      freebsd_instance:
+        image_family: freebsd-12-1
+      pkginstall_script:
+        - pkg update -f
+        - pkg install -y gmake autoconf automake libevent
+      configure_script:
+        - autoconf && autoheader
+        - ./configure --enable-checking
+      compile_script:
+        - make -j 3
+        - make cutest
+      test_script:
+        - ./cutest
+    - name: Standard build, No LTO, FreeBSD 12.1
+      freebsd_instance:
+        image_family: freebsd-12-1
+      pkginstall_script:
+        - pkg update -f
+        - pkg install -y gmake autoconf automake libevent
+      configure_script:
+        - autoconf && autoheader
+        - ./configure --enable-checking --disable-flto
+      compile_script:
+        - make -j 3
+        - make cutest
+      test_script:
+        - ./cutest
+    - name: Standard build, FreeBSD 13.0 (snap)
+      freebsd_instance:
+        image_family: freebsd-13-0-snap
+      pkginstall_script:
+        - pkg update -f
+        - pkg install -y gmake autoconf automake libevent
+      configure_script:
+        - autoconf && autoheader
+        - ./configure --enable-checking --disable-flto
+      compile_script:
+        - make -j 3
+        - make cutest
+      test_script:
+        - ./cutest
+    - name: Standard build, No LTO, FreeBSD 13.0 (snap)
+      freebsd_instance:
+        image_family: freebsd-13-0-snap
+      pkginstall_script:
+        - pkg update -f
+        - pkg install -y gmake autoconf automake libevent
+      configure_script:
+        - autoconf && autoheader
+        - ./configure --enable-checking
+      compile_script:
+        - make -j 3
+        - make cutest
+      test_script:
+        - ./cutest


### PR DESCRIPTION
This PR adds FreeBSD testing using Cirrus.

NLNetLabs has two actions to perform. First, go to [Cirrus](https://cirrus-ci.com/) and sign up for an account using GitHub credentials. Second, go to GitHub MarketPlace, find the Cirrus app, and install it.

Once things are configured, NLNetLabs will obtain testing results like [here](https://cirrus-ci.com/build/4956744224866304) and shown below.

-----

![cirrus-1](https://user-images.githubusercontent.com/3538226/77484321-9958a400-6e00-11ea-9b87-ae5213f272e0.png)

