### PR TITLE
Clearing hash_tree means just emptying the tree

### DIFF
--- a/namedb.c
+++ b/namedb.c
@@ -301,7 +301,9 @@ void zone_add_domain_in_hash_tree(region_type* region, rbtree_type** tree,
 {
 	if(!*tree)
 		*tree = rbtree_create(region, cmpf);
-	if(node->key) return;
+	if(node->key && node->key == domain
+	&& rbtree_search(*tree, domain) == node)
+		return;
 	memset(node, 0, sizeof(rbnode_type));
 	node->key = domain;
 	rbtree_insert(*tree, node);

--- a/namedb.c
+++ b/namedb.c
@@ -289,21 +289,6 @@ domain_table_deldomain(namedb_type* db, domain_type* domain)
 	}
 }
 
-/** clear hash tree */
-void
-hash_tree_clear(rbtree_type* tree)
-{
-	rbnode_type* n;
-	if(!tree) return;
-
-	/* note that elements are no longer in the tree */
-	for(n=rbtree_first(tree); n!=RBTREE_NULL; n=rbtree_next(n)) {
-		n->key = NULL;
-	}
-	tree->count = 0;
-	tree->root = RBTREE_NULL;
-}
-
 void hash_tree_delete(region_type* region, rbtree_type* tree)
 {
 	region_recycle(region, tree, sizeof(rbtree_type));

--- a/namedb.h
+++ b/namedb.h
@@ -231,7 +231,6 @@ void zone_add_domain_in_hash_tree(region_type* region, rbtree_type** tree,
 	int (*cmpf)(const void*, const void*), domain_type* domain,
 	rbnode_type* node);
 void zone_del_domain_in_hash_tree(rbtree_type* tree, rbnode_type* node);
-void hash_tree_clear(rbtree_type* tree);
 void hash_tree_delete(region_type* region, rbtree_type* tree);
 void prehash_clear(domain_table_type* table);
 void prehash_add(domain_table_type* table, domain_type* domain);

--- a/nsec3.c
+++ b/nsec3.c
@@ -396,6 +396,31 @@ nsec3_chain_find_prev(struct zone* zone, struct domain* domain)
 	return NULL;
 }
 
+
+/** clear hash tree. Called from nsec3_clear_precompile() only. */
+static void
+hash_tree_clear(rbtree_type* tree)
+{
+	rbnode_type* n;
+	if(!tree) return;
+
+	/* Previously (before commit 4ca61188b3f7a0e077476875810d18a5d439871f
+	 * and/or svn commit 4776) prehashes and corresponding rbtree nodes
+	 * were part of struct nsec3_domain_data. Clearing the hash_tree would
+	 * then mean setting the key value of the nodes to NULL to indicate
+	 * absence of the prehash.
+	 * But since prehash structs are separatly allocated, this is no longer
+	 * necessary as currently the prehash structs are simply recycled and 
+	 * NULLed.
+	 *
+	 * for(n=rbtree_first(tree); n!=RBTREE_NULL; n=rbtree_next(n)) {
+	 *	n->key = NULL;
+	 * }
+	 */
+	tree->count = 0;
+	tree->root = RBTREE_NULL;
+}
+
 void
 nsec3_clear_precompile(struct namedb* db, zone_type* zone)
 {

--- a/nsec3.c
+++ b/nsec3.c
@@ -401,7 +401,6 @@ nsec3_chain_find_prev(struct zone* zone, struct domain* domain)
 static void
 hash_tree_clear(rbtree_type* tree)
 {
-	rbnode_type* n;
 	if(!tree) return;
 
 	/* Previously (before commit 4ca61188b3f7a0e077476875810d18a5d439871f
@@ -413,6 +412,7 @@ hash_tree_clear(rbtree_type* tree)
 	 * necessary as currently the prehash structs are simply recycled and 
 	 * NULLed.
 	 *
+	 * rbnode_type* n;
 	 * for(n=rbtree_first(tree); n!=RBTREE_NULL; n=rbtree_next(n)) {
 	 *	n->key = NULL;
 	 * }


### PR DESCRIPTION
Previously (before commit 4ca61188 and/or svn commit 4776) prehashes and corresponding rbtree nodes were part of struct nsec3_domain_data. Clearing the hash_tree would then mean setting the key value of the nodes to NULL to indicate absence of the prehash. But since prehash structs are separately allocated, this is no longer necessary as currently the prehash structs are simply recycled and NULLed.

Currently we have few reports of corrupted hash_tree's during transfer (issue #18 ). Corruption can be caused, either because the prehashed structs of that specific tree were recycled, without them being removed from the tree. Another possibility is that the nodes use memory from recycled pieces of memory that are still in use.

A corrupted transport that we were able to study was for full zone updates (although by IXFR) only. Since this is the most simple recycle path ( with `nsec3_clear_precompile()`) which can hardly go wrong, I currently suspect that the corruption emerged from reusing recycled pieces still in use in other places.  Not writing to the nodes will ease the search for the actual culprit, for example by compiling with CHECK_DOUBLE_FREE checks which might get triggered with the recycling of the prehash structs in . Before this change, writing to key would cause a crash before this check can be made.

In any case, the corruption should be detected when it occurs perhaps testing for rbtree invariants (left->parent == this etc) and we should not crash because of side effects of such corruption. 