### PR TITLE
minor header hygiene

### DIFF
--- a/compat/cpuset.c
+++ b/compat/cpuset.c
@@ -6,6 +6,7 @@
  * See LICENSE for the license.
  *
  */
+#include "config.h"
 #include "cpuset.h"
 
 #include <stdlib.h>

--- a/compat/cpuset.h
+++ b/compat/cpuset.h
@@ -8,7 +8,6 @@
  */
 #ifndef _CPUSET_H_
 #define _CPUSET_H_
-#include "config.h"
 
 #ifdef HAVE_SCHED_H
 # include <sched.h>

--- a/options.h
+++ b/options.h
@@ -10,7 +10,6 @@
 #ifndef OPTIONS_H
 #define OPTIONS_H
 
-#include "config.h"
 #include <stdarg.h>
 #include "region-allocator.h"
 #include "rbtree.h"

--- a/tpkg/mini_tdir.sh
+++ b/tpkg/mini_tdir.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # tdir that only exes the files.
 args="../.."
 if test "$1" = "-a"; then

--- a/tpkg/run_vm.sh
+++ b/tpkg/run_vm.sh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bash
+#!/bin/bash
 # run tdir tests from within a VM.  Looks for loopback addr.
 # if run not from within a VM, runs the tests as usual.
 # with one argument: run that tdir, otherwise, run all tdirs.


### PR DESCRIPTION
- no more recursive inclusion off config.h in cpuset.{c,h}
- remove unnecessary include in options.h
- fix missing shebang in test utils