### PR TITLE
Use precious variables for GREP, EGREP, SED, AWK, LEX and YACC

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -47,13 +47,17 @@ INSTALL		= $(srcdir)/install-sh -c
 INSTALL_PROGRAM	= $(INSTALL)
 INSTALL_DATA	= $(INSTALL) -m 644
 
-YACC		= @YACC@
+SED 	= @SED@
+AWK 	= @AWK@
+GREP	= @GREP@
+EGREP	= @EGREP@
+YACC 	= @YACC@
 LEX		= @LEX@
 PROTOC_C	= @PROTOC_C@
 
 COMPILE		= $(CC) $(CPPFLAGS) $(CFLAGS)
 LINK		= $(CC) $(CFLAGS) $(LDFLAGS)
-EDIT		= sed \
+EDIT		= $(SED) \
 			-e 's,@prefix\@,$(prefix),g' \
 			-e 's,@exec_prefix\@,$(exec_prefix),g' \
 			-e 's,@sbindir\@,$(sbindir),g' \
@@ -95,11 +99,11 @@ nsd-control-setup.sh:	$(srcdir)/nsd-control-setup.sh.in config.h
 
 nsd.conf.sample:	$(srcdir)/nsd.conf.sample.in config.h
 	rm -f nsd.conf.sample
-	$(EDIT) $(srcdir)/nsd.conf.sample.in | awk '/RRLconfig'@ratelimit@'/ { while($$0 !~ /.*RRLend.*/) { getline; } getline; } {print} ' > nsd.conf.sample
+	$(EDIT) $(srcdir)/nsd.conf.sample.in | $(AWK) '/RRLconfig'@ratelimit@'/ { while($$0 !~ /.*RRLend.*/) { getline; } getline; } {print} ' > nsd.conf.sample
 
 nsd.conf.5:	$(srcdir)/nsd.conf.5.in config.h
 	rm -f nsd.conf.5
-	$(EDIT) $(srcdir)/nsd.conf.5.in | awk '/rrlstart'@ratelimit@'/ { while($$0 !~ /.*rrlend.*/) { getline; } getline; } {print} ' > nsd.conf.5
+	$(EDIT) $(srcdir)/nsd.conf.5.in | $(AWK) '/rrlstart'@ratelimit@'/ { while($$0 !~ /.*rrlend.*/) { getline; } getline; } {print} ' > nsd.conf.5
 
 nsd.8:	$(srcdir)/nsd.8.in config.h
 	rm -f nsd.8
@@ -368,8 +372,8 @@ DEPEND_TARGET=Makefile
 DEPEND_TARGET2=Makefile.in
 depend:
 	(cd $(srcdir) ; $(CC) -MM $(CPPFLAGS) *.c compat/*.c `if test -d tpkg/cutest; then echo tpkg/cutest/*.c; fi`) | \
-		sed -e 's? *\([^ ]*\.[ch]\)? $$(srcdir)/\1?g' | \
-		sed -e 's?$$(srcdir)/config.h?config.h?g' \
+		$(SED) -e 's? *\([^ ]*\.[ch]\)? $$(srcdir)/\1?g' | \
+		$(SED) -e 's?$$(srcdir)/config.h?config.h?g' \
 			-e 's?$$(srcdir)/configlexer.c?configlexer.c?g' \
 			-e 's?$$(srcdir)/configparser.c?configparser.c?g' \
 			-e 's?$$(srcdir)/configparser.h?configparser.h?g' \
@@ -381,12 +385,12 @@ depend:
 			-e 's?$$(srcdir)/zparser.h?zparser.h?g' \
 			> $(DEPEND_TMP)
 	cp $(DEPEND_TARGET) $(DEPEND_TMP2)
-	head -`egrep -n "# Dependencies" $(DEPEND_TARGET) | tail -1 | sed -e 's/:.*$$//'` $(DEPEND_TMP2) > $(DEPEND_TARGET)
+	head -`$(EGREP) -n "# Dependencies" $(DEPEND_TARGET) | tail -1 | $(SED) -e 's/:.*$$//'` $(DEPEND_TMP2) > $(DEPEND_TARGET)
 	cat $(DEPEND_TMP) >> $(DEPEND_TARGET)
 	@if diff $(DEPEND_TARGET) $(DEPEND_TMP2); then echo "	$(DEPEND_TARGET) unchanged"; else echo "	Updated $(DEPEND_TARGET))"; fi
 	@if test -f $(DEPEND_TARGET2); then \
 		cp $(DEPEND_TARGET2) $(DEPEND_TMP2); \
-		head -`egrep -n "# Dependencies" $(DEPEND_TARGET2) | tail -1 | sed -e 's/:.*$$//'` $(DEPEND_TMP2) > $(DEPEND_TARGET2); \
+		head -`$(EGREP) -n "# Dependencies" $(DEPEND_TARGET2) | tail -1 | $(SED) -e 's/:.*$$//'` $(DEPEND_TMP2) > $(DEPEND_TARGET2); \
 		cat $(DEPEND_TMP) >> $(DEPEND_TARGET2); \
 		if diff $(DEPEND_TARGET2) $(DEPEND_TMP2); then echo "	$(DEPEND_TARGET2) unchanged"; else echo "	Updated $(DEPEND_TARGET2))"; fi; \
 	fi

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,27 @@ sinclude(dnstap/dnstap.m4)
 AC_INIT(NSD,4.3.1,nsd-bugs@nlnetlabs.nl)
 AC_CONFIG_HEADER([config.h])
 
+#
+# Setup the standard programs
+# https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Setting-Output-Variables.html
+
+AC_ARG_VAR(SED, [location of the sed program])
+AC_ARG_VAR(AWK, [location of the awk program])
+AC_ARG_VAR(GREP, [location of the grep program])
+AC_ARG_VAR(EGREP, [location of the egrep program])
+AC_ARG_VAR(LEX, [location of the lex program with GNU extensions (flex)])
+AC_ARG_VAR(YACC, [location of the yacc program with GNU extensions (bison)])
+
+AC_PROG_CC
+AC_PROG_SED
+AC_PROG_AWK
+AC_PROG_GREP
+AC_PROG_EGREP
+AC_PROG_LEX
+AC_PROG_YACC
+AC_PROG_LN_S
+AC_PROG_INSTALL
+
 CFLAGS="$CFLAGS"
 AC_AIX
 if test "$ac_cv_header_minix_config_h" = "yes"; then
@@ -163,13 +184,18 @@ AC_ARG_WITH([user],
 AC_SUBST(user)
 AC_DEFINE_UNQUOTED(USER, ["$user"], [the user name to drop privileges to])
 
-# Checks for programs.
-AC_PROG_AWK
-AC_PROG_CC
-AC_PROG_LN_S
-AC_PROG_INSTALL
-AC_PROG_LEX
-AC_PROG_YACC
+# Solaris provides anemic tools, and they don't offer GNU extensions like
+# 'flex -i'. Solaris also does not offer GNU replacements in /usr/gnu/bin.
+AC_MSG_CHECKING([whether lex accepts -i])
+AS_IF([echo "%%" | $LEX -i -t >/dev/null 2>&1],
+  [
+    AC_MSG_RESULT([yes])
+  ],
+  [
+    AC_MSG_RESULT([no])
+    AC_MSG_ERROR([unable to find a lexer that supports -i. If one is available then set the LEX variable])
+  ]
+)
 
 if test "$LEX" != ":" -a "$LEX" != ""; then
   # Check if lex defines yy_current_buffer, because 2.4.6 and older use it,
@@ -178,8 +204,8 @@ if test "$LEX" != ":" -a "$LEX" != ""; then
   cat <<EOF >conftest.lex
 %%
 EOF
-  $LEX -i -t conftest.lex >> conftest.c
-  if grep "^#define yy_current_buffer" conftest.c >/dev/null; then
+  $LEX -i -t conftest.lex >> conftest.c 2>/dev/null
+  if $GREP "^#define yy_current_buffer" conftest.c >/dev/null; then
 	  AC_DEFINE_UNQUOTED(LEX_DEFINES_YY_CURRENT_BUFFER, 1, [If flex defines yy_current_buffer as a macro])
 	AC_MSG_RESULT(yes)
   else
@@ -257,7 +283,7 @@ AC_DEFUN([CHECK_COMPILER_FLAG],
 [
 AC_REQUIRE([AC_PROG_CC])
 AC_MSG_CHECKING(whether $CC supports -$1)
-cache=`echo $1 | sed 'y%.=/+-%___p_%'`
+cache=`echo $1 | $SED 'y%.=/+-%___p_%'`
 AC_CACHE_VAL(cv_prog_cc_flag_$cache,
 [
 echo 'void f(){}' >conftest.c
@@ -393,7 +419,7 @@ if test x_$withval = x_yes -o x_$withval != x_no; then
             		AC_MSG_RESULT(found in $thedir)
                 	CPPFLAGS="$CPPFLAGS -I$thedir -I$thedir/include"
 			# remove evdns from linking
-			ev_files_o=`ls $thedir/*.o | grep -v evdns\.o | grep -v bufferevent_openssl\.o`
+			ev_files_o=`ls $thedir/*.o | $GREP -v evdns\.o | $GREP -v bufferevent_openssl\.o`
 			cp $ev_files_o .
 			LDFLAGS="$ev_files_o $LDFLAGS -lm"
 		else
@@ -677,12 +703,12 @@ AC_DEFINE([HAVE_SENDMMSG], [1], [Define if sendmmsg exists])]
 esac
 
 # check if setreuid en setregid fail, on MacOSX10.4(darwin8).
-if echo $target_os | grep -i darwin8 > /dev/null; then
+if echo $target_os | $GREP -i darwin8 > /dev/null; then
 	AC_DEFINE(DARWIN_BROKEN_SETREUID, 1, [Define this if on macOSX10.4-darwin8 and setreuid and setregid do not work])
 fi
 
 # GNU HURD needs _GNU_SOURCE defined for cpu affinity gear
-if echo $target_os | grep -i -E 'linux|hurd' > /dev/null; then
+if echo $target_os | $EGREP -i 'linux|hurd' > /dev/null; then
   AC_DEFINE([_GNU_SOURCE, 1, [Define this if on Linux or GNU Hurd for cpu affinity interface]])
 fi
 


### PR DESCRIPTION
This PR uses precious variables for GREP, EGREP, SED, AWK, LEX and YACC. The PR eases building NSD on platforms like Solaris. The PR will make no difference on platforms like Linux.

The precious variables means `configure` will allow the user to override them in the environment, or find the best replacement using `AC_PROG_SED`, `AC_PROG_AWK`, `AC_PROG_GREP` and friends. The variables are then used in the `Makefile.in`.

Sun managed to provide some tools that are more anemic then Posix. Avoiding the anemic tools (like `egrep`) and using the more featured tools (like `ggrep -E`) resolves most build errors on Solaris.

Also see Issue 85, [configure.ac and Makefile.in hard codes tools](https://github.com/NLnetLabs/nsd/issues/85).