### PR TITLE
Bugfix/dnstap out of sync

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,45 +7,32 @@
 # For now builds are limited to Linux, FreeBSD and macOS builds on AMD64, more
 # may be added in the future.
 
-ubuntu_1804: &ubuntu_1804
+ubuntu_2004_gcc11: &ubuntu_2004_gcc11
   container:
-    image: ubuntu:bionic
+    image: ubuntu:focal
   env:
-    UBUNTU_CODENAME: bionic
+    UBUNTU_CODENAME: focal
     COV_COMPTYPE: gcc
     COV_PLATFORM: linux64
-
-ubuntu_1804_gcc9: &ubuntu_1804_gcc9
-  <<: *ubuntu_1804
-  env:
-    CC: gcc-9
+    CC: gcc-11
   bootstrap_script:
     - apt-get update
-    - apt-get install -y gnupg2 ca-certificates wget curl
-    - |
-      cat << EOF > /etc/apt/sources.list.d/ubuntu-toolchain-r.list
-      deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu ${UBUNTU_CODENAME} main
-      deb-src http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu ${UBUNTU_CODENAME} main
-      EOF
-    - apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F
+    - apt-get install -y gnupg2 ca-certificates wget curl software-properties-common
+    - add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - apt-get update
   install_script:
-    - apt-get install -y autoconf automake make gcc-9 clang libc-dev libevent-dev libssl-dev flex bison
+    - apt-get install -y autoconf automake make gcc-11 clang libc-dev libevent-dev libssl-dev flex bison
 
-ubuntu_1804_clang10: &ubuntu_1804_clang10
-  <<: *ubuntu_1804
+ubuntu_2104_clang12: &ubuntu_2104_clang12
+  container:
+    image: ubuntu:hirsute
   env:
-    CC: clang-10
-    CLANG_VERSION: 10
+    UBUNTU_CODENAME: hirsute
+    CC: clang-12
+    CLANG_VERSION: 12
   bootstrap_script:
     - apt-get update
-    - apt-get install -y gnupg2 ca-certificates wget curl
-    - |
-      cat << EOF > /etc/apt/sources.list.d/llvm-toolchain.list
-      deb http://apt.llvm.org/${UBUNTU_CODENAME} llvm-toolchain-${UBUNTU_CODENAME}-${CLANG_VERSION} main
-      deb-src http://apt.llvm.org/${UBUNTU_CODENAME} llvm-toolchain-${UBUNTU_CODENAME}-${CLANG_VERSION} main
-      EOF
-    - apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
+    - apt-get install -y gnupg2 ca-certificates wget curl software-properties-common
     - apt-get update
   install_script:
     - apt-get install -y autoconf automake make clang-${CLANG_VERSION} libc-dev libevent-dev libssl-dev flex bison
@@ -102,8 +89,8 @@ env:
 
 task:
   only_if: $CIRRUS_CRON != ''
-  name: "Build on Ubuntu 18.04 LTS with GCC 9 (Coverity Scan)"
-  <<: *ubuntu_1804_gcc9
+  name: "Build on Ubuntu 20.04 LTS with GCC 11 (Coverity Scan)"
+  <<: *ubuntu_2004_gcc11
   <<: *install_coverity
   build_script:
     - autoconf && autoheader
@@ -114,10 +101,10 @@ task:
 
 task:
   matrix:
-    - name: "Build and test on Ubuntu 18.04 LTS with GCC 9"
-      <<: *ubuntu_1804_gcc9
-    - name: "Build and test on Ubuntu 18.04 LTS with Clang 10 (ASan+UBSan+LSan)"
-      <<: *ubuntu_1804_clang10
+    - name: "Build and test on Ubuntu 20.04 LTS with GCC 11"
+      <<: *ubuntu_2004_gcc11
+    - name: "Build and test on Ubuntu 21.04 LTS with Clang 12 (ASan+UBSan+LSan)"
+      <<: *ubuntu_2104_clang12
       env:
         CFLAGS: "-g2 -O0 -fsanitize=address,undefined,leak -fno-sanitize-recover=all"
     - name: "Build and test on FreeBSD 12.2 (ASan+UBSan)"

--- a/dnstap/dnstap_collector.c
+++ b/dnstap/dnstap_collector.c
@@ -165,7 +165,12 @@ static int read_into_buffer(int fd, struct buffer* buf)
 	/* assert we have enough space, if we don't and we wanted to continue,
 	 * we would have to skip the message somehow, but that should never
 	 * happen because send_buffer and receive_buffer have the same size */
-	assert(buffer_capacity(buf) >= msglen + 4);
+	/* assert(buffer_capacity(buf) >= msglen + 4); */
+	if(msglen + 4 > buffer_capacity(buf)) {
+		log_msg(LOG_ERR, "dnstap collector: out of sync (msglen: %u)",
+			(unsigned int) msglen);
+		return -1;
+	}
 	r = read(fd, buffer_current(buf), msglen - (buffer_position(buf) - 4));
 	if(r == -1) {
 		if(errno == EAGAIN || errno == EINTR) {

--- a/dnstap/dnstap_collector.h
+++ b/dnstap/dnstap_collector.h
@@ -43,6 +43,12 @@ struct dt_collector {
 	struct region* region;
 	/* buffer for sending data to the collector */
 	struct buffer* send_buffer;
+	/* when a dnstap collector exits (because it became out of sync or
+	 * otherwise), it is respawn from main and will have the zone content
+	 * in memory. After that it needs to be respawn at every reload to not
+	 * diverge for the zone content in the serve childs and as such incur
+	 * a memory leak. */
+	unsigned respawn_on_reload : 2;
 };
 
 /* information per worker to get input from that worker. */
@@ -59,8 +65,12 @@ struct dt_collector_input {
 struct dt_collector* dt_collector_create(struct nsd* nsd);
 /* destroy the dt_collector structure */
 void dt_collector_destroy(struct dt_collector* dt_col, struct nsd* nsd);
+void dt_collector_destroy_fds(struct dt_collector* dt_col,
+	int* fd_send, int* fd_recv);
 /* close file descriptors */
 void dt_collector_close(struct dt_collector* dt_col, struct nsd* nsd);
+void dt_collector_close_fds(struct dt_collector* dt_col,
+	int* fd_send, int* fd_recv);
 /* start the collector process */
 void dt_collector_start(struct dt_collector* dt_col, struct nsd* nsd);
 

--- a/nsd.c
+++ b/nsd.c
@@ -1586,13 +1586,6 @@ main(int argc, char *argv[])
 	options_zonestatnames_create(nsd.options);
 	server_zonestat_alloc(&nsd);
 #endif /* USE_ZONE_STATS */
-#ifdef USE_DNSTAP
-	if(nsd.options->dnstap_enable) {
-		nsd.dt_collector = dt_collector_create(&nsd);
-		dt_collector_start(nsd.dt_collector, &nsd);
-	}
-#endif /* USE_DNSTAP */
-
 	if(nsd.server_kind == NSD_SERVER_MAIN) {
 		server_prepare_xfrd(&nsd);
 		/* xfrd forks this before reading database, so it does not get
@@ -1607,6 +1600,12 @@ main(int argc, char *argv[])
 			"not be started", argv0);
 	}
 	if(nsd.server_kind == NSD_SERVER_MAIN) {
+#ifdef USE_DNSTAP
+		if(nsd.options->dnstap_enable) {
+			nsd.dt_collector = dt_collector_create(&nsd);
+			dt_collector_start(nsd.dt_collector, &nsd);
+		}
+#endif /* USE_DNSTAP */
 		server_send_soa_xfrd(&nsd, 0);
 	}
 

--- a/nsd.c
+++ b/nsd.c
@@ -1593,6 +1593,12 @@ main(int argc, char *argv[])
 		server_start_xfrd(&nsd, 0, 0);
 		/* close zonelistfile in non-xfrd processes */
 		zone_list_close(nsd.options);
+#ifdef USE_DNSTAP
+		if(nsd.options->dnstap_enable) {
+			nsd.dt_collector = dt_collector_create(&nsd);
+			dt_collector_start(nsd.dt_collector, &nsd);
+		}
+#endif /* USE_DNSTAP */
 	}
 	if (server_prepare(&nsd) != 0) {
 		unlinkpid(nsd.pidfile);
@@ -1600,12 +1606,6 @@ main(int argc, char *argv[])
 			"not be started", argv0);
 	}
 	if(nsd.server_kind == NSD_SERVER_MAIN) {
-#ifdef USE_DNSTAP
-		if(nsd.options->dnstap_enable) {
-			nsd.dt_collector = dt_collector_create(&nsd);
-			dt_collector_start(nsd.dt_collector, &nsd);
-		}
-#endif /* USE_DNSTAP */
 		server_send_soa_xfrd(&nsd, 0);
 	}
 

--- a/nsd.h
+++ b/nsd.h
@@ -305,8 +305,14 @@ struct	nsd
 	/* the dnstap collector process info */
 	struct dt_collector* dt_collector;
 	/* the pipes from server processes to the dt_collector,
-	 * arrays of size child_count.  Kept open for (re-)forks. */
+	 * arrays of size child_count * 2.  Kept open for (re-)forks. */
 	int *dt_collector_fd_send, *dt_collector_fd_recv;
+	/* the pipes from server processes to the dt_collector. Initially
+	 * these point halfway into dt_collector_fd_send, but during reload
+	 * the pointer is swapped with dt_collector_fd_send in order to
+	 * to prevent writing to the dnstap collector by old serve childs
+	 * simultaneous with new serve childs. */
+	int *dt_collector_fd_swap;
 #endif /* USE_DNSTAP */
 	/* ratelimit for errors, time value */
 	time_t err_limit_time;

--- a/server.c
+++ b/server.c
@@ -3215,7 +3215,13 @@ service_remaining_tcp(struct nsd* nsd)
 	if(nsd->current_tcp_count == 0 || tcp_active_list == NULL)
 		return;
 	VERBOSITY(4, (LOG_INFO, "service remaining TCP connections"));
-
+#ifdef USE_DNSTAP
+	/* remove dnstap collector, we cannot write there because the new
+	 * child process is using the file descriptor, or the child
+	 * process after that. */
+	dt_collector_destroy(nsd->dt_collector, nsd);
+	nsd->dt_collector = NULL;
+#endif
 	/* setup event base */
 	event_base = nsd_child_event_base();
 	if(!event_base) {

--- a/server.c
+++ b/server.c
@@ -2492,9 +2492,12 @@ server_main(struct nsd *nsd)
 					log_msg(LOG_WARNING,
 					       "dnstap-collector %d terminated with status %d",
 					       (int) child_pid, status);
-					if(nsd->options->dnstap_enable) {
+					if(nsd->dt_collector) {
 						dt_collector_close(nsd->dt_collector, nsd);
 						dt_collector_destroy(nsd->dt_collector, nsd);
+						nsd->dt_collector = NULL;
+					}
+					if(nsd->options->dnstap_enable) {
 						nsd->dt_collector = dt_collector_create(nsd);
 						dt_collector_start(nsd->dt_collector, nsd);
 						nsd->mode = NSD_RELOAD;

--- a/server.c
+++ b/server.c
@@ -2487,6 +2487,19 @@ server_main(struct nsd *nsd)
 						log_msg(LOG_ERR, "problems sending reloadpid to xfrd: %s",
 							strerror(errno));
 					}
+#ifdef USE_DNSTAP
+				} else if(child_pid == nsd->dt_collector->dt_pid) {
+					log_msg(LOG_WARNING,
+					       "dnstap-collector %d terminated with status %d",
+					       (int) child_pid, status);
+					if(nsd->options->dnstap_enable) {
+						dt_collector_close(nsd->dt_collector, nsd);
+						dt_collector_destroy(nsd->dt_collector, nsd);
+						nsd->dt_collector = dt_collector_create(nsd);
+						dt_collector_start(nsd->dt_collector, nsd);
+						nsd->mode = NSD_RELOAD;
+					}
+#endif
 				} else if(status != 0) {
 					/* check for status, because we get
 					 * the old-servermain because reload


### PR DESCRIPTION
Recovery of dnstap collector getting out of sync with the serve childs.
TODO:

- [x] respawn dnstap collector on reload without closing sockets like the serve childs (otherwise we leak memory on zone updates because the dnstap collector has old version of database...)