### PR TITLE
Mutual TLS

### DIFF
--- a/configlexer.lex
+++ b/configlexer.lex
@@ -242,6 +242,9 @@ outgoing-interface{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_OUTGOING_INTE
 allow-axfr-fallback{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_ALLOW_AXFR_FALLBACK;}
 tls-auth{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_AUTH;}
 auth-domain-name{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_AUTH_DOMAIN_NAME;}
+client-cert{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_AUTH_CLIENT_CERT;}
+client-key{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_AUTH_CLIENT_KEY;}
+client-key-pw{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_AUTH_CLIENT_KEY_PW;}
 key{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_KEY;}
 algorithm{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_ALGORITHM;}
 secret{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_SECRET;}

--- a/configparser.y
+++ b/configparser.y
@@ -149,6 +149,9 @@ static int parse_range(const char *str, long long *low, long long *high);
 /* xot auth */
 %token VAR_TLS_AUTH
 %token VAR_TLS_AUTH_DOMAIN_NAME
+%token VAR_TLS_AUTH_CLIENT_CERT
+%token VAR_TLS_AUTH_CLIENT_KEY
+%token VAR_TLS_AUTH_CLIENT_KEY_PW
 
 /* pattern */
 %token VAR_PATTERN
@@ -672,6 +675,18 @@ tls_auth_option:
   | VAR_TLS_AUTH_DOMAIN_NAME STRING
     {
       cfg_parser->tls_auth->auth_domain_name = region_strdup(cfg_parser->opt->region, $2);
+    };
+  | VAR_TLS_AUTH_CLIENT_CERT STRING
+    {
+	    cfg_parser->tls_auth->client_cert = region_strdup(cfg_parser->opt->region, $2);
+    };
+  | VAR_TLS_AUTH_CLIENT_KEY STRING
+    {
+	    cfg_parser->tls_auth->client_key = region_strdup(cfg_parser->opt->region, $2);
+    };
+  | VAR_TLS_AUTH_CLIENT_KEY_PW STRING
+    {
+	    cfg_parser->tls_auth->client_key_pw = region_strdup(cfg_parser->opt->region, $2);
     };
 
 key:

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -325,6 +325,11 @@ remote-control:
 	# The authentication domain name as defined in RFC8310.
 	#auth-domain-name: "example.com"
 
+	# Client certificate and private key for Mutual TLS authentication
+	#client-cert: "path/to/clientcert.pem"
+	#client-key: "path/to/clientkey.key"
+	#client-key-pw: "password"
+
 # Patterns have zone configuration and they are shared by one or more zones.
 #
 # pattern:

--- a/options.h
+++ b/options.h
@@ -340,6 +340,9 @@ struct tls_auth_options {
 	rbnode_type node; /* key of tree is name */
 	char* name;
 	char* auth_domain_name;
+	char* client_cert;
+	char* client_key;
+	char* client_key_pw;
 };
 
 /** zone list free space */

--- a/xfrd-tcp.c
+++ b/xfrd-tcp.c
@@ -124,6 +124,14 @@ ssl_handshake(struct xfrd_tcp_pipeline* tp)
 
 	return 0;
 }
+
+int password_cb(char *buf, int size, int rwflag, void *u)
+{
+	strncpy(buf, (char *)u, size);
+	buf[size - 1] = '\0';
+	return strlen(buf);
+}
+
 #endif
 
 /* sort tcppipe, first on IP address, for an IPaddresss, sort on num_unused */
@@ -708,6 +716,25 @@ xfrd_tcp_open(struct xfrd_tcp_set* set, struct xfrd_tcp_pipeline* tp,
 			xfrd_set_refresh_now(zone);
 			return 0;
 		}
+
+		/* Load client certificate (if provided) */
+		if (zone->master->tls_auth_options->client_cert &&
+		    zone->master->tls_auth_options->client_key) {
+			if (SSL_CTX_use_certificate_chain_file(set->ssl_ctx,
+			                                       zone->master->tls_auth_options->client_cert) != 1) {
+				log_msg(LOG_ERR, "xfrd tls: Unable to load client certificate from file %s", zone->master->tls_auth_options->client_cert);
+			}
+
+			if (zone->master->tls_auth_options->client_key_pw) {
+				SSL_CTX_set_default_passwd_cb(set->ssl_ctx, password_cb);
+				SSL_CTX_set_default_passwd_cb_userdata(set->ssl_ctx, zone->master->tls_auth_options->client_key_pw);
+			}
+
+			if (SSL_CTX_use_PrivateKey_file(set->ssl_ctx, zone->master->tls_auth_options->client_key, SSL_FILETYPE_PEM) != 1) {
+				log_msg(LOG_ERR, "xfrd tls: Unable to load private key from file from file %s", zone->master->tls_auth_options->client_key);
+			}
+		}
+
 		tp->handshake_done = 0;
 		if(!ssl_handshake(tp)) {
 			if(tp->handshake_want == SSL_ERROR_SYSCALL) {


### PR DESCRIPTION
Add new config parameters to the `tls-auth` section for client authentication by the server in a XFR-over-TLS operation (Mutual TLS)