### PR TITLE
add ipv4 ifa_name support for ip-address configuration

### DIFF
--- a/test.conf
+++ b/test.conf
@@ -1,7 +1,6 @@
 server:
-    port: 8181
+    port: 2222
     username: gearnode
     debug-mode: yes
 
-    ip-address: ::1
     ip-address: lo0

--- a/test.conf
+++ b/test.conf
@@ -1,0 +1,7 @@
+server:
+    port: 8181
+    username: gearnode
+    debug-mode: yes
+
+    ip-address: ::1
+    ip-address: lo0

--- a/util.c
+++ b/util.c
@@ -266,6 +266,18 @@ lookup_by_id(lookup_table_type *table, int id)
 	return NULL;
 }
 
+char *
+xstrdup(const char *src) {
+  char *result = strdup(src);
+
+  if(!result) {
+    log_msg(LOG_ERR, "strdup failed: %s", strerror(errno));
+    exit(1);
+  }
+
+  return result;
+}
+
 void *
 xalloc(size_t size)
 {

--- a/util.h
+++ b/util.h
@@ -143,6 +143,7 @@ lookup_table_type *lookup_by_id(lookup_table_type table[], int id);
  * could not be allocated and exit the program.  These functions never
  * return NULL.
  */
+char *xstrdup(const char *src);
 void *xalloc(size_t size);
 void *xmallocarray(size_t num, size_t size);
 void *xalloc_zero(size_t size);
@@ -400,7 +401,7 @@ struct state_pretty_rr {
 struct state_pretty_rr* create_pretty_rr(struct region* region);
 /* print rr to file, returns 0 on failure(nothing is written) */
 int print_rr(FILE *out, struct state_pretty_rr* state, struct rr *record,
-	struct region* tmp_region, struct buffer* tmp_buffer); 
+	struct region* tmp_region, struct buffer* tmp_buffer);
 
 /*
  * Convert a numeric rcode value to a human readable string


### PR DESCRIPTION
# Proposal
Make it possible to use a network interface name for the `ip-address` configuration key.

# Rational
Not having to hardcode IP addresses (v4 and v6) in each NSD configuration file. 

E.g.
```
server:
    port: 53
    username: nsd
    debug-mode: yes

    ip-address: lo0
    ip-address: ext1

```

# State
The code of this patch is a proof of concept.