### PR TITLE
log old and new serials

### DIFF
--- a/xfrd.c
+++ b/xfrd.c
@@ -1942,12 +1942,12 @@ xfrd_parse_received_xfr_packet(xfrd_zone_type* zone, buffer_type* packet,
 		if(zone->soa_disk_acquired != 0 &&
 			zone->state != xfrd_zone_expired /* if expired - accept anything */ &&
 			compare_serial(ntohl(soa->serial), ntohl(zone->soa_disk.serial)) < 0) {
-			DEBUG(DEBUG_XFRD,1, (LOG_INFO,
-				"xfrd: zone %s ignoring old serial from %s",
-				zone->apex_str, zone->master->ip_address_spec));
-			VERBOSITY(1, (LOG_INFO,
-				"xfrd: zone %s ignoring old serial from %s",
-				zone->apex_str, zone->master->ip_address_spec));
+                        DEBUG(DEBUG_XFRD,1, (LOG_INFO,
+                                "xfrd: zone %s ignoring old serial (%u/%u) from %s",
+                                zone->apex_str, ntohl(zone->soa_disk.serial), ntohl(soa->serial), zone->master->ip_address_spec));
+                        VERBOSITY(1, (LOG_INFO,
+                                "xfrd: zone %s ignoring old serial (%u/%u) from %s",
+                                zone->apex_str, ntohl(zone->soa_disk.serial), ntohl(soa->serial), zone->master->ip_address_spec));
 			region_destroy(tempregion);
 			return xfrd_packet_bad;
 		}


### PR DESCRIPTION
This will log the old and new serial numbers.  Hmm.. the witespace is kinda weird, but I did do this as a patch off the 4.3.1 branch so maybe something changed upstream?