### PR TITLE
Xfrd tcp max memory

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -584,7 +584,7 @@ cutest_udb.o: $(srcdir)/tpkg/cutest/cutest_udb.c config.h $(srcdir)/tpkg/cutest/
 cutest_udbrad.o: $(srcdir)/tpkg/cutest/cutest_udbrad.c config.h \
  $(srcdir)/tpkg/cutest/cutest.h $(srcdir)/udbradtree.h $(srcdir)/udb.h
 cutest_util.o: $(srcdir)/tpkg/cutest/cutest_util.c config.h $(srcdir)/tpkg/cutest/cutest.h \
- $(srcdir)/region-allocator.h $(srcdir)/util.h
+ $(srcdir)/region-allocator.h $(srcdir)/util.h $(srcdir)/xfrd-tcp.h
 qtest.o: $(srcdir)/tpkg/cutest/qtest.c config.h $(srcdir)/tpkg/cutest/qtest.h $(srcdir)/buffer.h \
  $(srcdir)/region-allocator.h $(srcdir)/util.h $(srcdir)/query.h $(srcdir)/namedb.h $(srcdir)/dname.h $(srcdir)/buffer.h $(srcdir)/dns.h \
  $(srcdir)/radtree.h $(srcdir)/rbtree.h $(srcdir)/nsd.h $(srcdir)/edns.h $(srcdir)/packet.h $(srcdir)/tsig.h $(srcdir)/namedb.h $(srcdir)/util.h $(srcdir)/nsec3.h \

--- a/configlexer.lex
+++ b/configlexer.lex
@@ -295,6 +295,7 @@ answer-cookie{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_ANSWER_COOKIE;}
 cookie-secret{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_COOKIE_SECRET;}
 cookie-secret-file{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_COOKIE_SECRET_FILE;}
 xfrd-tcp-max{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_XFRD_TCP_MAX;}
+xfrd-tcp-pipeline{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_XFRD_TCP_PIPELINE;}
 {NEWLINE}		{ LEXOUT(("NL\n")); cfg_parser->line++;}
 
 servers={UNQUOTEDLETTER}*	{

--- a/configlexer.lex
+++ b/configlexer.lex
@@ -294,6 +294,7 @@ tls-cert-bundle{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_CERT_BUNDLE;
 answer-cookie{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_ANSWER_COOKIE;}
 cookie-secret{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_COOKIE_SECRET;}
 cookie-secret-file{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_COOKIE_SECRET_FILE;}
+xfrd-tcp-max{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_XFRD_TCP_MAX;}
 {NEWLINE}		{ LEXOUT(("NL\n")); cfg_parser->line++;}
 
 servers={UNQUOTEDLETTER}*	{

--- a/configparser.y
+++ b/configparser.y
@@ -120,6 +120,7 @@ static int parse_range(const char *str, long long *low, long long *high);
 %token <llng> VAR_SERVER_CPU_AFFINITY
 %token VAR_DROP_UPDATES
 %token VAR_XFRD_TCP_MAX
+%token VAR_XFRD_TCP_PIPELINE
 
 /* dnstap */
 %token VAR_DNSTAP
@@ -454,6 +455,8 @@ server_option:
     { cfg_parser->opt->cookie_secret_file = region_strdup(cfg_parser->opt->region, $2); }
   | VAR_XFRD_TCP_MAX number
     { cfg_parser->opt->xfrd_tcp_max = (int)$2; }
+  | VAR_XFRD_TCP_PIPELINE number
+    { cfg_parser->opt->xfrd_tcp_pipeline = (int)$2; }
   | VAR_CPU_AFFINITY cpus
     {
       cfg_parser->opt->cpu_affinity = $2;

--- a/configparser.y
+++ b/configparser.y
@@ -119,6 +119,7 @@ static int parse_range(const char *str, long long *low, long long *high);
 %token VAR_XFRD_CPU_AFFINITY
 %token <llng> VAR_SERVER_CPU_AFFINITY
 %token VAR_DROP_UPDATES
+%token VAR_XFRD_TCP_MAX
 
 /* dnstap */
 %token VAR_DNSTAP
@@ -451,6 +452,8 @@ server_option:
     { cfg_parser->opt->cookie_secret = region_strdup(cfg_parser->opt->region, $2); }
   | VAR_COOKIE_SECRET_FILE STRING
     { cfg_parser->opt->cookie_secret_file = region_strdup(cfg_parser->opt->region, $2); }
+  | VAR_XFRD_TCP_MAX number
+    { cfg_parser->opt->xfrd_tcp_max = (int)$2; }
   | VAR_CPU_AFFINITY cpus
     {
       cfg_parser->opt->cpu_affinity = $2;

--- a/nsd-checkconf.c
+++ b/nsd-checkconf.c
@@ -434,6 +434,7 @@ config_print_zone(nsd_options_type* opt, const char* k, int s, const char *o,
 		SERV_GET_INT(tcp_mss, o);
 		SERV_GET_INT(outgoing_tcp_mss, o);
 		SERV_GET_INT(xfrd_tcp_max, o);
+		SERV_GET_INT(xfrd_tcp_pipeline, o);
 		SERV_GET_INT(ipv4_edns_size, o);
 		SERV_GET_INT(ipv6_edns_size, o);
 		SERV_GET_INT(statistics, o);
@@ -583,6 +584,7 @@ config_test_print_server(nsd_options_type* opt)
 	printf("\ttcp-mss: %d\n", opt->tcp_mss);
 	printf("\toutgoing-tcp-mss: %d\n", opt->outgoing_tcp_mss);
 	printf("\txfrd-tcp-max: %d\n", opt->xfrd_tcp_max);
+	printf("\txfrd-tcp-pipeline: %d\n", opt->xfrd_tcp_pipeline);
 	printf("\tipv4-edns-size: %d\n", (int) opt->ipv4_edns_size);
 	printf("\tipv6-edns-size: %d\n", (int) opt->ipv6_edns_size);
 	print_string_var("pidfile:", opt->pidfile);

--- a/nsd-checkconf.c
+++ b/nsd-checkconf.c
@@ -433,6 +433,7 @@ config_print_zone(nsd_options_type* opt, const char* k, int s, const char *o,
 		SERV_GET_INT(tcp_timeout, o);
 		SERV_GET_INT(tcp_mss, o);
 		SERV_GET_INT(outgoing_tcp_mss, o);
+		SERV_GET_INT(xfrd_tcp_max, o);
 		SERV_GET_INT(ipv4_edns_size, o);
 		SERV_GET_INT(ipv6_edns_size, o);
 		SERV_GET_INT(statistics, o);
@@ -581,6 +582,7 @@ config_test_print_server(nsd_options_type* opt)
 	printf("\ttcp-timeout: %d\n", opt->tcp_timeout);
 	printf("\ttcp-mss: %d\n", opt->tcp_mss);
 	printf("\toutgoing-tcp-mss: %d\n", opt->outgoing_tcp_mss);
+	printf("\txfrd-tcp-max: %d\n", opt->xfrd_tcp_max);
 	printf("\tipv4-edns-size: %d\n", (int) opt->ipv4_edns_size);
 	printf("\tipv6-edns-size: %d\n", (int) opt->ipv6_edns_size);
 	print_string_var("pidfile:", opt->pidfile);

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -306,8 +306,8 @@ Default is system default MSS determined by interface MTU and
 negotiation between NSD and other servers.
 .TP
 .B xfrd\-tcp\-max:\fR <number>
-Number of sockets for xfrd to use for outgoing zone transfers. Default 32.
-Increase it to allow more zone transfer sockets, like to 128.
+Number of sockets for xfrd to use for outgoing zone transfers. Default 128.
+Increase it to allow more zone transfer sockets, like to 256.
 To save memory, this can be lowered, set it lower together with some other
 settings to have reduced memory footprint for NSD. xfrd\-tcp\-max: 32
 and xfrd\-tcp\-pipeline: 128 and rrl\-size: 1000

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -306,7 +306,8 @@ Default is system default MSS determined by interface MTU and
 negotiation between NSD and other servers.
 .TP
 .B xfrd\-tcp\-max:\fR <number>
-Number of sockets for xfrd to use for outgoing zone transfers. Default 128.
+Number of sockets for xfrd to use for outgoing zone transfers. Default 32.
+Increase it to allow more zone transfer sockets, like to 128.
 To save memory, this can be lowered, set it lower together with some other
 settings to have reduced memory footprint for NSD. xfrd\-tcp\-max: 32
 and xfrd\-tcp\-pipeline: 128 and rrl\-size: 1000
@@ -318,7 +319,7 @@ size of the zone data.
 .TP
 .B xfrd\-tcp\-pipeline:\fR <number>
 Number of simultaneous outgoing zone transfers that are possible on the
-tcp sockets of xfrd. Default is 65536.
+tcp sockets of xfrd. Max is 65536, default is 128.
 .TP
 .B ipv4\-edns\-size:\fR <number>
 Preferred EDNS buffer size for IPv4.  Default 1232.

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -305,6 +305,21 @@ Note that not all platform supports socket option to set MSS (TCP_MAXSEG).
 Default is system default MSS determined by interface MTU and
 negotiation between NSD and other servers.
 .TP
+.B xfrd\-tcp\-max:\fR <number>
+Number of sockets for xfrd to use for outgoing zone transfers. Default 128.
+To save memory, this can be lowered, set it lower together with some other
+settings to have reduced memory footprint for NSD. xfrd\-tcp\-max: 32
+and xfrd\-tcp\-pipeline: 128 and rrl\-size: 1000
+.IP
+This reduces memory footprint, other memory usage is caused mainly by
+the server\-count setting, the number of server processes, and the
+tcp\-count setting, which keeps buffers per server process, and by the
+size of the zone data.
+.TP
+.B xfrd\-tcp\-pipeline:\fR <number>
+Number of simultaneous outgoing zone transfers that are possible on the
+tcp sockets of xfrd. Default is 65536.
+.TP
 .B ipv4\-edns\-size:\fR <number>
 Preferred EDNS buffer size for IPv4.  Default 1232.
 .TP

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -178,9 +178,10 @@ server:
 	# xfrd-tcp-max: 32 and xfrd-tcp-pipeline: 128, also rrl-size: 1000
 	# other memory is determined by server-count, tcp-count and zone data
 	# max number of sockets used for outgoing zone transfers.
-	# xfrd-tcp-max: 128
+	# Increase this to allow more sockets for zone transfers.
+	# xfrd-tcp-max: 32
 	# max number of simultaneous outgoing zone transfers over one socket.
-	# xfrd-tcp-pipeline: 65536
+	# xfrd-tcp-pipeline: 128
 
 	# Preferred EDNS buffer size for IPv4.
 	# ipv4-edns-size: 1232

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -174,6 +174,14 @@ server:
 	# Default is 0, system default MSS.
 	# outgoing-tcp-mss: 0
 
+	# reduce these settings to save memory for NSD, to about
+	# xfrd-tcp-max: 32 and xfrd-tcp-pipeline: 128, also rrl-size: 1000
+	# other memory is determined by server-count, tcp-count and zone data
+	# max number of sockets used for outgoing zone transfers.
+	# xfrd-tcp-max: 128
+	# max number of simultaneous outgoing zone transfers over one socket.
+	# xfrd-tcp-pipeline: 65536
+
 	# Preferred EDNS buffer size for IPv4.
 	# ipv4-edns-size: 1232
 

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -179,7 +179,7 @@ server:
 	# other memory is determined by server-count, tcp-count and zone data
 	# max number of sockets used for outgoing zone transfers.
 	# Increase this to allow more sockets for zone transfers.
-	# xfrd-tcp-max: 32
+	# xfrd-tcp-max: 128
 	# max number of simultaneous outgoing zone transfers over one socket.
 	# xfrd-tcp-pipeline: 128
 

--- a/options.c
+++ b/options.c
@@ -92,6 +92,7 @@ nsd_options_create(region_type* region)
 /* deprecated?	opt->port = TCP_PORT; */
 	opt->reuseport = 0;
 	opt->xfrd_tcp_max = 128;
+	opt->xfrd_tcp_pipeline = 65536;
 	opt->statistics = 0;
 	opt->chroot = 0;
 	opt->username = USER;

--- a/options.c
+++ b/options.c
@@ -91,8 +91,8 @@ nsd_options_create(region_type* region)
 	opt->port = UDP_PORT;
 /* deprecated?	opt->port = TCP_PORT; */
 	opt->reuseport = 0;
-	opt->xfrd_tcp_max = 128;
-	opt->xfrd_tcp_pipeline = 65536;
+	opt->xfrd_tcp_max = 32;
+	opt->xfrd_tcp_pipeline = 128;
 	opt->statistics = 0;
 	opt->chroot = 0;
 	opt->username = USER;

--- a/options.c
+++ b/options.c
@@ -91,6 +91,7 @@ nsd_options_create(region_type* region)
 	opt->port = UDP_PORT;
 /* deprecated?	opt->port = TCP_PORT; */
 	opt->reuseport = 0;
+	opt->xfrd_tcp_max = 128;
 	opt->statistics = 0;
 	opt->chroot = 0;
 	opt->username = USER;

--- a/options.c
+++ b/options.c
@@ -91,7 +91,7 @@ nsd_options_create(region_type* region)
 	opt->port = UDP_PORT;
 /* deprecated?	opt->port = TCP_PORT; */
 	opt->reuseport = 0;
-	opt->xfrd_tcp_max = 32;
+	opt->xfrd_tcp_max = 128;
 	opt->xfrd_tcp_pipeline = 128;
 	opt->statistics = 0;
 	opt->chroot = 0;

--- a/options.h
+++ b/options.h
@@ -112,6 +112,7 @@ struct nsd_options {
 	int minimal_responses;
 	int refuse_any;
 	int reuseport;
+	int xfrd_tcp_max;
 
 	/* private key file for TLS */
 	char* tls_service_key;

--- a/options.h
+++ b/options.h
@@ -112,7 +112,10 @@ struct nsd_options {
 	int minimal_responses;
 	int refuse_any;
 	int reuseport;
+	/* max number of xfrd tcp sockets */
 	int xfrd_tcp_max;
+	/* max number of simultaneous requests on xfrd tcp socket */
+	int xfrd_tcp_pipeline;
 
 	/* private key file for TLS */
 	char* tls_service_key;

--- a/tpkg/checkconf.tdir/checkconf.check
+++ b/tpkg/checkconf.tdir/checkconf.check
@@ -26,6 +26,8 @@ server:
 	tcp-timeout: 120
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
+	xfrd-tcp-max: 32
+	xfrd-tcp-pipeline: 128
 	ipv4-edns-size: 1232
 	ipv6-edns-size: 1220
 	pidfile: "/var/pid/nsd.pid"
@@ -152,6 +154,8 @@ server:
 	tcp-timeout: 120
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
+	xfrd-tcp-max: 32
+	xfrd-tcp-pipeline: 128
 	ipv4-edns-size: 1232
 	ipv6-edns-size: 1232
 	pidfile: "/var/pid/nsd.pid"
@@ -219,6 +223,8 @@ server:
 	tcp-timeout: 120
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
+	xfrd-tcp-max: 32
+	xfrd-tcp-pipeline: 128
 	ipv4-edns-size: 1232
 	ipv6-edns-size: 1232
 	pidfile: "/var/run/nsd.pid"
@@ -295,6 +301,8 @@ server:
 	tcp-timeout: 120
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
+	xfrd-tcp-max: 32
+	xfrd-tcp-pipeline: 128
 	ipv4-edns-size: 1232
 	ipv6-edns-size: 1232
 	pidfile: "/var/run/nsd.pid"
@@ -415,6 +423,8 @@ server:
 	tcp-timeout: 120
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
+	xfrd-tcp-max: 32
+	xfrd-tcp-pipeline: 128
 	ipv4-edns-size: 1232
 	ipv6-edns-size: 1232
 	pidfile: "/var/run/nsd.pid"

--- a/tpkg/checkconf.tdir/checkconf.check2
+++ b/tpkg/checkconf.tdir/checkconf.check2
@@ -26,6 +26,8 @@ server:
 	tcp-timeout: 120
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
+	xfrd-tcp-max: 32
+	xfrd-tcp-pipeline: 128
 	ipv4-edns-size: 1232
 	ipv6-edns-size: 1220
 	pidfile: "/var/pid/nsd.pid"
@@ -150,6 +152,8 @@ server:
 	tcp-timeout: 120
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
+	xfrd-tcp-max: 32
+	xfrd-tcp-pipeline: 128
 	ipv4-edns-size: 1232
 	ipv6-edns-size: 1232
 	pidfile: "/var/pid/nsd.pid"
@@ -215,6 +219,8 @@ server:
 	tcp-timeout: 120
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
+	xfrd-tcp-max: 32
+	xfrd-tcp-pipeline: 128
 	ipv4-edns-size: 1232
 	ipv6-edns-size: 1232
 	pidfile: "/var/run/nsd.pid"
@@ -289,6 +295,8 @@ server:
 	tcp-timeout: 120
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
+	xfrd-tcp-max: 32
+	xfrd-tcp-pipeline: 128
 	ipv4-edns-size: 1232
 	ipv6-edns-size: 1232
 	pidfile: "/var/run/nsd.pid"
@@ -407,6 +415,8 @@ server:
 	tcp-timeout: 120
 	tcp-mss: 0
 	outgoing-tcp-mss: 0
+	xfrd-tcp-max: 32
+	xfrd-tcp-pipeline: 128
 	ipv4-edns-size: 1232
 	ipv6-edns-size: 1232
 	pidfile: "/var/run/nsd.pid"

--- a/tpkg/cutest/cutest_util.c
+++ b/tpkg/cutest/cutest_util.c
@@ -188,33 +188,24 @@ static void check_nodupes(CuTest* tc, uint16_t* array, int num)
 	}
 }
 
-static void util_5(CuTest *tc)
+static void testarray(CuTest* tc, int num, int max)
 {
 	uint16_t array[65536];
-	/* test void pick_id_values(uint16_t* array, int num, int max); */
 	memset(array, 0, sizeof(array[0])*65536);
-	pick_id_values(array, 1, 1);
-	check_nodupes(tc, array, 1);
-	pick_id_values(array, 10, 10);
-	check_nodupes(tc, array, 10);
-	pick_id_values(array, 100, 100);
-	check_nodupes(tc, array, 100);
-	pick_id_values(array, 32768, 32768);
-	check_nodupes(tc, array, 32768);
-	pick_id_values(array, 5, 10);
-	check_nodupes(tc, array, 5);
-	pick_id_values(array, 5, 10);
-	check_nodupes(tc, array, 5);
-	pick_id_values(array, 5, 10);
-	check_nodupes(tc, array, 5);
-	pick_id_values(array, 5, 32768);
-	check_nodupes(tc, array, 5);
-	pick_id_values(array, 32000, 32768);
-	check_nodupes(tc, array, 32000);
-	pick_id_values(array, 32000, 65536);
-	check_nodupes(tc, array, 32000);
-	pick_id_values(array, 128, 65536);
-	check_nodupes(tc, array, 128);
-	pick_id_values(array, 4, 65536);
-	check_nodupes(tc, array, 4);
+	pick_id_values(array, num, max);
+	check_nodupes(tc, array, num);
+}
+
+static void util_5(CuTest *tc)
+{
+	/* test void pick_id_values(uint16_t* array, int num, int max); */
+	testarray(tc, 1, 1);
+	testarray(tc, 10, 10);
+	testarray(tc, 1, 1);
+	testarray(tc, 10, 10);
+	testarray(tc, 100, 100);
+	testarray(tc, 32768, 32768);
+	testarray(tc, 5, 10);
+	testarray(tc, 5, 10);
+	testarray(tc, 5, 65536);
 }

--- a/tpkg/cutest/cutest_util.c
+++ b/tpkg/cutest/cutest_util.c
@@ -13,11 +13,13 @@
 #include "tpkg/cutest/cutest.h"
 #include "region-allocator.h"
 #include "util.h"
+#include "xfrd-tcp.h"
 
 static void util_1(CuTest *tc);
 static void util_2(CuTest *tc);
 static void util_3(CuTest *tc);
 static void util_4(CuTest *tc);
+static void util_5(CuTest *tc);
 
 CuSuite* reg_cutest_util(void)
 {
@@ -27,6 +29,7 @@ CuSuite* reg_cutest_util(void)
 	SUITE_ADD_TEST(suite, util_2);
 	SUITE_ADD_TEST(suite, util_3);
 	SUITE_ADD_TEST(suite, util_4);
+	SUITE_ADD_TEST(suite, util_5);
 	return suite;
 }
 
@@ -157,4 +160,61 @@ static void util_4(CuTest *tc)
 	CuAssert(tc, "test if pton is correct with ntop", hex_ntop(dest, 10, buf, 100) == 20);
 	/* strings differ only in case */
 	CuAssert(tc, "test results of pton ntop", strcasecmp(buf, teststr)==0);
+}
+
+/* compare for sort of ID values */
+static int
+compare_value(const void* x, const void* y)
+{
+	const uint16_t* ax = (const uint16_t*)x;
+	const uint16_t* ay = (const uint16_t*)y;
+	if(*ax < *ay)
+		return -1;
+	if(*ax > *ay)
+		return 1;
+	return 0;
+}
+
+/* check if array contains no duplicates. */
+static void check_nodupes(CuTest* tc, uint16_t* array, int num)
+{
+	int i;
+	qsort(array, num, sizeof(array[0]), &compare_value);
+	for(i=0; i<num-1; i++) {
+		if(i+1 < num) {
+			CuAssert(tc, "checknodupes",
+				array[i] != array[i+1]);
+		}
+	}
+}
+
+static void util_5(CuTest *tc)
+{
+	uint16_t array[65536];
+	/* test void pick_id_values(uint16_t* array, int num, int max); */
+	memset(array, 0, sizeof(array[0])*65536);
+	pick_id_values(array, 1, 1);
+	check_nodupes(tc, array, 1);
+	pick_id_values(array, 10, 10);
+	check_nodupes(tc, array, 10);
+	pick_id_values(array, 100, 100);
+	check_nodupes(tc, array, 100);
+	pick_id_values(array, 32768, 32768);
+	check_nodupes(tc, array, 32768);
+	pick_id_values(array, 5, 10);
+	check_nodupes(tc, array, 5);
+	pick_id_values(array, 5, 10);
+	check_nodupes(tc, array, 5);
+	pick_id_values(array, 5, 10);
+	check_nodupes(tc, array, 5);
+	pick_id_values(array, 5, 32768);
+	check_nodupes(tc, array, 5);
+	pick_id_values(array, 32000, 32768);
+	check_nodupes(tc, array, 32000);
+	pick_id_values(array, 32000, 65536);
+	check_nodupes(tc, array, 32000);
+	pick_id_values(array, 128, 65536);
+	check_nodupes(tc, array, 128);
+	pick_id_values(array, 4, 65536);
+	check_nodupes(tc, array, 4);
 }

--- a/xfrd-tcp.h
+++ b/xfrd-tcp.h
@@ -31,8 +31,10 @@ typedef struct xfrd_tcp_set xfrd_tcp_set_type;
  * A set of xfrd tcp connections.
  */
 struct xfrd_tcp_set {
-	/* tcp connections, each has packet and read/wr state */
-	struct xfrd_tcp_pipeline *tcp_state[XFRD_MAX_TCP];
+	/* tcp connections, array, each has packet and read/wr state */
+	struct xfrd_tcp_pipeline **tcp_state;
+	/* max number of tcp connections, size of tcp_state array */
+	int tcp_max;
 	/* number of TCP connections in use. */
 	int tcp_count;
 	/* TCP timeout. */
@@ -154,7 +156,7 @@ struct xfrd_tcp_pipeline {
 };
 
 /* create set of tcp connections */
-struct xfrd_tcp_set* xfrd_tcp_set_create(struct region* region, const char *tls_cert_bundle);
+struct xfrd_tcp_set* xfrd_tcp_set_create(struct region* region, const char *tls_cert_bundle, int tcp_max);
 
 /* init tcp state */
 struct xfrd_tcp* xfrd_tcp_create(struct region* region, size_t bufsize);

--- a/xfrd-tcp.h
+++ b/xfrd-tcp.h
@@ -227,5 +227,7 @@ socklen_t xfrd_acl_sockaddr_frm(struct acl_options* acl,
 /* create pipeline tcp structure */
 struct xfrd_tcp_pipeline* xfrd_tcp_pipeline_create(region_type* region,
 	int tcp_pipeline);
+/* pick num uint16_t values, from 0..max-1, store in array */
+void pick_id_values(uint16_t* array, int num, int max);
 
 #endif /* XFRD_TCP_H */

--- a/xfrd-tcp.h
+++ b/xfrd-tcp.h
@@ -90,6 +90,8 @@ struct xfrd_tcp_pipeline_id {
 	uint16_t id;
 	/** zone pointer or TCP_NULL_SKIP */
 	struct xfrd_zone* zone;
+	/** next free in free list */
+	struct xfrd_tcp_pipeline_id* next_free;
 };
 
 /**
@@ -156,6 +158,9 @@ struct xfrd_tcp_pipeline {
 
 	/* size of the id and unused arrays. */
 	int pipe_num;
+	/* list of free xfrd_tcp_pipeline_id nodes, these are not in the
+	 * zone_per_id tree. preallocated at pipe_num amount. */
+	struct xfrd_tcp_pipeline_id* pipe_id_free_list;
 	/* The xfrd_zone pointers, per id number.
 	 * The key is struct xfrd_tcp_pipeline_id.
 	 * per-ID number the queries that have this ID number, every

--- a/xfrd-tcp.h
+++ b/xfrd-tcp.h
@@ -80,6 +80,19 @@ struct xfrd_tcp {
 #define TCP_NULL_SKIP ((struct xfrd_zone*)-1)
 
 /**
+ * The per-id zone pointers, with TCP_NULL_SKIP or a zone pointer for the
+ * ID value.
+ */
+struct xfrd_tcp_pipeline_id {
+	/** rbtree node as first member, this is the key. */
+	rbnode_type node;
+	/** the ID of this member */
+	uint16_t id;
+	/** zone pointer or TCP_NULL_SKIP */
+	struct xfrd_zone* zone;
+};
+
+/**
  * The tcp pipeline key structure. By ip_len, ip, num_unused and unique by
  * pointer value.
  */
@@ -143,7 +156,8 @@ struct xfrd_tcp_pipeline {
 
 	/* size of the id and unused arrays. */
 	int pipe_num;
-	/* Array of xfrd_zone pointers, per id number.
+	/* The xfrd_zone pointers, per id number.
+	 * The key is struct xfrd_tcp_pipeline_id.
 	 * per-ID number the queries that have this ID number, every
 	 * query owns one ID numbers (until it is done). NULL: unused
 	 * When a query is done but not all answer-packets have been
@@ -151,9 +165,9 @@ struct xfrd_tcp_pipeline {
 	 * is denoted with the pointer-value TCP_NULL_SKIP, the ids that
 	 * are skipped are not on the unused list.  They may be
 	 * removed once the last answer packet is skipped.
-	 * pipe_num-num_unused values in the id array are nonNULL (either
+	 * pipe_num-num_unused values are in the tree (either
 	 * a zone pointer or SKIP) */
-	struct xfrd_zone** id;
+	rbtree_type* zone_per_id;
 	/* Array of uint16_t, with ID values.
 	 * unused ID numbers; the first part of the array contains the IDs */
 	uint16_t* unused;

--- a/xfrd.c
+++ b/xfrd.c
@@ -196,7 +196,7 @@ xfrd_init(int socket, struct nsd* nsd, int shortsoa, int reload_active,
 	daemon_remote_attach(xfrd->nsd->rc, xfrd);
 #endif
 
-	xfrd->tcp_set = xfrd_tcp_set_create(xfrd->region, nsd->options->tls_cert_bundle);
+	xfrd->tcp_set = xfrd_tcp_set_create(xfrd->region, nsd->options->tls_cert_bundle, nsd->options->xfrd_tcp_max);
 	xfrd->tcp_set->tcp_timeout = nsd->tcp_timeout;
 #if !defined(HAVE_ARC4RANDOM) && !defined(HAVE_GETRANDOM)
 	srandom((unsigned long) getpid() * (unsigned long) time(NULL));
@@ -402,6 +402,8 @@ xfrd_shutdown()
 	daemon_remote_delete(xfrd->nsd->rc); /* ssl-delete secret keys */
 	if (xfrd->nsd->tls_ctx)
 		SSL_CTX_free(xfrd->nsd->tls_ctx);
+	if(xfrd->tcp_set->ssl_ctx)
+		SSL_CTX_free(xfrd->tcp_set->ssl_ctx);
 #endif
 #ifdef USE_DNSTAP
 	dt_collector_close(nsd.dt_collector, &nsd);

--- a/xfrd.c
+++ b/xfrd.c
@@ -196,7 +196,7 @@ xfrd_init(int socket, struct nsd* nsd, int shortsoa, int reload_active,
 	daemon_remote_attach(xfrd->nsd->rc, xfrd);
 #endif
 
-	xfrd->tcp_set = xfrd_tcp_set_create(xfrd->region, nsd->options->tls_cert_bundle, nsd->options->xfrd_tcp_max);
+	xfrd->tcp_set = xfrd_tcp_set_create(xfrd->region, nsd->options->tls_cert_bundle, nsd->options->xfrd_tcp_max, nsd->options->xfrd_tcp_pipeline);
 	xfrd->tcp_set->tcp_timeout = nsd->tcp_timeout;
 #if !defined(HAVE_ARC4RANDOM) && !defined(HAVE_GETRANDOM)
 	srandom((unsigned long) getpid() * (unsigned long) time(NULL));

--- a/xfrd.h
+++ b/xfrd.h
@@ -240,7 +240,7 @@ enum xfrd_packet_result {
    Note that also some sockets are used for writing the ixfr.db, xfrd.state
    files and for the pipes to the main parent process.
 
-   For xfrd_tcp_max 128 can be the number of TCP AXFR/IXFR concurrent
+   For xfrd_tcp_max, 128 is the default number of TCP AXFR/IXFR concurrent
    connections. Each entry has 64Kb buffer preallocated.
 */
 #define XFRD_MAX_UDP 128 /* max number of UDP sockets at a time for IXFR */

--- a/xfrd.h
+++ b/xfrd.h
@@ -239,9 +239,10 @@ enum xfrd_packet_result {
    And it should be below FD_SETSIZE, to be able to select() on replies.
    Note that also some sockets are used for writing the ixfr.db, xfrd.state
    files and for the pipes to the main parent process.
+
+   For xfrd_tcp_max 128 can be the number of TCP AXFR/IXFR concurrent
+   connections. Each entry has 64Kb buffer preallocated.
 */
-#define XFRD_MAX_TCP 128 /* max number of TCP AXFR/IXFR concurrent connections.*/
-			/* Each entry has 64Kb buffer preallocated.*/
 #define XFRD_MAX_UDP 128 /* max number of UDP sockets at a time for IXFR */
 #define XFRD_MAX_UDP_NOTIFY 128 /* max concurrent UDP sockets for NOTIFY */
 


### PR DESCRIPTION
This adds configuration options for the zone transfers memory usage. It sets the maximum number of transfers that can be performed, at the same time.

The options added are `xfrd-tcp-max` and `xfrd-tcp-pipeline`.