### PR TITLE
Fix help return code in nsd-control-setup script

### DIFF
--- a/nsd-control-setup.sh.in
+++ b/nsd-control-setup.sh.in
@@ -99,7 +99,7 @@ OPTIND=1
 while getopts 'd:hr' arg; do
     case "$arg" in
       d) DESTDIR="$OPTARG" ;;
-      h) usage; exit 0 ;;
+      h) usage; exit 1 ;;
       r) RECREATE=1 ;;
       ?) fatal "'$arg' unknown option" ;;
     esac


### PR DESCRIPTION
`nsdc-run` test failed because the exit code changed. This "fixes" it.