### PR TITLE
Add support for connection re-use by secondary for XFR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@
 .cproject
 .project
 .settings/
+
+# Separate build directory
+build/*

--- a/configlexer.lex
+++ b/configlexer.lex
@@ -225,6 +225,7 @@ tcp-count{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TCP_COUNT;}
 tcp-reject-overflow{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TCP_REJECT_OVERFLOW;}
 tcp-query-count{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TCP_QUERY_COUNT;}
 tcp-timeout{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TCP_TIMEOUT;}
+tcp-idle-timeout{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TCP_IDLE_TIMEOUT;}
 tcp-mss{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_TCP_MSS;}
 outgoing-tcp-mss{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_OUTGOING_TCP_MSS;}
 ipv4-edns-size{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_IPV4_EDNS_SIZE;}

--- a/configlexer.lex
+++ b/configlexer.lex
@@ -242,6 +242,7 @@ difffile{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_DIFFFILE;}
 xfrdfile{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_XFRDFILE;}
 xfrdir{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_XFRDIR;}
 xfrd-reload-timeout{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_XFRD_RELOAD_TIMEOUT;}
+xfrd-conn-reuse{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_XFRD_CONN_REUSE;}
 verbosity{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_VERBOSITY;}
 zone{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_ZONE;}
 zonefile{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_ZONEFILE;}

--- a/configparser.y
+++ b/configparser.y
@@ -98,6 +98,7 @@ static int parse_range(const char *str, long long *low, long long *high);
 %token VAR_IPV6_EDNS_SIZE
 %token VAR_STATISTICS
 %token VAR_XFRD_RELOAD_TIMEOUT
+%token VAR_XFRD_CONN_REUSE
 %token VAR_LOG_TIME_ASCII
 %token VAR_ROUND_ROBIN
 %token VAR_MINIMAL_RESPONSES
@@ -350,6 +351,8 @@ server_option:
     { cfg_parser->opt->xfrdir = region_strdup(cfg_parser->opt->region, $2); }
   | VAR_XFRD_RELOAD_TIMEOUT number
     { cfg_parser->opt->xfrd_reload_timeout = (int)$2; }
+  | VAR_XFRD_CONN_REUSE boolean
+    { cfg_parser->opt->xfrd_conn_reuse = $2; }
   | VAR_VERBOSITY number
     { cfg_parser->opt->verbosity = (int)$2; }
   | VAR_RRL_SIZE number

--- a/configparser.y
+++ b/configparser.y
@@ -91,6 +91,7 @@ static int parse_range(const char *str, long long *low, long long *high);
 %token VAR_TCP_REJECT_OVERFLOW
 %token VAR_TCP_QUERY_COUNT
 %token VAR_TCP_TIMEOUT
+%token VAR_TCP_IDLE_TIMEOUT
 %token VAR_TCP_MSS
 %token VAR_OUTGOING_TCP_MSS
 %token VAR_IPV4_EDNS_SIZE
@@ -310,6 +311,8 @@ server_option:
     { cfg_parser->opt->tcp_query_count = (int)$2; }
   | VAR_TCP_TIMEOUT number
     { cfg_parser->opt->tcp_timeout = (int)$2; }
+  | VAR_TCP_IDLE_TIMEOUT number
+    { cfg_parser->opt->tcp_idle_timeout = (int)$2; }
   | VAR_TCP_MSS number
     { cfg_parser->opt->tcp_mss = (int)$2; }
   | VAR_OUTGOING_TCP_MSS number

--- a/configure.ac
+++ b/configure.ac
@@ -900,6 +900,16 @@ AC_ARG_WITH([tcp_timeout],
 AC_DEFINE_UNQUOTED([TCP_TIMEOUT], $tcp_timeout, [Define to the default tcp timeout.])
 
 dnl
+dnl Determine the default tcp idle timeout (used when closing outgoing XFR TCP connections)
+dnl
+tcp_idle_timeout=10
+AC_ARG_WITH([tcp_idle_timeout],
+	AC_HELP_STRING([--with-tcp-idle-timeout=number], [Limit the default tcp idle timeout, used when closing outgoing XFR TCP connections]),
+	[tcp_idle_timeout=$withval])
+AC_DEFINE_UNQUOTED([TCP_IDLE_TIMEOUT], $tcp_idle_timeout, [Define to the default tcp idle timeout.])
+
+
+dnl
 dnl Features
 dnl
 AC_ARG_ENABLE(root-server, AC_HELP_STRING([--enable-root-server], [Configure NSD as a root server]))

--- a/configure.ac
+++ b/configure.ac
@@ -904,7 +904,7 @@ dnl Determine the default tcp idle timeout (used when closing outgoing XFR TCP c
 dnl
 tcp_idle_timeout=10
 AC_ARG_WITH([tcp_idle_timeout],
-	AC_HELP_STRING([--with-tcp-idle-timeout=number], [Limit the default tcp idle timeout, used when closing outgoing XFR TCP connections]),
+	AC_HELP_STRING([--with-tcp-idle-timeout=number], [Limit the default tcp idle timeout, used when closing outgoing XFR TCP connections when xfrd-conn-resuse option is enabled]),
 	[tcp_idle_timeout=$withval])
 AC_DEFINE_UNQUOTED([TCP_IDLE_TIMEOUT], $tcp_idle_timeout, [Define to the default tcp idle timeout.])
 

--- a/nsd-checkconf.c
+++ b/nsd-checkconf.c
@@ -408,6 +408,7 @@ config_print_zone(nsd_options_type* opt, const char* k, int s, const char *o,
 		SERV_GET_INT(ipv6_edns_size, o);
 		SERV_GET_INT(statistics, o);
 		SERV_GET_INT(xfrd_reload_timeout, o);
+		SERV_GET_BIN(xfrd_conn_reuse, o);        
 		SERV_GET_INT(verbosity, o);
 		SERV_GET_INT(send_buffer_size, o);
 		SERV_GET_INT(receive_buffer_size, o);
@@ -563,6 +564,7 @@ config_test_print_server(nsd_options_type* opt)
 	print_string_var("zonelistfile:", opt->zonelistfile);
 	print_string_var("xfrdir:", opt->xfrdir);
 	printf("\txfrd-reload-timeout: %d\n", opt->xfrd_reload_timeout);
+	printf("\txfrd-conn-reuse: %s\n", opt->xfrd_conn_reuse?"yes":"no");
 	printf("\tlog-time-ascii: %s\n", opt->log_time_ascii?"yes":"no");
 	printf("\tround-robin: %s\n", opt->round_robin?"yes":"no");
 	printf("\tminimal-responses: %s\n", opt->minimal_responses?"yes":"no");

--- a/nsd-checkconf.c
+++ b/nsd-checkconf.c
@@ -401,6 +401,7 @@ config_print_zone(nsd_options_type* opt, const char* k, int s, const char *o,
 		SERV_GET_INT(tcp_count, o);
 		SERV_GET_INT(tcp_query_count, o);
 		SERV_GET_INT(tcp_timeout, o);
+		SERV_GET_INT(tcp_idle_timeout, o);
 		SERV_GET_INT(tcp_mss, o);
 		SERV_GET_INT(outgoing_tcp_mss, o);
 		SERV_GET_INT(ipv4_edns_size, o);
@@ -547,6 +548,7 @@ config_test_print_server(nsd_options_type* opt)
 	printf("\ttcp-count: %d\n", opt->tcp_count);
 	printf("\ttcp-query-count: %d\n", opt->tcp_query_count);
 	printf("\ttcp-timeout: %d\n", opt->tcp_timeout);
+	printf("\ttcp-idle-timeout: %d\n", opt->tcp_idle_timeout);
 	printf("\ttcp-mss: %d\n", opt->tcp_mss);
 	printf("\toutgoing-tcp-mss: %d\n", opt->outgoing_tcp_mss);
 	printf("\tipv4-edns-size: %d\n", (int) opt->ipv4_edns_size);

--- a/nsd.c
+++ b/nsd.c
@@ -1070,6 +1070,7 @@ main(int argc, char *argv[])
 	}
 	nsd.tcp_timeout = nsd.options->tcp_timeout;
 	nsd.tcp_idle_timeout = nsd.options->tcp_idle_timeout;
+	nsd.xfrd_conn_reuse = nsd.options->xfrd_conn_reuse;
 	nsd.tcp_query_count = nsd.options->tcp_query_count;
 	nsd.tcp_mss = nsd.options->tcp_mss;
 	nsd.outgoing_tcp_mss = nsd.options->outgoing_tcp_mss;

--- a/nsd.c
+++ b/nsd.c
@@ -1069,6 +1069,7 @@ main(int argc, char *argv[])
 		nsd.maximum_tcp_count = nsd.options->tcp_count;
 	}
 	nsd.tcp_timeout = nsd.options->tcp_timeout;
+	nsd.tcp_idle_timeout = nsd.options->tcp_idle_timeout;
 	nsd.tcp_query_count = nsd.options->tcp_query_count;
 	nsd.tcp_mss = nsd.options->tcp_mss;
 	nsd.outgoing_tcp_mss = nsd.options->outgoing_tcp_mss;

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -282,7 +282,8 @@ The default is 120 seconds.
 .TP
 .B tcp\-idle\-timeout:\fR <number>
 Overrides the default TCP idle timeout. This is used when closing outgoing
-TCP connections used for zone transfers. The default is 10 seconds.
+TCP connections used for zone transfers when the xfrd\-conn\-reuse option is enabled. 
+The default is 10 seconds.
 .TP
 .B tcp-mss:\fR <number>
 Maximum segment size (MSS) of TCP socket on which the server responds
@@ -377,7 +378,8 @@ once per the number of seconds. The default is 1 second.
 .B xfrd\-conn\-reuse:\fR <yes or no>
 When making outgoing XFR requests to the same master an open TCP connection 
 will be used in preference to opening a new connection for each request. 
-Default is no.
+After all transfers complete, connections will be left open for 
+tcp\-idle\-timeout seconds to increase the chance of reuse. Default is no.
 .TP
 .B verbosity:\fR <level>
 This value specifies the verbosity level for (non\-debug) logging. 

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -374,6 +374,11 @@ transfer, then it will wait for the number of seconds before it will
 trigger a new reload. Setting this value throttles the reloads to 
 once per the number of seconds. The default is 1 second.
 .TP
+.B xfrd\-conn\-reuse:\fR <yes or no>
+When making outgoing XFR requests to the same master an open TCP connection 
+will be used in preference to opening a new connection for each request. 
+Default is no.
+.TP
 .B verbosity:\fR <level>
 This value specifies the verbosity level for (non\-debug) logging. 
 Default is 0. 1 gives more information about incoming notifies and

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -280,6 +280,10 @@ Default is 0, meaning there is no maximum.
 Overrides the default TCP timeout. This also affects zone transfers over TCP.
 The default is 120 seconds.
 .TP
+.B tcp\-idle\-timeout:\fR <number>
+Overrides the default TCP idle timeout. This is used when closing outgoing
+TCP connections used for zone transfers. The default is 10 seconds.
+.TP
 .B tcp-mss:\fR <number>
 Maximum segment size (MSS) of TCP socket on which the server responds
 to queries. Value lower than common MSS on Ethernet 

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -167,7 +167,7 @@ server:
 	# tcp-timeout: 120
 
 	# Override the default (10 seconds) TCP idle timeout, used when
-    # closing outgoing XFR TCP connections when xfrd-conn-reuse is enabled.
+	# closing outgoing XFR TCP connections when xfrd-conn-reuse is enabled.
 	# tcp-idle-timeout: 10
 
 	# Maximum segment size (MSS) of TCP socket on which the server
@@ -192,7 +192,7 @@ server:
 	# xfrd-reload-timeout: 1
 
 	# Prefer to reuse open connections to a master instead of opening
-    # a new connection for each transfer request to that master.
+	# a new connection for each transfer request to that master.
 	# xfrd-conn-reuse: no
 
 	# log timestamp in ascii (y-m-d h:m:s.msec), yes is default.

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -166,6 +166,10 @@ server:
 	# Override the default (120 seconds) TCP timeout.
 	# tcp-timeout: 120
 
+	# Override the default (10 seconds) TCP idle timeout, used when
+    # closing outgoing XFR TCP connections.
+	# tcp-idle-timeout: 120
+
 	# Maximum segment size (MSS) of TCP socket on which the server
 	# responds to queries. Default is 0, system default MSS.
 	# tcp-mss: 0
@@ -186,6 +190,10 @@ server:
 
 	# Number of seconds between reloads triggered by xfrd.
 	# xfrd-reload-timeout: 1
+
+	# Prefer to reuse open connections to a master instead of opening
+    # a new connection for each transfer request to that master
+	# xfrd-conn-reuse: no
 
 	# log timestamp in ascii (y-m-d h:m:s.msec), yes is default.
 	# log-time-ascii: yes

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -167,8 +167,8 @@ server:
 	# tcp-timeout: 120
 
 	# Override the default (10 seconds) TCP idle timeout, used when
-    # closing outgoing XFR TCP connections.
-	# tcp-idle-timeout: 120
+    # closing outgoing XFR TCP connections when xfrd-conn-reuse is enabled.
+	# tcp-idle-timeout: 10
 
 	# Maximum segment size (MSS) of TCP socket on which the server
 	# responds to queries. Default is 0, system default MSS.
@@ -192,7 +192,7 @@ server:
 	# xfrd-reload-timeout: 1
 
 	# Prefer to reuse open connections to a master instead of opening
-    # a new connection for each transfer request to that master
+    # a new connection for each transfer request to that master.
 	# xfrd-conn-reuse: no
 
 	# log timestamp in ascii (y-m-d h:m:s.msec), yes is default.

--- a/nsd.h
+++ b/nsd.h
@@ -267,6 +267,7 @@ struct	nsd
 	int current_tcp_count;
 	int tcp_query_count;
 	int tcp_timeout;
+	int tcp_idle_timeout;
 	int tcp_mss;
 	int outgoing_tcp_mss;
 	size_t ipv4_edns_size;

--- a/nsd.h
+++ b/nsd.h
@@ -268,8 +268,8 @@ struct	nsd
 	int tcp_query_count;
 	int tcp_timeout;
 	int tcp_idle_timeout;
-    int xfrd_conn_reuse;
-    
+	int xfrd_conn_reuse;
+
 	int tcp_mss;
 	int outgoing_tcp_mss;
 	size_t ipv4_edns_size;

--- a/nsd.h
+++ b/nsd.h
@@ -268,6 +268,8 @@ struct	nsd
 	int tcp_query_count;
 	int tcp_timeout;
 	int tcp_idle_timeout;
+    int xfrd_conn_reuse;
+    
 	int tcp_mss;
 	int outgoing_tcp_mss;
 	size_t ipv4_edns_size;

--- a/options.c
+++ b/options.c
@@ -123,6 +123,7 @@ nsd_options_create(region_type* region)
 		opt->zonefiles_write = ZONEFILES_WRITE_INTERVAL;
 	else	opt->zonefiles_write = 0;
 	opt->xfrd_reload_timeout = 1;
+	opt->xfrd_conn_reuse = 0;
 	opt->tls_service_key = NULL;
 	opt->tls_service_ocsp = NULL;
 	opt->tls_service_pem = NULL;

--- a/options.c
+++ b/options.c
@@ -79,6 +79,7 @@ nsd_options_create(region_type* region)
 	opt->tcp_reject_overflow = 0;
 	opt->tcp_query_count = 0;
 	opt->tcp_timeout = TCP_TIMEOUT;
+	opt->tcp_idle_timeout = TCP_IDLE_TIMEOUT;
 	opt->tcp_mss = 0;
 	opt->outgoing_tcp_mss = 0;
 	opt->ipv4_edns_size = EDNS_MAX_MESSAGE_LEN;

--- a/options.h
+++ b/options.h
@@ -87,6 +87,7 @@ struct nsd_options {
 	int confine_to_zone;
 	int tcp_query_count;
 	int tcp_timeout;
+    int tcp_idle_timeout;
 	int tcp_mss;
 	int outgoing_tcp_mss;
 	size_t ipv4_edns_size;

--- a/options.h
+++ b/options.h
@@ -103,6 +103,7 @@ struct nsd_options {
 	const char* zonelistfile;
 	const char* nsid;
 	int xfrd_reload_timeout;
+	int xfrd_conn_reuse;
 	int zonefiles_check;
 	int zonefiles_write;
 	int log_time_ascii;

--- a/options.h
+++ b/options.h
@@ -87,7 +87,7 @@ struct nsd_options {
 	int confine_to_zone;
 	int tcp_query_count;
 	int tcp_timeout;
-    int tcp_idle_timeout;
+	int tcp_idle_timeout;
 	int tcp_mss;
 	int outgoing_tcp_mss;
 	size_t ipv4_edns_size;

--- a/tpkg/checkconf.tdir/checkconf.check
+++ b/tpkg/checkconf.tdir/checkconf.check
@@ -24,6 +24,7 @@ server:
 	tcp-count: 100
 	tcp-query-count: 0
 	tcp-timeout: 120
+	tcp-idle-timeout: 10
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
 	ipv4-edns-size: 4096
@@ -38,6 +39,7 @@ server:
 	zonelistfile: "/var/db/nsd/zone.list"
 	xfrdir: "/tmp"
 	xfrd-reload-timeout: 1
+	xfrd-conn-reuse: no
 	log-time-ascii: yes
 	round-robin: no
 	minimal-responses: no
@@ -135,6 +137,7 @@ server:
 	tcp-count: 100
 	tcp-query-count: 0
 	tcp-timeout: 120
+	tcp-idle-timeout: 10
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
 	ipv4-edns-size: 4096
@@ -149,6 +152,7 @@ server:
 	zonelistfile: "/var/db/nsd/zone.list"
 	xfrdir: "/tmp"
 	xfrd-reload-timeout: 1
+	xfrd-conn-reuse: no
 	log-time-ascii: yes
 	round-robin: no
 	minimal-responses: no
@@ -199,6 +203,7 @@ server:
 	tcp-count: 100
 	tcp-query-count: 0
 	tcp-timeout: 120
+	tcp-idle-timeout: 10
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
 	ipv4-edns-size: 4096
@@ -213,6 +218,7 @@ server:
 	zonelistfile: "/var/db/nsd/zone.list"
 	xfrdir: "/tmp"
 	xfrd-reload-timeout: 1
+	xfrd-conn-reuse: no
 	log-time-ascii: no
 	round-robin: no
 	minimal-responses: no
@@ -272,6 +278,7 @@ server:
 	tcp-count: 100
 	tcp-query-count: 0
 	tcp-timeout: 120
+	tcp-idle-timeout: 10
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
 	ipv4-edns-size: 4096
@@ -286,6 +293,7 @@ server:
 	zonelistfile: "/var/db/nsd/zone.list"
 	xfrdir: "/tmp"
 	xfrd-reload-timeout: 1
+	xfrd-conn-reuse: no
 	log-time-ascii: yes
 	round-robin: no
 	minimal-responses: no
@@ -389,6 +397,7 @@ server:
 	tcp-count: 100
 	tcp-query-count: 0
 	tcp-timeout: 120
+	tcp-idle-timeout: 10
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
 	ipv4-edns-size: 4096
@@ -403,6 +412,7 @@ server:
 	zonelistfile: "/var/db/nsd/zone.list"
 	xfrdir: "/tmp"
 	xfrd-reload-timeout: 1
+	xfrd-conn-reuse: no
 	log-time-ascii: yes
 	round-robin: no
 	minimal-responses: no

--- a/tpkg/checkconf.tdir/checkconf.check2
+++ b/tpkg/checkconf.tdir/checkconf.check2
@@ -24,6 +24,7 @@ server:
 	tcp-count: 100
 	tcp-query-count: 0
 	tcp-timeout: 120
+	tcp-idle-timeout: 10
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
 	ipv4-edns-size: 4096
@@ -38,6 +39,7 @@ server:
 	zonelistfile: "/var/db/nsd/zone.list"
 	xfrdir: "/tmp"
 	xfrd-reload-timeout: 1
+	xfrd-conn-reuse: no
 	log-time-ascii: yes
 	round-robin: no
 	minimal-responses: no
@@ -135,6 +137,7 @@ server:
 	tcp-count: 100
 	tcp-query-count: 0
 	tcp-timeout: 120
+	tcp-idle-timeout: 10
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
 	ipv4-edns-size: 4096
@@ -149,6 +152,7 @@ server:
 	zonelistfile: "/var/db/nsd/zone.list"
 	xfrdir: "/tmp"
 	xfrd-reload-timeout: 1
+	xfrd-conn-reuse: no
 	log-time-ascii: yes
 	round-robin: no
 	minimal-responses: no
@@ -199,6 +203,7 @@ server:
 	tcp-count: 100
 	tcp-query-count: 0
 	tcp-timeout: 120
+	tcp-idle-timeout: 10
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
 	ipv4-edns-size: 4096
@@ -213,6 +218,7 @@ server:
 	zonelistfile: "/var/db/nsd/zone.list"
 	xfrdir: "/tmp"
 	xfrd-reload-timeout: 1
+	xfrd-conn-reuse: no
 	log-time-ascii: no
 	round-robin: no
 	minimal-responses: no
@@ -272,6 +278,7 @@ server:
 	tcp-count: 100
 	tcp-query-count: 0
 	tcp-timeout: 120
+	tcp-idle-timeout: 10
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
 	ipv4-edns-size: 4096
@@ -286,6 +293,7 @@ server:
 	zonelistfile: "/var/db/nsd/zone.list"
 	xfrdir: "/tmp"
 	xfrd-reload-timeout: 1
+	xfrd-conn-reuse: no
 	log-time-ascii: yes
 	round-robin: no
 	minimal-responses: no
@@ -389,6 +397,7 @@ server:
 	tcp-count: 100
 	tcp-query-count: 0
 	tcp-timeout: 120
+	tcp-idle-timeout: 10
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
 	ipv4-edns-size: 4096
@@ -403,6 +412,7 @@ server:
 	zonelistfile: "/var/db/nsd/zone.list"
 	xfrdir: "/tmp"
 	xfrd-reload-timeout: 1
+	xfrd-conn-reuse: no
 	log-time-ascii: yes
 	round-robin: no
 	minimal-responses: no

--- a/xfrd-tcp.c
+++ b/xfrd-tcp.c
@@ -296,16 +296,30 @@ tcp_pipe_id_remove(struct xfrd_tcp_pipeline* tp, xfrd_zone_type* zone)
 	(void)rbtree_insert(xfrd->tcp_set->pipetree, &tp->node);
 }
 
+/* determine if pipeline is actually in use*/
+static int 
+tcp_pipe_in_use(struct xfrd_tcp_pipeline* tp) {
+    /* Check there are no active transfers (outstanding query ids) but we 
+       need to ignore any outstanding responses for skipped transactions
+       - in other check we do not have at least one 'nonskip' ID */
+    /* NOTE: There is a minor question if a tcp connection still with skipped
+       transactions is truely 'idle', but for our purposes we are going to treat
+       it as if it is...*/
+    return (ID_PIPE_NUM - tp->num_unused > tp->num_skip)?1:0; 
+}
+
 /* stop the tcp pipe (and all its zones need to retry) */
 static void
 xfrd_tcp_pipe_stop(struct xfrd_tcp_pipeline* tp)
 {
 	int i, conn = -1;
-    /* With connections now left open when (effectively) idle, it is possible to arrive here
-       because the far end shuts the idle connection (causing a read event with no data).
-       So just warn if we get here while the pipe is still in use */
-    if (!(tp->num_unused >= ID_PIPE_NUM || tp->num_skip >= ID_PIPE_NUM - tp->num_unused)) {
-        log_msg(LOG_WARNING, "xfrd: an in use TCP connection was closed by the far end, retrying all zones");
+    /* With connections now left open when (effectively) idle, it is possible to
+       arrive here because the far end shuts the idle connection (causing a read
+       event with no data). So just warn if we get here while the pipe is still 
+       in use */
+    if (tcp_pipe_in_use(tp)) {
+        log_msg(LOG_WARNING, "xfrd: an in use TCP connection was closed by the" 
+                             "far end, retrying all zones");
     	/* need to retry for all the zones connected to it */
     	/* these could use different lists and go to a different nextmaster*/
     	for(i=0; i<ID_PIPE_NUM; i++) {
@@ -330,9 +344,9 @@ tcp_pipe_reset_timeout(struct xfrd_tcp_pipeline* tp)
 {
 	int fd = tp->handler.ev_fd;
 	struct timeval tv;
-    /* pipe is effectively unused - for now set a fixed idle timeout until EDNS0 
+    /* pipe is unused - for now set a fixed idle timeout until EDNS0 
        Keepalive is implemented */
-    if(tp->num_unused >= ID_PIPE_NUM || tp->num_skip >= ID_PIPE_NUM - tp->num_unused)
+    if(!tcp_pipe_in_use(tp))
         tv.tv_sec = xfrd->tcp_set->tcp_idle_timeout;
     else
 	    tv.tv_sec = xfrd->tcp_set->tcp_timeout;
@@ -369,10 +383,11 @@ xfrd_handle_tcp_pipe(int ATTR_UNUSED(fd), short event, void* arg)
 	}
 	if((event & EV_TIMEOUT) && tp->handler_added) {
 		/* tcp connection timed out */
-        /* pipe is unused (timeout triggered while idle), just release indicating
-           we don't have access to the conn for the pipe from here */
-        if(tp->num_unused >= ID_PIPE_NUM || tp->num_skip >= ID_PIPE_NUM - tp->num_unused) {
-    		DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: idle pipeline had tcp timeout event"));
+        /* pipe is unused (timeout triggered while idle), just release it but
+           note that we don't have access to the conn for the pipe from here */
+        if(!tcp_pipe_in_use(tp)){
+    		DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: idle pipeline had tcp timeout"
+                "event"));
              xfrd_tcp_pipe_release(xfrd->tcp_set, tp, -1);
          }
         else
@@ -416,16 +431,11 @@ pipeline_setup_new_zone(struct xfrd_tcp_set* set, struct xfrd_tcp_pipeline* tp,
 	}
 }
 
-void
-xfrd_tcp_obtain(struct xfrd_tcp_set* set, xfrd_zone_type* zone)
-{
-	struct xfrd_tcp_pipeline* tp;
-	assert(zone->tcp_conn == -1);
-	assert(zone->tcp_waiting == 0);
 
-	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: connection reuse is set to %s",
-		set->xfrd_conn_reuse?"yes":"no"));
+static struct xfrd_tcp_pipeline*
+xfrd_tcp_find_pipeline(struct xfrd_tcp_set* set, xfrd_zone_type* zone) {
 
+	struct xfrd_tcp_pipeline* tp;    
     /* check for a pipeline to the same master with unused ID */
 	if((tp = pipeline_find(set, zone))!= NULL) {
 		int i;
@@ -438,61 +448,92 @@ xfrd_tcp_obtain(struct xfrd_tcp_set* set, xfrd_zone_type* zone)
 		xfrd_deactivate_zone(zone);
 		xfrd_unset_timer(zone);
 		pipeline_setup_new_zone(set, tp, zone);
-    	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: zone %s is re-using pipeline %d",
-    		zone->apex_str, i));
-		return;
+    	DEBUG(DEBUG_XFRD,1, (LOG_INFO, 
+            "xfrd: zone %s is re-using tcp conn pipeline %d",
+    		zone->apex_str, zone->tcp_conn));
+		return tp;
 	}
+    return NULL;    
+}
 
-	if(set->tcp_count < XFRD_MAX_TCP) {
-		int i;
-		assert(!set->tcp_waiting_first);
-		set->tcp_count ++;
-		/* find a free tcp_buffer */
-		for(i=0; i<XFRD_MAX_TCP; i++) {
-			if(set->tcp_state[i]->tcp_r->fd == -1) {
-				zone->tcp_conn = i;
-				break;
-			}
-		}
-		/** What if there is no free tcp_buffer? return; */
-		if (zone->tcp_conn < 0) {
-			return;
-		}
+static struct xfrd_tcp_pipeline*
+xfrd_tcp_new_pipeline(struct xfrd_tcp_set* set, xfrd_zone_type* zone) {
 
-		tp = set->tcp_state[zone->tcp_conn];
-		zone->tcp_waiting = 0;
+	struct xfrd_tcp_pipeline* tp;
+    /* Open a new pipeline if one is available*/
+    if(set->tcp_count < XFRD_MAX_TCP) {
+    	int i;
+    	assert(!set->tcp_waiting_first);
+    	set->tcp_count ++;
+    	/* find a free tcp_buffer */
+    	for(i=0; i<XFRD_MAX_TCP; i++) {
+    		if(set->tcp_state[i]->tcp_r->fd == -1) {
+    			zone->tcp_conn = i;
+    			break;
+    		}
+    	}
+    	/** What if there is no free tcp_buffer? return; */
+    	if (zone->tcp_conn < 0) {
+            zone->tcp_conn = -1;
+            set->tcp_count --;
+            xfrd_set_refresh_now(zone);
+    		return NULL;
+    	}
 
-		/* stop udp use (if any) */
-		if(zone->zone_handler.ev_fd != -1)
-			xfrd_udp_release(zone);
+    	tp = set->tcp_state[zone->tcp_conn];
+    	zone->tcp_waiting = 0;
 
-		if(!xfrd_tcp_open(set, tp, zone)) {
-			zone->tcp_conn = -1;
-			set->tcp_count --;
-			xfrd_set_refresh_now(zone);
-			return;
-		}
-		/* ip and ip_len set by tcp_open */
-		tp->node.key = tp;
-		tp->num_unused = ID_PIPE_NUM;
-		tp->num_skip = 0;
-		tp->tcp_send_first = NULL;
-		tp->tcp_send_last = NULL;
-		memset(tp->id, 0, sizeof(tp->id));
-		for(i=0; i<ID_PIPE_NUM; i++) {
-			tp->unused[i] = i;
-		}
+    	/* stop udp use (if any) */
+    	if(zone->zone_handler.ev_fd != -1)
+    		xfrd_udp_release(zone);
 
-		/* insert into tree */
-		(void)rbtree_insert(set->pipetree, &tp->node);
-		xfrd_deactivate_zone(zone);
-		xfrd_unset_timer(zone);
-		pipeline_setup_new_zone(set, tp, zone);
+    	if(!xfrd_tcp_open(set, tp, zone)) {
+    		zone->tcp_conn = -1;
+    		set->tcp_count --;
+    		xfrd_set_refresh_now(zone);
+    		return NULL;
+    	}
+    	/* ip and ip_len set by tcp_open */
+    	tp->node.key = tp;
+    	tp->num_unused = ID_PIPE_NUM;
+    	tp->num_skip = 0;
+    	tp->tcp_send_first = NULL;
+    	tp->tcp_send_last = NULL;
+    	memset(tp->id, 0, sizeof(tp->id));
+    	for(i=0; i<ID_PIPE_NUM; i++) {
+    		tp->unused[i] = i;
+    	}
+
+    	/* insert into tree */
+    	(void)rbtree_insert(set->pipetree, &tp->node);
+    	xfrd_deactivate_zone(zone);
+    	xfrd_unset_timer(zone);
+    	pipeline_setup_new_zone(set, tp, zone);
     	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: zone %s opened a new tcp conn %d",
-    		zone->apex_str, i));
-		return;
-	}
+    		zone->apex_str, zone->tcp_conn));
+    	return tp;
+    }
+    return NULL;
+}
 
+void
+xfrd_tcp_obtain(struct xfrd_tcp_set* set, xfrd_zone_type* zone)
+{
+	struct xfrd_tcp_pipeline* tp;
+	assert(zone->tcp_conn == -1);
+	assert(zone->tcp_waiting == 0);
+
+	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: connection reuse is set to %s",
+		set->xfrd_conn_reuse?"yes":"no"));
+    
+    /* Select an existing or new pipeline first depending on the configuration*/
+    if ((tp = set->xfrd_conn_reuse?xfrd_tcp_find_pipeline(set, zone): 
+                                   xfrd_tcp_new_pipeline(set, zone))!=NULL)
+        return;
+    if ((tp = set->xfrd_conn_reuse?xfrd_tcp_new_pipeline(set, zone): 
+                                   xfrd_tcp_find_pipeline(set, zone))!=NULL)
+        return;
+    
 	/* wait, at end of line */
 	DEBUG(DEBUG_XFRD,2, (LOG_INFO, "xfrd: max number of tcp "
 		"connections (%d) reached.", XFRD_MAX_TCP));
@@ -952,7 +993,6 @@ xfrd_tcp_read(struct xfrd_tcp_pipeline* tp)
 			xfrd_make_request(zone);
 			break;
 	}
-    tcp_pipe_reset_timeout(tp);
 }
 
 void
@@ -960,8 +1000,9 @@ xfrd_tcp_release(struct xfrd_tcp_set* set, xfrd_zone_type* zone)
 {
 	int conn = zone->tcp_conn;
 	struct xfrd_tcp_pipeline* tp = set->tcp_state[conn];
-	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: zone %s mapping to tcp conn %s is released",
-		zone->apex_str, zone->master->ip_address_spec));
+	DEBUG(DEBUG_XFRD,1, (LOG_INFO, 
+        "xfrd: zone %s mapping to tcp conn %d (%s) is released",
+		zone->apex_str, zone->tcp_conn, zone->master->ip_address_spec));
 	assert(zone->tcp_conn != -1);
 	assert(zone->tcp_waiting == 0);
 	zone->tcp_conn = -1;
@@ -972,7 +1013,8 @@ xfrd_tcp_release(struct xfrd_tcp_set* set, xfrd_zone_type* zone)
 	/* remove it from the ID list */
 	if(tp->id[zone->query_id] != TCP_NULL_SKIP)
 		tcp_pipe_id_remove(tp, zone);
-	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: zone %s removed from pipeline mappings, %d unused",
+	DEBUG(DEBUG_XFRD,1, (LOG_INFO, 
+        "xfrd: zone %s query id removed from pipeline, %d unused ids",
 		zone->apex_str, tp->num_unused));
 	/* if pipe was full, but no more, then see if waiting element is
 	 * for the same master, and can fill the unused ID */
@@ -999,16 +1041,19 @@ xfrd_tcp_release(struct xfrd_tcp_set* set, xfrd_zone_type* zone)
 		/* waiting zone did not go to same server */
 	}
 
-	/* if all unused, or only skipped leftover, close the pipeline */
-    // if(tp->num_unused >= ID_PIPE_NUM || tp->num_skip >= ID_PIPE_NUM - tp->num_unused)
-    //     xfrd_tcp_pipe_release(set, tp, conn);
+    if (!set->xfrd_conn_reuse) {
+    	/* if all unused, or only skipped leftover, close the pipeline */
+        if(!tcp_pipe_in_use(tp))
+            xfrd_tcp_pipe_release(set, tp, conn);
+    } else {
+        tcp_pipe_reset_timeout(tp);        
+    }
 }
 
 void
 xfrd_tcp_pipe_release(struct xfrd_tcp_set* set, struct xfrd_tcp_pipeline* tp,
 	int conn)
 {
-	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: tcp pipe released"));
 	/* one handler per tcp pipe */
 	if(tp->handler_added)
 		event_del(&tp->handler);
@@ -1030,6 +1075,7 @@ xfrd_tcp_pipe_release(struct xfrd_tcp_set* set, struct xfrd_tcp_pipeline* tp,
 				conn = i;
 		}
     }
+    DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: tcp pipeline %d released", conn));
     assert(conn != -1);
 
 	/* a waiting zone can use the free tcp slot (to another server) */
@@ -1077,6 +1123,8 @@ xfrd_tcp_pipe_release(struct xfrd_tcp_set* set, struct xfrd_tcp_pipeline* tp,
 	/* no task to start, cleanup */
 	assert(!set->tcp_waiting_first);
 	set->tcp_count --;
+    DEBUG(DEBUG_XFRD,1, (LOG_INFO, 
+        "xfrd: %d tcp pipelines in use", set->tcp_count));
 	assert(set->tcp_count >= 0);
 }
 

--- a/xfrd-tcp.c
+++ b/xfrd-tcp.c
@@ -330,10 +330,10 @@ tcp_pipe_reset_timeout(struct xfrd_tcp_pipeline* tp)
 {
 	int fd = tp->handler.ev_fd;
 	struct timeval tv;
-    /* pipe is effectively unused - for now set a default 10s idle timeout until EDNS0 
+    /* pipe is effectively unused - for now set a fixed idle timeout until EDNS0 
        Keepalive is implemented */
     if(tp->num_unused >= ID_PIPE_NUM || tp->num_skip >= ID_PIPE_NUM - tp->num_unused)
-        tv.tv_sec = 10;
+        tv.tv_sec = xfrd->tcp_set->tcp_idle_timeout;
     else
 	    tv.tv_sec = xfrd->tcp_set->tcp_timeout;
 	tv.tv_usec = 0;

--- a/xfrd-tcp.c
+++ b/xfrd-tcp.c
@@ -527,12 +527,12 @@ xfrd_tcp_obtain(struct xfrd_tcp_set* set, xfrd_zone_type* zone)
 		set->xfrd_conn_reuse?"yes":"no"));
     
     /* Select an existing or new pipeline first depending on the configuration*/
-    if ((tp = set->xfrd_conn_reuse?xfrd_tcp_find_pipeline(set, zone): 
-                                   xfrd_tcp_new_pipeline(set, zone))!=NULL)
-        return;
-    if ((tp = set->xfrd_conn_reuse?xfrd_tcp_new_pipeline(set, zone): 
-                                   xfrd_tcp_find_pipeline(set, zone))!=NULL)
-        return;
+    tp = set->xfrd_conn_reuse?xfrd_tcp_find_pipeline(set, zone): 
+                         xfrd_tcp_new_pipeline(set, zone);
+    if (tp != NULL) return;
+    tp = set->xfrd_conn_reuse?xfrd_tcp_new_pipeline(set, zone): 
+                         xfrd_tcp_find_pipeline(set, zone);
+    if (tp != NULL) return;
     
 	/* wait, at end of line */
 	DEBUG(DEBUG_XFRD,2, (LOG_INFO, "xfrd: max number of tcp "

--- a/xfrd-tcp.c
+++ b/xfrd-tcp.c
@@ -423,6 +423,9 @@ xfrd_tcp_obtain(struct xfrd_tcp_set* set, xfrd_zone_type* zone)
 	assert(zone->tcp_conn == -1);
 	assert(zone->tcp_waiting == 0);
 
+	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "xfrd: connection reuse is set to %s",
+		set->xfrd_conn_reuse?"yes":"no"));
+
     /* check for a pipeline to the same master with unused ID */
 	if((tp = pipeline_find(set, zone))!= NULL) {
 		int i;

--- a/xfrd-tcp.h
+++ b/xfrd-tcp.h
@@ -35,6 +35,8 @@ struct xfrd_tcp_set {
 	int tcp_timeout;
 	/* TCP idle timeout. */
 	int tcp_idle_timeout;
+	/* TCP connection reuse. */
+	int xfrd_conn_reuse;
 	/* rbtree with pipelines sorted by master */
 	rbtree_type* pipetree;
 	/* double linked list of zones waiting for a TCP connection */

--- a/xfrd-tcp.h
+++ b/xfrd-tcp.h
@@ -33,6 +33,8 @@ struct xfrd_tcp_set {
 	int tcp_count;
 	/* TCP timeout. */
 	int tcp_timeout;
+	/* TCP idle timeout. */
+	int tcp_idle_timeout;
 	/* rbtree with pipelines sorted by master */
 	rbtree_type* pipetree;
 	/* double linked list of zones waiting for a TCP connection */

--- a/xfrd.c
+++ b/xfrd.c
@@ -197,7 +197,7 @@ xfrd_init(int socket, struct nsd* nsd, int shortsoa, int reload_active,
 #endif
 
 	xfrd->tcp_set = xfrd_tcp_set_create(xfrd->region);
-	xfrd->tcp_set->tcp_timeout = 30;
+	xfrd->tcp_set->tcp_timeout = nsd->tcp_timeout;
 #if !defined(HAVE_ARC4RANDOM) && !defined(HAVE_GETRANDOM)
 	srandom((unsigned long) getpid() * (unsigned long) time(NULL));
 #endif

--- a/xfrd.c
+++ b/xfrd.c
@@ -1185,7 +1185,7 @@ xfrd_handle_incoming_soa(xfrd_zone_type* zone,
 	if(zone->soa_disk_acquired && soa->serial == zone->soa_disk.serial)
 	{
 		/* soa in disk has been loaded in memory */
-		log_msg(LOG_INFO, "zone %s serial %u is updated to %u",
+		log_msg(LOG_INFO, "xyzzy zone %s serial %u is updated to %u",
 			zone->apex_str, (unsigned)ntohl(zone->soa_nsd.serial),
 			(unsigned)ntohl(soa->serial));
 		zone->soa_nsd = zone->soa_disk;

--- a/xfrd.c
+++ b/xfrd.c
@@ -198,6 +198,7 @@ xfrd_init(int socket, struct nsd* nsd, int shortsoa, int reload_active,
 
 	xfrd->tcp_set = xfrd_tcp_set_create(xfrd->region);
 	xfrd->tcp_set->tcp_timeout = nsd->tcp_timeout;
+	xfrd->tcp_set->tcp_idle_timeout = nsd->tcp_idle_timeout;
 #if !defined(HAVE_ARC4RANDOM) && !defined(HAVE_GETRANDOM)
 	srandom((unsigned long) getpid() * (unsigned long) time(NULL));
 #endif

--- a/xfrd.c
+++ b/xfrd.c
@@ -197,7 +197,7 @@ xfrd_init(int socket, struct nsd* nsd, int shortsoa, int reload_active,
 #endif
 
 	xfrd->tcp_set = xfrd_tcp_set_create(xfrd->region);
-	xfrd->tcp_set->tcp_timeout = nsd->tcp_timeout;
+	xfrd->tcp_set->tcp_timeout = 30;
 #if !defined(HAVE_ARC4RANDOM) && !defined(HAVE_GETRANDOM)
 	srandom((unsigned long) getpid() * (unsigned long) time(NULL));
 #endif
@@ -1185,7 +1185,7 @@ xfrd_handle_incoming_soa(xfrd_zone_type* zone,
 	if(zone->soa_disk_acquired && soa->serial == zone->soa_disk.serial)
 	{
 		/* soa in disk has been loaded in memory */
-		log_msg(LOG_INFO, "xyzzy zone %s serial %u is updated to %u",
+		log_msg(LOG_INFO, "zone %s serial %u is updated to %u",
 			zone->apex_str, (unsigned)ntohl(zone->soa_nsd.serial),
 			(unsigned)ntohl(soa->serial));
 		zone->soa_nsd = zone->soa_disk;

--- a/xfrd.c
+++ b/xfrd.c
@@ -199,6 +199,7 @@ xfrd_init(int socket, struct nsd* nsd, int shortsoa, int reload_active,
 	xfrd->tcp_set = xfrd_tcp_set_create(xfrd->region);
 	xfrd->tcp_set->tcp_timeout = nsd->tcp_timeout;
 	xfrd->tcp_set->tcp_idle_timeout = nsd->tcp_idle_timeout;
+	xfrd->tcp_set->xfrd_conn_reuse = nsd->xfrd_conn_reuse;
 #if !defined(HAVE_ARC4RANDOM) && !defined(HAVE_GETRANDOM)
 	srandom((unsigned long) getpid() * (unsigned long) time(NULL));
 #endif

--- a/xfrd.c
+++ b/xfrd.c
@@ -371,6 +371,13 @@ xfrd_shutdown()
 		}
 	}
 	close_notify_fds(xfrd->notify_zones);
+    /* and any open TCP connections so the far end knows we are gone */
+    struct xfrd_tcp_pipeline* tp;
+    for(int i=0; i<XFRD_MAX_TCP; i++) {
+		tp = xfrd->tcp_set->tcp_state[i];
+        if (tp->tcp_r->fd != -1)
+            xfrd_tcp_pipe_release(xfrd->tcp_set, tp, -2);
+    }
 
 	/* wait for server parent (if necessary) */
 	if(xfrd->reload_pid != -1) {


### PR DESCRIPTION
*** FOR REVIEW ONLY AT THIS TIME***
* Part of the work to prototype draft-ietf-dprive-xfr-over-tls
* Adds 2 new parameters: `xfrd-conn-reuse` (default no) and `tcp-idle-timeout` (default 10)
* If `xfrd-conn-reuse: yes` the secondary will utilise the existing the mechanisms in place (which are currently only used when `XFRD_MAX_TCP` is exhausted) to re-use connections
* It will additionally leave those connections open and idle for `tcp-idle-timeout`, which is currently a fixed timeout. A later commit will add support for EDNS0 Keepalive, so the server can signal the timeout to use (as described in draft-ietf-dprive-xfr-over-tls)
* Tested against BIND for multiple IXFR and AXFR on the same connection, for the same and different zones
* NOTE: Encountered an issue with NSD reload behaviour and persistent XFR connections when trying to update the `tpkg\long\testplan-axfr.dir` test, will send separate email about this. 