### PR TITLE
Adhere better to xfrd bounds…

### DIFF
--- a/xfrd-disk.c
+++ b/xfrd-disk.c
@@ -312,7 +312,7 @@ xfrd_read_state(struct xfrd_state* xfrd)
 			xfrd_deactivate_zone(zone);
 			zone->state = state;
 			xfrd_set_timer(zone,
-				within_refresh_limits(zone, timeout));
+				within_refresh_bounds(zone, timeout));
 		}	
 		if((zone->soa_nsd_acquired == 0 && soa_nsd_acquired_read == 0 &&
 			soa_disk_acquired_read == 0) ||
@@ -322,7 +322,7 @@ xfrd_read_state(struct xfrd_state* xfrd)
 			xfrd_deactivate_zone(zone);
 			zone->state = state;
 			xfrd_set_timer(zone,
-				within_retry_limits(zone, timeout));
+				within_retry_bounds(zone, timeout));
 		}
 
 		/* handle as an incoming SOA. */

--- a/xfrd-disk.c
+++ b/xfrd-disk.c
@@ -311,8 +311,8 @@ xfrd_read_state(struct xfrd_state* xfrd)
 			&& zone->soa_nsd.serial == soa_nsd_read.serial) {
 			xfrd_deactivate_zone(zone);
 			zone->state = state;
-			xfrd_set_timer(zone, timeout > XFRD_LOWERBOUND_REFRESH
-			                   ? timeout : XFRD_LOWERBOUND_REFRESH);
+			xfrd_set_timer(zone,
+				within_refresh_limits(zone, timeout));
 		}	
 		if((zone->soa_nsd_acquired == 0 && soa_nsd_acquired_read == 0 &&
 			soa_disk_acquired_read == 0) ||
@@ -321,8 +321,8 @@ xfrd_read_state(struct xfrd_state* xfrd)
 			 * storm of attempts on some master servers */
 			xfrd_deactivate_zone(zone);
 			zone->state = state;
-			xfrd_set_timer(zone, timeout > XFRD_LOWERBOUND_RETRY
-			                   ? timeout : XFRD_LOWERBOUND_RETRY);
+			xfrd_set_timer(zone,
+				within_retry_limits(zone, timeout));
 		}
 
 		/* handle as an incoming SOA. */

--- a/xfrd-disk.c
+++ b/xfrd-disk.c
@@ -311,7 +311,8 @@ xfrd_read_state(struct xfrd_state* xfrd)
 			&& zone->soa_nsd.serial == soa_nsd_read.serial) {
 			xfrd_deactivate_zone(zone);
 			zone->state = state;
-			xfrd_set_timer(zone, timeout);
+			xfrd_set_timer(zone, timeout > XFRD_LOWERBOUND_REFRESH
+			                   ? timeout : XFRD_LOWERBOUND_REFRESH);
 		}	
 		if((zone->soa_nsd_acquired == 0 && soa_nsd_acquired_read == 0 &&
 			soa_disk_acquired_read == 0) ||
@@ -320,7 +321,8 @@ xfrd_read_state(struct xfrd_state* xfrd)
 			 * storm of attempts on some master servers */
 			xfrd_deactivate_zone(zone);
 			zone->state = state;
-			xfrd_set_timer(zone, timeout);
+			xfrd_set_timer(zone, timeout > XFRD_LOWERBOUND_RETRY
+			                   ? timeout : XFRD_LOWERBOUND_RETRY);
 		}
 
 		/* handle as an incoming SOA. */

--- a/xfrd.c
+++ b/xfrd.c
@@ -771,7 +771,7 @@ xfrd_set_timer_refresh(xfrd_zone_type* zone)
 	                                ? set_refresh : set_expire );
 
 	/* set point in time to period for xfrd_set_timer() */
-	xfrd_set_timer(zone, within_refresh_limits(zone,
+	xfrd_set_timer(zone, within_refresh_bounds(zone,
 		  set > xfrd_time()
 		? set - xfrd_time() : XFRD_LOWERBOUND_REFRESH));
 }
@@ -799,15 +799,15 @@ xfrd_set_timer_retry(xfrd_zone_type* zone)
 	/* set timer for next retry or expire timeout if earlier. */
 	if(zone->soa_disk_acquired == 0) {
 		/* if no information, use reasonable timeout
-		 * within configured and defined limits
+		 * within configured and defined bounds
 		 */
 		xfrd_set_timer(zone,
-			within_retry_limits(zone, zone->fresh_xfr_timeout
+			within_retry_bounds(zone, zone->fresh_xfr_timeout
 				+ random_generate(zone->fresh_xfr_timeout)));
 		return;
 	}
-	/* exponential backoff within configured and defined limits */
-	set_retry = within_retry_limits(zone,
+	/* exponential backoff within configured and defined bounds */
+	set_retry = within_retry_bounds(zone,
 			ntohl(zone->soa_disk.retry * mult));
 	if(zone->state == xfrd_zone_expired) {
 		xfrd_set_timer(zone, set_retry);
@@ -821,11 +821,11 @@ xfrd_set_timer_retry(xfrd_zone_type* zone)
 	}
 	/* Not expired, but next retry will be > than expire timeout.
 	 * Retry when the expire timeout runs out.
-	 * set_expire is below retry upper bound limits (if statement above),
-	 * but not necessarily above lower bound limits,
-	 * so use within_retry_limits() again.
+	 * set_expire is below retry upper bounds (if statement above),
+	 * but not necessarily above lower bounds,
+	 * so use within_retry_bounds() again.
 	 */
-	xfrd_set_timer(zone, within_retry_limits(zone,
+	xfrd_set_timer(zone, within_retry_bounds(zone,
 		  set_expire > xfrd_time()
 		? set_expire - xfrd_time() : XFRD_LOWERBOUND_RETRY));
 }

--- a/xfrd.c
+++ b/xfrd.c
@@ -808,7 +808,7 @@ xfrd_set_timer_retry(xfrd_zone_type* zone)
 	}
 	/* exponential backoff within configured and defined bounds */
 	set_retry = within_retry_bounds(zone,
-			ntohl(zone->soa_disk.retry * mult));
+			ntohl(zone->soa_disk.retry) * mult);
 	if(zone->state == xfrd_zone_expired) {
 		xfrd_set_timer(zone, set_retry);
 		return;

--- a/xfrd.c
+++ b/xfrd.c
@@ -765,7 +765,7 @@ xfrd_set_timer_refresh(xfrd_zone_type* zone)
 		return;
 	}
 	/* refresh or expire timeout, whichever is earlier */
-	set_refresh = limited_soa_disk_refresh(zone);
+	set_refresh = bound_soa_disk_refresh(zone);
 	set_expire  = soa_disk_expire(zone);
 	set = zone->soa_disk_acquired + ( set_refresh < set_expire
 	                                ? set_refresh : set_expire );
@@ -884,7 +884,7 @@ xfrd_handle_zone(int ATTR_UNUSED(fd), short event, void* arg)
 		}
 		else if(zone->state == xfrd_zone_ok &&
 			xfrd_time() >= zone->soa_disk_acquired
-			               + limited_soa_disk_refresh(zone)) {
+			               + bound_soa_disk_refresh(zone)) {
 			/* zone goes to refreshing state. */
 			DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: zone %s is refreshing", zone->apex_str));
 			xfrd_set_zone_state(zone, xfrd_zone_refreshing);
@@ -1196,7 +1196,7 @@ xfrd_handle_incoming_soa(xfrd_zone_type* zone,
 		seconds_since_acquired =
 			  xfrd_time() > zone->soa_disk_acquired
 			? xfrd_time() - zone->soa_disk_acquired : 0;
-		if(seconds_since_acquired < limited_soa_disk_refresh(zone))
+		if(seconds_since_acquired < bound_soa_disk_refresh(zone))
 		{
 			/* zone ok, wait for refresh time */
 			xfrd_set_zone_state(zone, xfrd_zone_ok);

--- a/xfrd.c
+++ b/xfrd.c
@@ -759,40 +759,28 @@ xfrd_set_timer_refresh(xfrd_zone_type* zone)
 {
 	time_t set_refresh;
 	time_t set_expire;
-	time_t set_min;
 	time_t set;
 	if(zone->soa_disk_acquired == 0 || zone->state != xfrd_zone_ok) {
 		xfrd_set_timer_retry(zone);
 		return;
 	}
 	/* refresh or expire timeout, whichever is earlier */
-	set_refresh = ntohl(zone->soa_disk.refresh);
-	if (set_refresh > (time_t)zone->zone_options->pattern->max_refresh_time)
-		set_refresh = zone->zone_options->pattern->max_refresh_time;
-	else if (set_refresh < (time_t)zone->zone_options->pattern->min_refresh_time)
-		set_refresh = zone->zone_options->pattern->min_refresh_time;
-	set_refresh += zone->soa_disk_acquired;
-	set_expire = zone->soa_disk_acquired + ntohl(zone->soa_disk.expire);
-	if(set_refresh < set_expire)
-		set = set_refresh;
-	else set = set_expire;
-	set_min = zone->soa_disk_acquired + XFRD_LOWERBOUND_REFRESH;
-	if(set < set_min)
-		set = set_min;
-	if(set < xfrd_time())
-		set = 0;
-	else	set -= xfrd_time();
-	if(set > XFRD_TRANSFER_TIMEOUT_MAX)
-		set = XFRD_TRANSFER_TIMEOUT_MAX;
-	else if (set < XFRD_LOWERBOUND_REFRESH)
-		set = XFRD_LOWERBOUND_REFRESH;
-	xfrd_set_timer(zone, set);
+	set_refresh = limited_soa_disk_refresh(zone);
+	set_expire  = soa_disk_expire(zone);
+	set = zone->soa_disk_acquired + ( set_refresh < set_expire
+	                                ? set_refresh : set_expire );
+
+	/* set point in time to period for xfrd_set_timer() */
+	xfrd_set_timer(zone, within_refresh_limits(zone,
+		  set > xfrd_time()
+		? set - xfrd_time() : XFRD_LOWERBOUND_REFRESH));
 }
 
 static void
 xfrd_set_timer_retry(xfrd_zone_type* zone)
 {
 	time_t set_retry;
+	time_t set_expire;
 	int mult;
 	/* perform exponential backoff in all the cases */
 	if(zone->fresh_xfr_timeout == 0)
@@ -810,41 +798,36 @@ xfrd_set_timer_retry(xfrd_zone_type* zone)
 
 	/* set timer for next retry or expire timeout if earlier. */
 	if(zone->soa_disk_acquired == 0) {
-		/* if no information, use reasonable timeout */
-		set_retry = zone->fresh_xfr_timeout
-			+ random_generate(zone->fresh_xfr_timeout);
-		if(set_retry < XFRD_LOWERBOUND_RETRY)
-			set_retry = XFRD_LOWERBOUND_RETRY;
-		xfrd_set_timer(zone, set_retry);
-	} else if(zone->state == xfrd_zone_expired ||
-		xfrd_time() + (time_t)ntohl(zone->soa_disk.retry)*mult <
-		zone->soa_disk_acquired + (time_t)ntohl(zone->soa_disk.expire))
-	{
-		set_retry = ntohl(zone->soa_disk.retry);
-		set_retry *= mult;
-		if(set_retry > XFRD_TRANSFER_TIMEOUT_MAX)
-			set_retry = XFRD_TRANSFER_TIMEOUT_MAX;
-		if(set_retry > (time_t)zone->zone_options->pattern->max_retry_time)
-			set_retry = zone->zone_options->pattern->max_retry_time;
-		else if(set_retry < (time_t)zone->zone_options->pattern->min_retry_time)
-			set_retry = zone->zone_options->pattern->min_retry_time;
-		if(set_retry < XFRD_LOWERBOUND_RETRY)
-			set_retry = XFRD_LOWERBOUND_RETRY;
-		xfrd_set_timer(zone, set_retry);
-	} else {
-		set_retry = ntohl(zone->soa_disk.expire);
-		if(set_retry > XFRD_TRANSFER_TIMEOUT_MAX)
-			set_retry = XFRD_TRANSFER_TIMEOUT_MAX;
-		if(set_retry < XFRD_LOWERBOUND_RETRY)
-			xfrd_set_timer(zone, XFRD_LOWERBOUND_RETRY);
-		else {
-			if(zone->soa_disk_acquired + set_retry
-					< xfrd_time() + XFRD_LOWERBOUND_RETRY)
-				xfrd_set_timer(zone, XFRD_LOWERBOUND_RETRY);
-			else xfrd_set_timer(zone, zone->soa_disk_acquired +
-				set_retry - xfrd_time());
-		}
+		/* if no information, use reasonable timeout
+		 * within configured and defined limits
+		 */
+		xfrd_set_timer(zone,
+			within_retry_limits(zone, zone->fresh_xfr_timeout
+				+ random_generate(zone->fresh_xfr_timeout)));
+		return;
 	}
+	/* exponential backoff within configured and defined limits */
+	set_retry = within_retry_limits(zone,
+			ntohl(zone->soa_disk.retry * mult));
+	if(zone->state == xfrd_zone_expired) {
+		xfrd_set_timer(zone, set_retry);
+		return;
+	}
+	/* retry or expire timeout, whichever is earlier */
+	set_expire = zone->soa_disk_acquired + soa_disk_expire(zone);
+	if(xfrd_time() + set_retry < set_expire) {
+		xfrd_set_timer(zone, set_retry);
+		return;
+	}
+	/* Not expired, but next retry will be > than expire timeout.
+	 * Retry when the expire timeout runs out.
+	 * set_expire is below retry upper bound limits (if statement above),
+	 * but not necessarily above lower bound limits,
+	 * so use within_retry_limits() again.
+	 */
+	xfrd_set_timer(zone, within_retry_limits(zone,
+		  set_expire > xfrd_time()
+		? set_expire - xfrd_time() : XFRD_LOWERBOUND_RETRY));
 }
 
 void
@@ -893,13 +876,15 @@ xfrd_handle_zone(int ATTR_UNUSED(fd), short event, void* arg)
 	if(zone->soa_disk_acquired)
 	{
 		if (zone->state != xfrd_zone_expired &&
-			xfrd_time() >= zone->soa_disk_acquired + (time_t)ntohl(zone->soa_disk.expire)) {
+			xfrd_time() >= zone->soa_disk_acquired
+					+ soa_disk_expire(zone)) {
 			/* zone expired */
 			log_msg(LOG_ERR, "xfrd: zone %s has expired", zone->apex_str);
 			xfrd_set_zone_state(zone, xfrd_zone_expired);
 		}
 		else if(zone->state == xfrd_zone_ok &&
-			xfrd_time() >= zone->soa_disk_acquired + (time_t)ntohl(zone->soa_disk.refresh)) {
+			xfrd_time() >= zone->soa_disk_acquired
+			               + limited_soa_disk_refresh(zone)) {
 			/* zone goes to refreshing state. */
 			DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: zone %s is refreshing", zone->apex_str));
 			xfrd_set_zone_state(zone, xfrd_zone_refreshing);
@@ -1156,6 +1141,8 @@ xfrd_set_timer(xfrd_zone_type* zone, time_t t)
 {
 	int fd = zone->zone_handler.ev_fd;
 	int fl = ((fd == -1)?EV_TIMEOUT:zone->zone_handler_flags);
+	if(t > XFRD_TRANSFER_TIMEOUT_MAX)
+		t = XFRD_TRANSFER_TIMEOUT_MAX;
 	/* randomize the time, within 90%-100% of original */
 	/* not later so zones cannot expire too late */
 	/* only for times far in the future */
@@ -1184,6 +1171,7 @@ void
 xfrd_handle_incoming_soa(xfrd_zone_type* zone,
 	xfrd_soa_type* soa, time_t acquired)
 {
+	time_t seconds_since_acquired;
 	if(soa == NULL) {
 		/* nsd no longer has a zone in memory */
 		zone->soa_nsd_acquired = 0;
@@ -1205,22 +1193,22 @@ xfrd_handle_incoming_soa(xfrd_zone_type* zone,
 		xfrd->write_zonefile_needed = 1;
 		/* reset exponential backoff, we got a normal timer now */
 		zone->fresh_xfr_timeout = 0;
-		if(xfrd_time() - zone->soa_disk_acquired
-			< (time_t)ntohl(zone->soa_disk.refresh))
+		seconds_since_acquired =
+			  xfrd_time() > zone->soa_disk_acquired
+			? xfrd_time() - zone->soa_disk_acquired : 0;
+		if(seconds_since_acquired < limited_soa_disk_refresh(zone))
 		{
 			/* zone ok, wait for refresh time */
 			xfrd_set_zone_state(zone, xfrd_zone_ok);
 			zone->round_num = -1;
 			xfrd_set_timer_refresh(zone);
-		} else if(xfrd_time() - zone->soa_disk_acquired
-			< (time_t)ntohl(zone->soa_disk.expire))
+		} else if(seconds_since_acquired < soa_disk_expire(zone))
 		{
 			/* zone refreshing */
 			xfrd_set_zone_state(zone, xfrd_zone_refreshing);
 			xfrd_set_refresh_now(zone);
 		}
-		if(xfrd_time() - zone->soa_disk_acquired
-			>= (time_t)ntohl(zone->soa_disk.expire)) {
+		if(seconds_since_acquired >= soa_disk_expire(zone)) {
 			/* zone expired */
 			xfrd_set_zone_state(zone, xfrd_zone_expired);
 			xfrd_set_refresh_now(zone);

--- a/xfrd.h
+++ b/xfrd.h
@@ -246,6 +246,8 @@ enum xfrd_packet_result {
 
 #define XFRD_TRANSFER_TIMEOUT_START 10 /* empty zone timeout is between x and 2*x seconds */
 #define XFRD_TRANSFER_TIMEOUT_MAX 86400 /* empty zone timeout max expbackoff */
+#define XFRD_LOWERBOUND_REFRESH 1 /* seconds, smallest refresh timeout */
+#define XFRD_LOWERBOUND_RETRY 1 /* seconds, smallest retry timeout */
 
 extern xfrd_state_type* xfrd;
 

--- a/xfrd.h
+++ b/xfrd.h
@@ -269,7 +269,7 @@ within_refresh_bounds(xfrd_zone_type* zone, time_t refresh)
  * within configured and defined lower and upper bounds
  */
 static inline time_t
-limited_soa_disk_refresh(xfrd_zone_type* zone)
+bound_soa_disk_refresh(xfrd_zone_type* zone)
 {
 	return within_refresh_bounds(zone, ntohl(zone->soa_disk.refresh));
 }
@@ -294,7 +294,7 @@ within_retry_bounds(xfrd_zone_type* zone, time_t retry)
  * within configured and defined lower and upper bounds
  */
 static inline time_t
-limited_soa_disk_retry(xfrd_zone_type* zone)
+bound_soa_disk_retry(xfrd_zone_type* zone)
 {
 	return within_retry_bounds(zone, ntohl(zone->soa_disk.retry));
 }

--- a/xfrd.h
+++ b/xfrd.h
@@ -251,10 +251,10 @@ enum xfrd_packet_result {
 
 /*
  * return refresh period
- * within configured and defined lower and upper bound limits
+ * within configured and defined lower and upper bounds
  */
 static inline time_t
-within_refresh_limits(xfrd_zone_type* zone, time_t refresh)
+within_refresh_bounds(xfrd_zone_type* zone, time_t refresh)
 {
 	return (time_t)zone->zone_options->pattern->max_refresh_time < refresh
 	     ? (time_t)zone->zone_options->pattern->max_refresh_time
@@ -266,20 +266,20 @@ within_refresh_limits(xfrd_zone_type* zone, time_t refresh)
 
 /*
  * return the zone's refresh period (from the on disk stored SOA)
- * within configured and defined lower and upper bound limits
+ * within configured and defined lower and upper bounds
  */
 static inline time_t
 limited_soa_disk_refresh(xfrd_zone_type* zone)
 {
-	return within_refresh_limits(zone, ntohl(zone->soa_disk.refresh));
+	return within_refresh_bounds(zone, ntohl(zone->soa_disk.refresh));
 }
 
 /*
  * return retry period
- * within configured and defined lower and upper bound limits
+ * within configured and defined lower and upper bounds
  */
 static inline time_t
-within_retry_limits(xfrd_zone_type* zone, time_t retry)
+within_retry_bounds(xfrd_zone_type* zone, time_t retry)
 {
 	return (time_t)zone->zone_options->pattern->max_retry_time < retry
 	     ? (time_t)zone->zone_options->pattern->max_retry_time
@@ -291,12 +291,12 @@ within_retry_limits(xfrd_zone_type* zone, time_t retry)
 
 /*
  * return the zone's retry period (from the on disk stored SOA)
- * within configured and defined lower and upper bound limits
+ * within configured and defined lower and upper bounds
  */
 static inline time_t
 limited_soa_disk_retry(xfrd_zone_type* zone)
 {
-	return within_retry_limits(zone, ntohl(zone->soa_disk.retry));
+	return within_retry_bounds(zone, ntohl(zone->soa_disk.retry));
 }
 
 /* return the zone's expire period (from the on disk stored SOA) */

--- a/xfrd.h
+++ b/xfrd.h
@@ -249,6 +249,63 @@ enum xfrd_packet_result {
 #define XFRD_LOWERBOUND_REFRESH 1 /* seconds, smallest refresh timeout */
 #define XFRD_LOWERBOUND_RETRY 1 /* seconds, smallest retry timeout */
 
+/*
+ * return refresh period
+ * within configured and defined lower and upper bound limits
+ */
+static inline time_t
+within_refresh_limits(xfrd_zone_type* zone, time_t refresh)
+{
+	return (time_t)zone->zone_options->pattern->max_refresh_time < refresh
+	     ? (time_t)zone->zone_options->pattern->max_refresh_time
+	     : (time_t)zone->zone_options->pattern->min_refresh_time > refresh
+	     ? (time_t)zone->zone_options->pattern->min_refresh_time
+	     : XFRD_LOWERBOUND_REFRESH > refresh
+	     ? XFRD_LOWERBOUND_REFRESH : refresh;
+}
+
+/*
+ * return the zone's refresh period (from the on disk stored SOA)
+ * within configured and defined lower and upper bound limits
+ */
+static inline time_t
+limited_soa_disk_refresh(xfrd_zone_type* zone)
+{
+	return within_refresh_limits(zone, ntohl(zone->soa_disk.refresh));
+}
+
+/*
+ * return retry period
+ * within configured and defined lower and upper bound limits
+ */
+static inline time_t
+within_retry_limits(xfrd_zone_type* zone, time_t retry)
+{
+	return (time_t)zone->zone_options->pattern->max_retry_time < retry
+	     ? (time_t)zone->zone_options->pattern->max_retry_time
+	     : (time_t)zone->zone_options->pattern->min_retry_time > retry
+	     ? (time_t)zone->zone_options->pattern->min_retry_time
+	     : XFRD_LOWERBOUND_RETRY > retry
+	     ? XFRD_LOWERBOUND_RETRY : retry;
+}
+
+/*
+ * return the zone's retry period (from the on disk stored SOA)
+ * within configured and defined lower and upper bound limits
+ */
+static inline time_t
+limited_soa_disk_retry(xfrd_zone_type* zone)
+{
+	return within_retry_limits(zone, ntohl(zone->soa_disk.retry));
+}
+
+/* return the zone's expire period (from the on disk stored SOA) */
+static inline time_t
+soa_disk_expire(xfrd_zone_type* zone)
+{
+	return ntohl(zone->soa_disk.expire);
+}
+
 extern xfrd_state_type* xfrd;
 
 /* start xfrd, new start. Pass socket to server_main. */


### PR DESCRIPTION
Specified in XFRD_LOWERBOUND_REFRESH and XFRD_LOWERBOUND_RETRY

They have moved to xfrd.h too so xfrd-disk.c can use them too.
This is a first step in addressing issue #103 