### PR TITLE
- Support using system-wide crypto policies

### DIFF
--- a/server.c
+++ b/server.c
@@ -1995,9 +1995,12 @@ server_tls_ctx_setup(char* key, char* pem, char* verifypem)
 	}
 #endif
 #if defined(SHA256_DIGEST_LENGTH) && defined(SSL_TXT_CHACHA20)
-	/* if we have sha256, set the cipher list to have no known vulns */
-	if(!SSL_CTX_set_cipher_list(ctx, "ECDHE+AESGCM:ECDHE+CHACHA20"))
-		log_crypto_err("could not set cipher list with SSL_CTX_set_cipher_list");
+	/* if we detect system-wide crypto policies, use those */
+	if (access( "/etc/crypto-policies/config", F_OK ) != 0 ) {
+		/* if we have sha256, set the cipher list to have no known vulns */
+		if(!SSL_CTX_set_cipher_list(ctx, "ECDHE+AESGCM:ECDHE+CHACHA20"))
+			log_crypto_err("could not set cipher list with SSL_CTX_set_cipher_list");
+	}
 #endif
 	if((SSL_CTX_set_options(ctx, SSL_OP_CIPHER_SERVER_PREFERENCE) &
 		SSL_OP_CIPHER_SERVER_PREFERENCE) !=


### PR DESCRIPTION
System Wide crypto policies are supported via crypto libraries
(openssl, NSS, gnutls) on various distros (RHEL, CentOS, Fedora)

By not manually calling SSL_CTX_set_cipher_list(), the system-wide
crypto policies would be used instead.

System-wide crypto policies are detected via the presence of the
file /etc/crypto-policies/config