### PR TITLE
add missing default in documentation

### DIFF
--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -395,7 +395,7 @@ Prevent NSD from replying with the identity string on CHAOS class
 queries.  Default is no.
 .TP
 .B drop\-updates:\fR <yes or no>
-If set to yes, drop received packets with the UPDATE opcode.
+If set to yes, drop received packets with the UPDATE opcode.  Default is no.
 .TP
 .B use\-systemd:\fR <yes or no>
 This option is deprecated and ignored.  If compiled with libsystemd,


### PR DESCRIPTION
add missing default for option `drop-updates` in documentation