### PR TITLE
include config.h in compat/setproctitle.c and fix prototype of `setproctitle`

### DIFF
--- a/compat/setproctitle.c
+++ b/compat/setproctitle.c
@@ -6,9 +6,7 @@
  * See LICENSE for the license.
  *
  */
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
 
 #if defined(__linux)
 #include <assert.h>

--- a/configure.ac
+++ b/configure.ac
@@ -1313,7 +1313,7 @@ char *nsd_strptime(const char *s, const char *format, struct tm *tm);
 #ifdef __linux__
 #define HAVE_SETPROCTITLE 1
 #include <stdarg.h>
-void setproctitle(char *fmt, ...);
+void setproctitle(const char *fmt, ...);
 #endif
 #endif
 ])


### PR DESCRIPTION
- the include guard HAVE_CONFIG_H prevent the inclusion of the actual "config.h"
- setproctitle.c would include <libgen.h> which i am not sure if this is needed, if so config.h should include it?