### PR TITLE
fix 0-init of local ( stack ) buffer.

### DIFF
--- a/dname.c
+++ b/dname.c
@@ -109,7 +109,7 @@ dname_make_wire_from_packet(uint8_t *buf, buffer_type *packet,
 	const uint8_t *label;
 	ssize_t mark = -1;
 
-	memset(visited, 0, (buffer_limit(packet)+7)/8);
+	memset(visited, 0, sizeof(visited));
 
 	while (!done) {
 		if (!buffer_available(packet, 1)) {


### PR DESCRIPTION
`buffer_limit` might be bigger than the `MAX_PACKET_SIZE` of the local buffer

usually the `buffer_limit` is ensured during receiving data and it should
not be possible to trigger this stack overwrite with an malicious packet.
the buffer_limit in the default config i at least twice the MAX_PACKET_SIZE
and other not connected in any way to the size of the local buffer.

for correctnes, use the local buffer size for full zero initialization.

if parital initialization is wanted then the code should read
`memset(visited, 0, min(sizeof(visited), buffer_limit(buf)+7/8)`.
i went for the conservative full init approach.