### PR TITLE
Features/min expire time option

### DIFF
--- a/configlexer.lex
+++ b/configlexer.lex
@@ -295,6 +295,7 @@ max-refresh-time{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_MAX_REFRESH_TIM
 min-refresh-time{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_MIN_REFRESH_TIME;}
 max-retry-time{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_MAX_RETRY_TIME;}
 min-retry-time{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_MIN_RETRY_TIME;}
+min-expire-time{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_MIN_EXPIRE_TIME;}
 multi-master-check{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_MULTI_MASTER_CHECK;}
 tls-service-key{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_SERVICE_KEY;}
 tls-service-ocsp{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_SERVICE_OCSP;}

--- a/configparser.y
+++ b/configparser.y
@@ -33,6 +33,7 @@ extern config_parser_state_type *cfg_parser;
 
 static void append_acl(struct acl_options **list, struct acl_options *acl);
 static int parse_boolean(const char *str, int *bln);
+static int parse_expire_expr(const char *str, long long *num, uint8_t *expr);
 static int parse_number(const char *str, long long *num);
 static int parse_range(const char *str, long long *low, long long *high);
 %}
@@ -161,6 +162,7 @@ static int parse_range(const char *str, long long *low, long long *high);
 %token VAR_MIN_REFRESH_TIME
 %token VAR_MAX_RETRY_TIME
 %token VAR_MIN_RETRY_TIME
+%token VAR_MIN_EXPIRE_TIME
 %token VAR_MULTI_MASTER_CHECK
 %token VAR_SIZE_LIMIT_XFR
 %token VAR_ZONESTATS
@@ -857,7 +859,19 @@ pattern_or_zone_option:
     {
       cfg_parser->pattern->min_retry_time = $2;
       cfg_parser->pattern->min_retry_time_is_default = 0;
-    } ;
+    } 
+  | VAR_MIN_EXPIRE_TIME STRING
+    {
+      long long num;
+      uint8_t expr;
+
+      if (!parse_expire_expr($2, &num, &expr)) {
+        yyerror("expected an expire time in seconds or \"refresh+retry+1\"");
+        YYABORT; /* trigger a parser error */
+      }
+      cfg_parser->pattern->min_expire_time = num;
+      cfg_parser->pattern->min_expire_time_expr = expr;
+    };
 
 ip_address:
     STRING
@@ -916,6 +930,21 @@ parse_boolean(const char *str, int *bln)
 	}
 
 	return 1;
+}
+
+static int
+parse_expire_expr(const char *str, long long *num, uint8_t *expr)
+{
+	if(parse_number(str, num)) {
+		*expr = EXPIRE_TIME_HAS_VALUE;
+		return 1;
+	}
+	if(strcmp(str, REFRESHPLUSRETRYPLUS1_STR) == 0) {
+		*num = 0;
+		*expr = REFRESHPLUSRETRYPLUS1;
+		return 1;
+	}
+	return 0;
 }
 
 static int

--- a/nsd-checkconf.c
+++ b/nsd-checkconf.c
@@ -317,6 +317,7 @@ config_print_zone(nsd_options_type* opt, const char* k, int s, const char *o,
 		ZONE_GET_INT(min_refresh_time, o, zone->pattern);
 		ZONE_GET_INT(max_retry_time, o, zone->pattern);
 		ZONE_GET_INT(min_retry_time, o, zone->pattern);
+		ZONE_GET_INT(min_expire_time, o, zone->pattern);
 		ZONE_GET_INT(size_limit_xfr, o, zone->pattern);
 #ifdef RATELIMIT
 		ZONE_GET_RRL(rrl_whitelist, o, zone->pattern);
@@ -348,6 +349,7 @@ config_print_zone(nsd_options_type* opt, const char* k, int s, const char *o,
 		ZONE_GET_INT(min_refresh_time, o, p);
 		ZONE_GET_INT(max_retry_time, o, p);
 		ZONE_GET_INT(min_retry_time, o, p);
+		ZONE_GET_INT(min_expire_time, o, p);
 		ZONE_GET_INT(size_limit_xfr, o, p);
 #ifdef RATELIMIT
 		ZONE_GET_RRL(rrl_whitelist, o, p);
@@ -483,6 +485,10 @@ static void print_zone_content_elems(pattern_options_type* pat)
 		printf("\tmax-retry-time: %d\n", pat->max_retry_time);
 	if(!pat->min_retry_time_is_default)
 		printf("\tmin-retry-time: %d\n", pat->min_retry_time);
+	if(pat->min_expire_time_expr == REFRESHPLUSRETRYPLUS1)
+		printf("\tmin-expire-time: " REFRESHPLUSRETRYPLUS1_STR "\n");
+	else if(pat->min_expire_time_expr == EXPIRE_TIME_HAS_VALUE)
+		printf("\tmin-expire-time: %d\n", pat->min_expire_time);
 	if(pat->size_limit_xfr != 0)
 		printf("\tsize-limit-xfr: %llu\n",
 			(long long unsigned)pat->size_limit_xfr);

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -745,6 +745,14 @@ used, followed by an exponential backoff, but this option restricts that value.
 .B min\-retry\-time:\fR <seconds>
 Limit retry time for secondary zones.
 .TP
+.B min\-expire\-time:\fR <seconds or refresh+retry+1>
+Limit expire time for secondary zones.  The value can be expressed either by a
+number of seconds, or the string "refresh+retry+1".  With the latter the expire
+time will be lower bound to the refresh plus the retry value from the SOA
+record, plus 1.  The refresh and retry values will be subject to the bounds
+configured with max\-refresh\-time, min\-refresh\-time, max\-retry\-time and
+min\-retry\-time if given.
+.TP
 .B zonestats:\fR <name>
 When compiled with \-\-enable\-zone\-stats NSD can collect statistics per zone.
 This name gives the group where statistics are added to.  The groups are

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -357,6 +357,10 @@ remote-control:
 	#min-refresh-time: 0
 	#max-retry-time: 1209600
 	#min-retry-time: 0
+	# Lower bound of expire interval in seconds.  The value can be "refresh+retry+1"
+	# in which case the lower bound of expire interval is the sum of the refresh and
+	# retry values (limited to the bounds given with the above parameters), plus 1.
+	#min-expire-time: 0
 
 	# Slave server tries zone transfer to all masters and picks highest
 	# zone version available, for when masters have different versions.

--- a/options.c
+++ b/options.c
@@ -755,6 +755,16 @@ zone_options_create(region_type* region)
 /* true is booleans are the same truth value */
 #define booleq(x,y) ( ((x) && (y)) || (!(x) && !(y)) )
 
+/* true is min_expire_time_expr has either an equal known value
+ * or none of these known values but booleanally equal
+ */
+#define expire_expr_eq(x,y) (  (  (x) == REFRESHPLUSRETRYPLUS1 \
+                               && (y) == REFRESHPLUSRETRYPLUS1 ) \
+                            || (  (x) != REFRESHPLUSRETRYPLUS1 \
+                               && (y) != REFRESHPLUSRETRYPLUS1 \
+                               && booleq((x), (y))))
+
+
 int
 acl_equal(struct acl_options* p, struct acl_options* q)
 {
@@ -817,6 +827,8 @@ pattern_options_create(region_type* region)
 	p->max_retry_time_is_default = 1;
 	p->min_retry_time = 0;
 	p->min_retry_time_is_default = 1;
+	p->min_expire_time = 0;
+	p->min_expire_time_expr = EXPIRE_TIME_IS_DEFAULT;
 #ifdef RATELIMIT
 	p->rrl_whitelist = 0;
 #endif
@@ -948,6 +960,8 @@ copy_pat_fixed(region_type* region, struct pattern_options* orig,
 	orig->max_retry_time_is_default = p->max_retry_time_is_default;
 	orig->min_retry_time = p->min_retry_time;
 	orig->min_retry_time_is_default = p->min_retry_time_is_default;
+	orig->min_expire_time = p->min_expire_time;
+	orig->min_expire_time_expr = p->min_expire_time_expr;
 #ifdef RATELIMIT
 	orig->rrl_whitelist = p->rrl_whitelist;
 #endif
@@ -1034,6 +1048,9 @@ pattern_options_equal(struct pattern_options* p, struct pattern_options* q)
 	if(p->min_retry_time != q->min_retry_time) return 0;
 	if(!booleq(p->min_retry_time_is_default,
 		q->min_retry_time_is_default)) return 0;
+	if(p->min_expire_time != q->min_expire_time) return 0;
+	if(!expire_expr_eq(p->min_expire_time_expr,
+		q->min_expire_time_expr)) return 0;
 #ifdef RATELIMIT
 	if(p->rrl_whitelist != q->rrl_whitelist) return 0;
 #endif
@@ -1198,6 +1215,8 @@ pattern_options_marshal(struct buffer* b, struct pattern_options* p)
 	marshal_u8(b, p->max_retry_time_is_default);
 	marshal_u32(b, p->min_retry_time);
 	marshal_u8(b, p->min_retry_time_is_default);
+	marshal_u32(b, p->min_expire_time);
+	marshal_u8(b, p->min_expire_time_expr);
 	marshal_u8(b, p->multi_master_check);
 }
 
@@ -1230,6 +1249,8 @@ pattern_options_unmarshal(region_type* r, struct buffer* b)
 	p->max_retry_time_is_default = unmarshal_u8(b);
 	p->min_retry_time = unmarshal_u32(b);
 	p->min_retry_time_is_default = unmarshal_u8(b);
+	p->min_expire_time = unmarshal_u32(b);
+	p->min_expire_time_expr = unmarshal_u8(b);
 	p->multi_master_check = unmarshal_u8(b);
 	return p;
 }
@@ -1999,6 +2020,10 @@ config_apply_pattern(struct pattern_options *dest, const char* name)
 	if(!pat->min_retry_time_is_default) {
 		dest->min_retry_time = pat->min_retry_time;
 		dest->min_retry_time_is_default = 0;
+	}
+	if(!expire_time_is_default(pat->min_expire_time_expr)) {
+		dest->min_expire_time = pat->min_expire_time;
+		dest->min_expire_time_expr = pat->min_expire_time_expr;
 	}
 	dest->size_limit_xfr = pat->size_limit_xfr;
 #ifdef RATELIMIT

--- a/options.h
+++ b/options.h
@@ -193,6 +193,17 @@ struct cpu_map_option {
 };
 
 /*
+ * Defines for min_expire_time_expr value
+ */
+#define EXPIRE_TIME_HAS_VALUE     0
+#define EXPIRE_TIME_IS_DEFAULT    1
+#define REFRESHPLUSRETRYPLUS1     2
+#define REFRESHPLUSRETRYPLUS1_STR "refresh+retry+1"
+#define expire_time_is_default(x) (!(  (x) == REFRESHPLUSRETRYPLUS1 \
+                                    || (x) == EXPIRE_TIME_HAS_VALUE ))
+
+
+/*
  * Pattern of zone options, used to contain options for zone(s).
  */
 struct pattern_options {
@@ -222,6 +233,12 @@ struct pattern_options {
 	uint8_t max_retry_time_is_default;
 	uint32_t min_retry_time;
 	uint8_t min_retry_time_is_default;
+	uint32_t min_expire_time;
+	/* min_expir_time_expr is either a known value (REFRESHPLUSRETRYPLUS1
+	 * or EXPIRE_EXPR_HAS_VALUE) or else min_expire_time is the default.
+	 * This can be tested with expire_time_is_default(x) define.
+	 */
+	uint8_t min_expire_time_expr;
 	uint64_t size_limit_xfr;
 	uint8_t multi_master_check;
 } ATTR_PACKED;

--- a/xfrd-disk.c
+++ b/xfrd-disk.c
@@ -312,7 +312,7 @@ xfrd_read_state(struct xfrd_state* xfrd)
 			xfrd_deactivate_zone(zone);
 			zone->state = state;
 			xfrd_set_timer(zone,
-				within_refresh_limits(zone, timeout));
+				within_refresh_bounds(zone, timeout));
 		}	
 		if((zone->soa_nsd_acquired == 0 && soa_nsd_acquired_read == 0 &&
 			soa_disk_acquired_read == 0) ||
@@ -322,7 +322,7 @@ xfrd_read_state(struct xfrd_state* xfrd)
 			xfrd_deactivate_zone(zone);
 			zone->state = state;
 			xfrd_set_timer(zone,
-				within_retry_limits(zone, timeout));
+				within_retry_bounds(zone, timeout));
 		}
 
 		/* handle as an incoming SOA. */

--- a/xfrd-disk.c
+++ b/xfrd-disk.c
@@ -311,8 +311,8 @@ xfrd_read_state(struct xfrd_state* xfrd)
 			&& zone->soa_nsd.serial == soa_nsd_read.serial) {
 			xfrd_deactivate_zone(zone);
 			zone->state = state;
-			xfrd_set_timer(zone, timeout > XFRD_LOWERBOUND_REFRESH
-			                   ? timeout : XFRD_LOWERBOUND_REFRESH);
+			xfrd_set_timer(zone,
+				within_refresh_limits(zone, timeout));
 		}	
 		if((zone->soa_nsd_acquired == 0 && soa_nsd_acquired_read == 0 &&
 			soa_disk_acquired_read == 0) ||
@@ -321,8 +321,8 @@ xfrd_read_state(struct xfrd_state* xfrd)
 			 * storm of attempts on some master servers */
 			xfrd_deactivate_zone(zone);
 			zone->state = state;
-			xfrd_set_timer(zone, timeout > XFRD_LOWERBOUND_RETRY
-			                   ? timeout : XFRD_LOWERBOUND_RETRY);
+			xfrd_set_timer(zone,
+				within_retry_limits(zone, timeout));
 		}
 
 		/* handle as an incoming SOA. */

--- a/xfrd-disk.c
+++ b/xfrd-disk.c
@@ -311,7 +311,8 @@ xfrd_read_state(struct xfrd_state* xfrd)
 			&& zone->soa_nsd.serial == soa_nsd_read.serial) {
 			xfrd_deactivate_zone(zone);
 			zone->state = state;
-			xfrd_set_timer(zone, timeout);
+			xfrd_set_timer(zone, timeout > XFRD_LOWERBOUND_REFRESH
+			                   ? timeout : XFRD_LOWERBOUND_REFRESH);
 		}	
 		if((zone->soa_nsd_acquired == 0 && soa_nsd_acquired_read == 0 &&
 			soa_disk_acquired_read == 0) ||
@@ -320,7 +321,8 @@ xfrd_read_state(struct xfrd_state* xfrd)
 			 * storm of attempts on some master servers */
 			xfrd_deactivate_zone(zone);
 			zone->state = state;
-			xfrd_set_timer(zone, timeout);
+			xfrd_set_timer(zone, timeout > XFRD_LOWERBOUND_RETRY
+			                   ? timeout : XFRD_LOWERBOUND_RETRY);
 		}
 
 		/* handle as an incoming SOA. */

--- a/xfrd.c
+++ b/xfrd.c
@@ -771,7 +771,7 @@ xfrd_set_timer_refresh(xfrd_zone_type* zone)
 	                                ? set_refresh : set_expire );
 
 	/* set point in time to period for xfrd_set_timer() */
-	xfrd_set_timer(zone, within_refresh_limits(zone,
+	xfrd_set_timer(zone, within_refresh_bounds(zone,
 		  set > xfrd_time()
 		? set - xfrd_time() : XFRD_LOWERBOUND_REFRESH));
 }
@@ -799,15 +799,15 @@ xfrd_set_timer_retry(xfrd_zone_type* zone)
 	/* set timer for next retry or expire timeout if earlier. */
 	if(zone->soa_disk_acquired == 0) {
 		/* if no information, use reasonable timeout
-		 * within configured and defined limits
+		 * within configured and defined bounds
 		 */
 		xfrd_set_timer(zone,
-			within_retry_limits(zone, zone->fresh_xfr_timeout
+			within_retry_bounds(zone, zone->fresh_xfr_timeout
 				+ random_generate(zone->fresh_xfr_timeout)));
 		return;
 	}
-	/* exponential backoff within configured and defined limits */
-	set_retry = within_retry_limits(zone,
+	/* exponential backoff within configured and defined bounds */
+	set_retry = within_retry_bounds(zone,
 			ntohl(zone->soa_disk.retry * mult));
 	if(zone->state == xfrd_zone_expired) {
 		xfrd_set_timer(zone, set_retry);
@@ -821,11 +821,11 @@ xfrd_set_timer_retry(xfrd_zone_type* zone)
 	}
 	/* Not expired, but next retry will be > than expire timeout.
 	 * Retry when the expire timeout runs out.
-	 * set_expire is below retry upper bound limits (if statement above),
-	 * but not necessarily above lower bound limits,
-	 * so use within_retry_limits() again.
+	 * set_expire is below retry upper bounds (if statement above),
+	 * but not necessarily above lower bounds,
+	 * so use within_retry_bounds() again.
 	 */
-	xfrd_set_timer(zone, within_retry_limits(zone,
+	xfrd_set_timer(zone, within_retry_bounds(zone,
 		  set_expire > xfrd_time()
 		? set_expire - xfrd_time() : XFRD_LOWERBOUND_RETRY));
 }

--- a/xfrd.c
+++ b/xfrd.c
@@ -766,7 +766,7 @@ xfrd_set_timer_refresh(xfrd_zone_type* zone)
 	}
 	/* refresh or expire timeout, whichever is earlier */
 	set_refresh = bound_soa_disk_refresh(zone);
-	set_expire  = soa_disk_expire(zone);
+	set_expire  = bound_soa_disk_expire(zone);
 	set = zone->soa_disk_acquired + ( set_refresh < set_expire
 	                                ? set_refresh : set_expire );
 
@@ -814,7 +814,7 @@ xfrd_set_timer_retry(xfrd_zone_type* zone)
 		return;
 	}
 	/* retry or expire timeout, whichever is earlier */
-	set_expire = zone->soa_disk_acquired + soa_disk_expire(zone);
+	set_expire = zone->soa_disk_acquired + bound_soa_disk_expire(zone);
 	if(xfrd_time() + set_retry < set_expire) {
 		xfrd_set_timer(zone, set_retry);
 		return;
@@ -877,7 +877,7 @@ xfrd_handle_zone(int ATTR_UNUSED(fd), short event, void* arg)
 	{
 		if (zone->state != xfrd_zone_expired &&
 			xfrd_time() >= zone->soa_disk_acquired
-					+ soa_disk_expire(zone)) {
+					+ bound_soa_disk_expire(zone)) {
 			/* zone expired */
 			log_msg(LOG_ERR, "xfrd: zone %s has expired", zone->apex_str);
 			xfrd_set_zone_state(zone, xfrd_zone_expired);
@@ -1202,13 +1202,13 @@ xfrd_handle_incoming_soa(xfrd_zone_type* zone,
 			xfrd_set_zone_state(zone, xfrd_zone_ok);
 			zone->round_num = -1;
 			xfrd_set_timer_refresh(zone);
-		} else if(seconds_since_acquired < soa_disk_expire(zone))
+		} else if(seconds_since_acquired < bound_soa_disk_expire(zone))
 		{
 			/* zone refreshing */
 			xfrd_set_zone_state(zone, xfrd_zone_refreshing);
 			xfrd_set_refresh_now(zone);
 		}
-		if(seconds_since_acquired >= soa_disk_expire(zone)) {
+		if(seconds_since_acquired >= bound_soa_disk_expire(zone)) {
 			/* zone expired */
 			xfrd_set_zone_state(zone, xfrd_zone_expired);
 			xfrd_set_refresh_now(zone);

--- a/xfrd.c
+++ b/xfrd.c
@@ -808,7 +808,7 @@ xfrd_set_timer_retry(xfrd_zone_type* zone)
 	}
 	/* exponential backoff within configured and defined bounds */
 	set_retry = within_retry_bounds(zone,
-			ntohl(zone->soa_disk.retry * mult));
+			ntohl(zone->soa_disk.retry) * mult);
 	if(zone->state == xfrd_zone_expired) {
 		xfrd_set_timer(zone, set_retry);
 		return;

--- a/xfrd.c
+++ b/xfrd.c
@@ -765,7 +765,7 @@ xfrd_set_timer_refresh(xfrd_zone_type* zone)
 		return;
 	}
 	/* refresh or expire timeout, whichever is earlier */
-	set_refresh = limited_soa_disk_refresh(zone);
+	set_refresh = bound_soa_disk_refresh(zone);
 	set_expire  = soa_disk_expire(zone);
 	set = zone->soa_disk_acquired + ( set_refresh < set_expire
 	                                ? set_refresh : set_expire );
@@ -884,7 +884,7 @@ xfrd_handle_zone(int ATTR_UNUSED(fd), short event, void* arg)
 		}
 		else if(zone->state == xfrd_zone_ok &&
 			xfrd_time() >= zone->soa_disk_acquired
-			               + limited_soa_disk_refresh(zone)) {
+			               + bound_soa_disk_refresh(zone)) {
 			/* zone goes to refreshing state. */
 			DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: zone %s is refreshing", zone->apex_str));
 			xfrd_set_zone_state(zone, xfrd_zone_refreshing);
@@ -1196,7 +1196,7 @@ xfrd_handle_incoming_soa(xfrd_zone_type* zone,
 		seconds_since_acquired =
 			  xfrd_time() > zone->soa_disk_acquired
 			? xfrd_time() - zone->soa_disk_acquired : 0;
-		if(seconds_since_acquired < limited_soa_disk_refresh(zone))
+		if(seconds_since_acquired < bound_soa_disk_refresh(zone))
 		{
 			/* zone ok, wait for refresh time */
 			xfrd_set_zone_state(zone, xfrd_zone_ok);

--- a/xfrd.c
+++ b/xfrd.c
@@ -759,40 +759,28 @@ xfrd_set_timer_refresh(xfrd_zone_type* zone)
 {
 	time_t set_refresh;
 	time_t set_expire;
-	time_t set_min;
 	time_t set;
 	if(zone->soa_disk_acquired == 0 || zone->state != xfrd_zone_ok) {
 		xfrd_set_timer_retry(zone);
 		return;
 	}
 	/* refresh or expire timeout, whichever is earlier */
-	set_refresh = ntohl(zone->soa_disk.refresh);
-	if (set_refresh > (time_t)zone->zone_options->pattern->max_refresh_time)
-		set_refresh = zone->zone_options->pattern->max_refresh_time;
-	else if (set_refresh < (time_t)zone->zone_options->pattern->min_refresh_time)
-		set_refresh = zone->zone_options->pattern->min_refresh_time;
-	set_refresh += zone->soa_disk_acquired;
-	set_expire = zone->soa_disk_acquired + ntohl(zone->soa_disk.expire);
-	if(set_refresh < set_expire)
-		set = set_refresh;
-	else set = set_expire;
-	set_min = zone->soa_disk_acquired + XFRD_LOWERBOUND_REFRESH;
-	if(set < set_min)
-		set = set_min;
-	if(set < xfrd_time())
-		set = 0;
-	else	set -= xfrd_time();
-	if(set > XFRD_TRANSFER_TIMEOUT_MAX)
-		set = XFRD_TRANSFER_TIMEOUT_MAX;
-	else if (set < XFRD_LOWERBOUND_REFRESH)
-		set = XFRD_LOWERBOUND_REFRESH;
-	xfrd_set_timer(zone, set);
+	set_refresh = limited_soa_disk_refresh(zone);
+	set_expire  = soa_disk_expire(zone);
+	set = zone->soa_disk_acquired + ( set_refresh < set_expire
+	                                ? set_refresh : set_expire );
+
+	/* set point in time to period for xfrd_set_timer() */
+	xfrd_set_timer(zone, within_refresh_limits(zone,
+		  set > xfrd_time()
+		? set - xfrd_time() : XFRD_LOWERBOUND_REFRESH));
 }
 
 static void
 xfrd_set_timer_retry(xfrd_zone_type* zone)
 {
 	time_t set_retry;
+	time_t set_expire;
 	int mult;
 	/* perform exponential backoff in all the cases */
 	if(zone->fresh_xfr_timeout == 0)
@@ -810,41 +798,36 @@ xfrd_set_timer_retry(xfrd_zone_type* zone)
 
 	/* set timer for next retry or expire timeout if earlier. */
 	if(zone->soa_disk_acquired == 0) {
-		/* if no information, use reasonable timeout */
-		set_retry = zone->fresh_xfr_timeout
-			+ random_generate(zone->fresh_xfr_timeout);
-		if(set_retry < XFRD_LOWERBOUND_RETRY)
-			set_retry = XFRD_LOWERBOUND_RETRY;
-		xfrd_set_timer(zone, set_retry);
-	} else if(zone->state == xfrd_zone_expired ||
-		xfrd_time() + (time_t)ntohl(zone->soa_disk.retry)*mult <
-		zone->soa_disk_acquired + (time_t)ntohl(zone->soa_disk.expire))
-	{
-		set_retry = ntohl(zone->soa_disk.retry);
-		set_retry *= mult;
-		if(set_retry > XFRD_TRANSFER_TIMEOUT_MAX)
-			set_retry = XFRD_TRANSFER_TIMEOUT_MAX;
-		if(set_retry > (time_t)zone->zone_options->pattern->max_retry_time)
-			set_retry = zone->zone_options->pattern->max_retry_time;
-		else if(set_retry < (time_t)zone->zone_options->pattern->min_retry_time)
-			set_retry = zone->zone_options->pattern->min_retry_time;
-		if(set_retry < XFRD_LOWERBOUND_RETRY)
-			set_retry = XFRD_LOWERBOUND_RETRY;
-		xfrd_set_timer(zone, set_retry);
-	} else {
-		set_retry = ntohl(zone->soa_disk.expire);
-		if(set_retry > XFRD_TRANSFER_TIMEOUT_MAX)
-			set_retry = XFRD_TRANSFER_TIMEOUT_MAX;
-		if(set_retry < XFRD_LOWERBOUND_RETRY)
-			xfrd_set_timer(zone, XFRD_LOWERBOUND_RETRY);
-		else {
-			if(zone->soa_disk_acquired + set_retry
-					< xfrd_time() + XFRD_LOWERBOUND_RETRY)
-				xfrd_set_timer(zone, XFRD_LOWERBOUND_RETRY);
-			else xfrd_set_timer(zone, zone->soa_disk_acquired +
-				set_retry - xfrd_time());
-		}
+		/* if no information, use reasonable timeout
+		 * within configured and defined limits
+		 */
+		xfrd_set_timer(zone,
+			within_retry_limits(zone, zone->fresh_xfr_timeout
+				+ random_generate(zone->fresh_xfr_timeout)));
+		return;
 	}
+	/* exponential backoff within configured and defined limits */
+	set_retry = within_retry_limits(zone,
+			ntohl(zone->soa_disk.retry * mult));
+	if(zone->state == xfrd_zone_expired) {
+		xfrd_set_timer(zone, set_retry);
+		return;
+	}
+	/* retry or expire timeout, whichever is earlier */
+	set_expire = zone->soa_disk_acquired + soa_disk_expire(zone);
+	if(xfrd_time() + set_retry < set_expire) {
+		xfrd_set_timer(zone, set_retry);
+		return;
+	}
+	/* Not expired, but next retry will be > than expire timeout.
+	 * Retry when the expire timeout runs out.
+	 * set_expire is below retry upper bound limits (if statement above),
+	 * but not necessarily above lower bound limits,
+	 * so use within_retry_limits() again.
+	 */
+	xfrd_set_timer(zone, within_retry_limits(zone,
+		  set_expire > xfrd_time()
+		? set_expire - xfrd_time() : XFRD_LOWERBOUND_RETRY));
 }
 
 void
@@ -893,13 +876,15 @@ xfrd_handle_zone(int ATTR_UNUSED(fd), short event, void* arg)
 	if(zone->soa_disk_acquired)
 	{
 		if (zone->state != xfrd_zone_expired &&
-			xfrd_time() >= zone->soa_disk_acquired + (time_t)ntohl(zone->soa_disk.expire)) {
+			xfrd_time() >= zone->soa_disk_acquired
+					+ soa_disk_expire(zone)) {
 			/* zone expired */
 			log_msg(LOG_ERR, "xfrd: zone %s has expired", zone->apex_str);
 			xfrd_set_zone_state(zone, xfrd_zone_expired);
 		}
 		else if(zone->state == xfrd_zone_ok &&
-			xfrd_time() >= zone->soa_disk_acquired + (time_t)ntohl(zone->soa_disk.refresh)) {
+			xfrd_time() >= zone->soa_disk_acquired
+			               + limited_soa_disk_refresh(zone)) {
 			/* zone goes to refreshing state. */
 			DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: zone %s is refreshing", zone->apex_str));
 			xfrd_set_zone_state(zone, xfrd_zone_refreshing);
@@ -1156,6 +1141,8 @@ xfrd_set_timer(xfrd_zone_type* zone, time_t t)
 {
 	int fd = zone->zone_handler.ev_fd;
 	int fl = ((fd == -1)?EV_TIMEOUT:zone->zone_handler_flags);
+	if(t > XFRD_TRANSFER_TIMEOUT_MAX)
+		t = XFRD_TRANSFER_TIMEOUT_MAX;
 	/* randomize the time, within 90%-100% of original */
 	/* not later so zones cannot expire too late */
 	/* only for times far in the future */
@@ -1184,6 +1171,7 @@ void
 xfrd_handle_incoming_soa(xfrd_zone_type* zone,
 	xfrd_soa_type* soa, time_t acquired)
 {
+	time_t seconds_since_acquired;
 	if(soa == NULL) {
 		/* nsd no longer has a zone in memory */
 		zone->soa_nsd_acquired = 0;
@@ -1205,22 +1193,22 @@ xfrd_handle_incoming_soa(xfrd_zone_type* zone,
 		xfrd->write_zonefile_needed = 1;
 		/* reset exponential backoff, we got a normal timer now */
 		zone->fresh_xfr_timeout = 0;
-		if(xfrd_time() - zone->soa_disk_acquired
-			< (time_t)ntohl(zone->soa_disk.refresh))
+		seconds_since_acquired =
+			  xfrd_time() > zone->soa_disk_acquired
+			? xfrd_time() - zone->soa_disk_acquired : 0;
+		if(seconds_since_acquired < limited_soa_disk_refresh(zone))
 		{
 			/* zone ok, wait for refresh time */
 			xfrd_set_zone_state(zone, xfrd_zone_ok);
 			zone->round_num = -1;
 			xfrd_set_timer_refresh(zone);
-		} else if(xfrd_time() - zone->soa_disk_acquired
-			< (time_t)ntohl(zone->soa_disk.expire))
+		} else if(seconds_since_acquired < soa_disk_expire(zone))
 		{
 			/* zone refreshing */
 			xfrd_set_zone_state(zone, xfrd_zone_refreshing);
 			xfrd_set_refresh_now(zone);
 		}
-		if(xfrd_time() - zone->soa_disk_acquired
-			>= (time_t)ntohl(zone->soa_disk.expire)) {
+		if(seconds_since_acquired >= soa_disk_expire(zone)) {
 			/* zone expired */
 			xfrd_set_zone_state(zone, xfrd_zone_expired);
 			xfrd_set_refresh_now(zone);

--- a/xfrd.h
+++ b/xfrd.h
@@ -246,6 +246,8 @@ enum xfrd_packet_result {
 
 #define XFRD_TRANSFER_TIMEOUT_START 10 /* empty zone timeout is between x and 2*x seconds */
 #define XFRD_TRANSFER_TIMEOUT_MAX 86400 /* empty zone timeout max expbackoff */
+#define XFRD_LOWERBOUND_REFRESH 1 /* seconds, smallest refresh timeout */
+#define XFRD_LOWERBOUND_RETRY 1 /* seconds, smallest retry timeout */
 
 extern xfrd_state_type* xfrd;
 

--- a/xfrd.h
+++ b/xfrd.h
@@ -269,7 +269,7 @@ within_refresh_bounds(xfrd_zone_type* zone, time_t refresh)
  * within configured and defined lower and upper bounds
  */
 static inline time_t
-limited_soa_disk_refresh(xfrd_zone_type* zone)
+bound_soa_disk_refresh(xfrd_zone_type* zone)
 {
 	return within_refresh_bounds(zone, ntohl(zone->soa_disk.refresh));
 }
@@ -294,7 +294,7 @@ within_retry_bounds(xfrd_zone_type* zone, time_t retry)
  * within configured and defined lower and upper bounds
  */
 static inline time_t
-limited_soa_disk_retry(xfrd_zone_type* zone)
+bound_soa_disk_retry(xfrd_zone_type* zone)
 {
 	return within_retry_bounds(zone, ntohl(zone->soa_disk.retry));
 }

--- a/xfrd.h
+++ b/xfrd.h
@@ -299,11 +299,31 @@ bound_soa_disk_retry(xfrd_zone_type* zone)
 	return within_retry_bounds(zone, ntohl(zone->soa_disk.retry));
 }
 
+/*
+ * return expire period
+ * within configured and defined lower bounds
+ */
+static inline time_t
+within_expire_bounds(xfrd_zone_type* zone, time_t expire)
+{
+	switch (zone->zone_options->pattern->min_expire_time_expr) {
+	case EXPIRE_TIME_HAS_VALUE:
+		return (time_t)zone->zone_options->pattern->min_expire_time > expire
+		     ? (time_t)zone->zone_options->pattern->min_expire_time : expire;
+
+	case REFRESHPLUSRETRYPLUS1:
+		return bound_soa_disk_refresh(zone)
+		     + bound_soa_disk_retry(zone) + 1;
+	default:
+		return expire;
+	}
+}
+
 /* return the zone's expire period (from the on disk stored SOA) */
 static inline time_t
-soa_disk_expire(xfrd_zone_type* zone)
+bound_soa_disk_expire(xfrd_zone_type* zone)
 {
-	return ntohl(zone->soa_disk.expire);
+	return within_expire_bounds(zone, ntohl(zone->soa_disk.expire));
 }
 
 extern xfrd_state_type* xfrd;

--- a/xfrd.h
+++ b/xfrd.h
@@ -251,10 +251,10 @@ enum xfrd_packet_result {
 
 /*
  * return refresh period
- * within configured and defined lower and upper bound limits
+ * within configured and defined lower and upper bounds
  */
 static inline time_t
-within_refresh_limits(xfrd_zone_type* zone, time_t refresh)
+within_refresh_bounds(xfrd_zone_type* zone, time_t refresh)
 {
 	return (time_t)zone->zone_options->pattern->max_refresh_time < refresh
 	     ? (time_t)zone->zone_options->pattern->max_refresh_time
@@ -266,20 +266,20 @@ within_refresh_limits(xfrd_zone_type* zone, time_t refresh)
 
 /*
  * return the zone's refresh period (from the on disk stored SOA)
- * within configured and defined lower and upper bound limits
+ * within configured and defined lower and upper bounds
  */
 static inline time_t
 limited_soa_disk_refresh(xfrd_zone_type* zone)
 {
-	return within_refresh_limits(zone, ntohl(zone->soa_disk.refresh));
+	return within_refresh_bounds(zone, ntohl(zone->soa_disk.refresh));
 }
 
 /*
  * return retry period
- * within configured and defined lower and upper bound limits
+ * within configured and defined lower and upper bounds
  */
 static inline time_t
-within_retry_limits(xfrd_zone_type* zone, time_t retry)
+within_retry_bounds(xfrd_zone_type* zone, time_t retry)
 {
 	return (time_t)zone->zone_options->pattern->max_retry_time < retry
 	     ? (time_t)zone->zone_options->pattern->max_retry_time
@@ -291,12 +291,12 @@ within_retry_limits(xfrd_zone_type* zone, time_t retry)
 
 /*
  * return the zone's retry period (from the on disk stored SOA)
- * within configured and defined lower and upper bound limits
+ * within configured and defined lower and upper bounds
  */
 static inline time_t
 limited_soa_disk_retry(xfrd_zone_type* zone)
 {
-	return within_retry_limits(zone, ntohl(zone->soa_disk.retry));
+	return within_retry_bounds(zone, ntohl(zone->soa_disk.retry));
 }
 
 /* return the zone's expire period (from the on disk stored SOA) */

--- a/xfrd.h
+++ b/xfrd.h
@@ -249,6 +249,63 @@ enum xfrd_packet_result {
 #define XFRD_LOWERBOUND_REFRESH 1 /* seconds, smallest refresh timeout */
 #define XFRD_LOWERBOUND_RETRY 1 /* seconds, smallest retry timeout */
 
+/*
+ * return refresh period
+ * within configured and defined lower and upper bound limits
+ */
+static inline time_t
+within_refresh_limits(xfrd_zone_type* zone, time_t refresh)
+{
+	return (time_t)zone->zone_options->pattern->max_refresh_time < refresh
+	     ? (time_t)zone->zone_options->pattern->max_refresh_time
+	     : (time_t)zone->zone_options->pattern->min_refresh_time > refresh
+	     ? (time_t)zone->zone_options->pattern->min_refresh_time
+	     : XFRD_LOWERBOUND_REFRESH > refresh
+	     ? XFRD_LOWERBOUND_REFRESH : refresh;
+}
+
+/*
+ * return the zone's refresh period (from the on disk stored SOA)
+ * within configured and defined lower and upper bound limits
+ */
+static inline time_t
+limited_soa_disk_refresh(xfrd_zone_type* zone)
+{
+	return within_refresh_limits(zone, ntohl(zone->soa_disk.refresh));
+}
+
+/*
+ * return retry period
+ * within configured and defined lower and upper bound limits
+ */
+static inline time_t
+within_retry_limits(xfrd_zone_type* zone, time_t retry)
+{
+	return (time_t)zone->zone_options->pattern->max_retry_time < retry
+	     ? (time_t)zone->zone_options->pattern->max_retry_time
+	     : (time_t)zone->zone_options->pattern->min_retry_time > retry
+	     ? (time_t)zone->zone_options->pattern->min_retry_time
+	     : XFRD_LOWERBOUND_RETRY > retry
+	     ? XFRD_LOWERBOUND_RETRY : retry;
+}
+
+/*
+ * return the zone's retry period (from the on disk stored SOA)
+ * within configured and defined lower and upper bound limits
+ */
+static inline time_t
+limited_soa_disk_retry(xfrd_zone_type* zone)
+{
+	return within_retry_limits(zone, ntohl(zone->soa_disk.retry));
+}
+
+/* return the zone's expire period (from the on disk stored SOA) */
+static inline time_t
+soa_disk_expire(xfrd_zone_type* zone)
+{
+	return ntohl(zone->soa_disk.expire);
+}
+
 extern xfrd_state_type* xfrd;
 
 /* start xfrd, new start. Pass socket to server_main. */

--- a/xfrd.h
+++ b/xfrd.h
@@ -312,8 +312,8 @@ within_expire_bounds(xfrd_zone_type* zone, time_t expire)
 		     ? (time_t)zone->zone_options->pattern->min_expire_time : expire;
 
 	case REFRESHPLUSRETRYPLUS1:
-		return bound_soa_disk_refresh(zone)
-		     + bound_soa_disk_retry(zone) + 1;
+		return bound_soa_disk_refresh(zone) + bound_soa_disk_retry(zone) + 1 > expire
+		     ? bound_soa_disk_refresh(zone) + bound_soa_disk_retry(zone) + 1 : expire;
 	default:
 		return expire;
 	}


### PR DESCRIPTION
Resolve Issue #103 : min-expire-time option.
To provide a lower bound for expire period.
Expressed in number of seconds or refresh+retry+1

When merged, this will merge in bugfix PR #106 too.