### PR TITLE
Allow user to specify socket type per ip-addres

### DIFF
--- a/configlexer.lex
+++ b/configlexer.lex
@@ -178,6 +178,7 @@ COMMENT \#
 COLON 	\:
 ANY     [^\"\n\r\\]|\\.
 
+%s	ip_address
 %x	quotedstring include include_quoted
 
 %%
@@ -185,7 +186,6 @@ ANY     [^\"\n\r\\]|\\.
 {SPACE}*{COMMENT}.* 	{ LEXOUT(("comment(%s) ", yytext)); /* ignore */ }
 server{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_SERVER;}
 name{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_NAME;}
-ip-address{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_IP_ADDRESS;}
 interface{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_IP_ADDRESS;}
 ip-transparent{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_IP_TRANSPARENT;}
 ip-freebind{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_IP_FREEBIND;}
@@ -299,22 +299,40 @@ cookie-secret{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_COOKIE_SECRET;}
 cookie-secret-file{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_COOKIE_SECRET_FILE;}
 xfrd-tcp-max{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_XFRD_TCP_MAX;}
 xfrd-tcp-pipeline{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_XFRD_TCP_PIPELINE;}
-{NEWLINE}		{ LEXOUT(("NL\n")); cfg_parser->line++;}
 
-servers={UNQUOTEDLETTER}*	{
+ip-address{COLON} {
+	BEGIN(ip_address);
+	LEXOUT(("v(%s) ", yytext));
+	return VAR_IP_ADDRESS;
+}
+<ip_address>tcp {
+	LEXOUT(("v(%s) ", yytext));
+	return VAR_TCP;
+}
+<ip_address>udp {
+	LEXOUT(("v(%s) ", yytext));
+	return VAR_UDP;
+}
+<ip_address>servers={UNQUOTEDLETTER}* {
 	yyless(yyleng - (yyleng - 8));
 	LEXOUT(("v(%s) ", yytext));
 	return VAR_SERVERS;
 }
-bindtodevice={UNQUOTEDLETTER}*	{
+<ip_address>bindtodevice={UNQUOTEDLETTER}* {
 	yyless(yyleng - (yyleng - 13));
 	LEXOUT(("v(%s) ", yytext));
 	return VAR_BINDTODEVICE;
 }
-setfib={UNQUOTEDLETTER}*	{
+<ip_address>setfib={UNQUOTEDLETTER}* {
 	yyless(yyleng - (yyleng - 7));
 	LEXOUT(("v(%s) ", yytext));
 	return VAR_SETFIB;
+}
+
+{NEWLINE}	{
+	BEGIN(INITIAL);
+	LEXOUT(("NL\n"));
+	cfg_parser->line++;
 }
 
 cpu-affinity{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_CPU_AFFINITY; }
@@ -333,24 +351,24 @@ server-[1-9][0-9]*-cpu-affinity{COLON}	{
 	/* Quoted strings. Strip leading and ending quotes */
 \"			{ BEGIN(quotedstring); LEXOUT(("QS ")); }
 <quotedstring><<EOF>>   {
-        c_error("EOF inside quoted string");
-        BEGIN(INITIAL);
+	c_error("EOF inside quoted string");
+	BEGIN(INITIAL);
 }
 <quotedstring>{ANY}*    { LEXOUT(("STR(%s) ", yytext)); yymore(); }
 <quotedstring>\n        { cfg_parser->line++; yymore(); }
 <quotedstring>\" {
-        LEXOUT(("QE "));
-        BEGIN(INITIAL);
-        yytext[yyleng - 1] = '\0';
+	LEXOUT(("QE "));
+	BEGIN(INITIAL);
+	yytext[yyleng - 1] = '\0';
 	c_lval.str = region_strdup(cfg_parser->opt->region, yytext);
-        return STRING;
+	return STRING;
 }
 
 	/* include: directive */
 include{COLON}		{ LEXOUT(("v(%s) ", yytext)); BEGIN(include); }
 <include><<EOF>>	{
-        c_error("EOF inside include directive");
-        BEGIN(INITIAL);
+	c_error("EOF inside include directive");
+	BEGIN(INITIAL);
 }
 <include>{SPACE}*	{ LEXOUT(("ISP ")); /* ignore */ }
 <include>{NEWLINE}	{ LEXOUT(("NL\n")); cfg_parser->line++;}
@@ -361,8 +379,8 @@ include{COLON}		{ LEXOUT(("v(%s) ", yytext)); BEGIN(include); }
 	BEGIN(INITIAL);
 }
 <include_quoted><<EOF>>	{
-        c_error("EOF inside quoted string");
-        BEGIN(INITIAL);
+	c_error("EOF inside quoted string");
+	BEGIN(INITIAL);
 }
 <include_quoted>{ANY}*	{ LEXOUT(("ISTR(%s) ", yytext)); yymore(); }
 <include_quoted>{NEWLINE}	{ cfg_parser->line++; yymore(); }
@@ -382,7 +400,10 @@ include{COLON}		{ LEXOUT(("v(%s) ", yytext)); BEGIN(include); }
 	}
 }
 
-{UNQUOTEDLETTER}*	{ LEXOUT(("unquotedstr(%s) ", yytext)); 
-			c_lval.str = region_strdup(cfg_parser->opt->region, yytext); return STRING; }
+{UNQUOTEDLETTER}*	{
+	LEXOUT(("unquotedstr(%s) ", yytext));
+	c_lval.str = region_strdup(cfg_parser->opt->region, yytext);
+	return STRING;
+}
 
 %%

--- a/configparser.y
+++ b/configparser.y
@@ -164,6 +164,7 @@ static int parse_range(const char *str, long long *low, long long *high);
 %token VAR_ALLOW_QUERY
 %token VAR_AXFR
 %token VAR_UDP
+%token VAR_TCP
 %token VAR_NOTIFY_RETRY
 %token VAR_ALLOW_NOTIFY
 %token VAR_REQUEST_XFR
@@ -226,6 +227,7 @@ server_option:
 
         cfg_parser->ip = $2;
       }
+    socket_types
     socket_options
     {
       cfg_parser->ip = NULL;
@@ -492,6 +494,26 @@ server_option:
         }
       }
     }
+  ;
+
+socket_types:
+  | udp_and_tcp
+    { cfg_parser->ip->udp = 1;
+      cfg_parser->ip->tcp = 1;
+    }
+  | VAR_UDP
+    { cfg_parser->ip->tcp = 0;
+      cfg_parser->ip->udp = 1;
+    }
+  | VAR_TCP
+    { cfg_parser->ip->tcp = 1;
+      cfg_parser->ip->udp = 0;
+    }
+  ;
+
+udp_and_tcp:
+    VAR_UDP VAR_TCP
+  | VAR_TCP VAR_UDP
   ;
 
 socket_options:
@@ -971,6 +993,8 @@ ip_address:
         cfg_parser->opt->region, sizeof(*ip));
       ip->address = region_strdup(cfg_parser->opt->region, $1);
       ip->fib = -1;
+      ip->udp = 2;
+      ip->tcp = 2;
       $$ = ip;
     } ;
 

--- a/ipc.c
+++ b/ipc.c
@@ -86,8 +86,8 @@ child_handle_parent_command(int fd, short event, void* arg)
 		break;
 	case NSD_QUIT_CHILD:
 		/* close our listening sockets and ack */
-		server_close_all_sockets(data->nsd->udp, data->nsd->ifs);
-		server_close_all_sockets(data->nsd->tcp, data->nsd->ifs);
+		server_close_all_sockets(&data->nsd->udp);
+		server_close_all_sockets(&data->nsd->tcp);
 		/* mode == NSD_QUIT_CHILD */
 		if(write(fd, &mode, sizeof(mode)) == -1) {
 			VERBOSITY(3, (LOG_INFO, "quit child write: %s",

--- a/nsd-checkconf.c
+++ b/nsd-checkconf.c
@@ -607,6 +607,10 @@ config_test_print_server(nsd_options_type* opt)
 	for(ip = opt->ip_addresses; ip; ip=ip->next)
 	{
 		printf("\tip-address: %s", ip->address);
+		if(ip->udp == 1)
+			printf(" udp");
+		if(ip->tcp == 1)
+			printf(" tcp");
 		if(ip->servers) {
 			const char *sep;
 			struct range_option *n;

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -142,9 +142,10 @@ clause. There may only be one
 .B server: 
 clause.
 .TP
-.B ip\-address:\fR <ip4 or ip6>[@port] [servers] [bindtodevice] [setfib]
+.B ip\-address:\fR <ip4 or ip6>[@port] [tcp|udp] [servers] [bindtodevice] [setfib]
 NSD will bind to the listed ip\-address. Can be given multiple times 
-to bind multiple ip\-addresses. Optionally, a port number can be given.
+to bind multiple ip\-addresses. Optionally, a port number and protocol type
+can be provided.
 If none are given NSD listens to the wildcard interface. Same as commandline option
 .BR \-a.
 .IP

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -40,6 +40,14 @@ server:
 	# ip-address: 1.2.3.4@5678
 	# ip-address: 12fe::8ef0
 	#
+	# IP addresses can be configured for a particular protocol if desired
+	# (default is to accept UDP and TCP). Specify what protocol types to
+	# to accept by specifying the protocol with the IP address.
+	#
+	# ip-address: 1.2.3.4       tcp
+	# ip-address: 1.2.3.4@5678  udp
+	# ip-address: 12fe::8ef0    tcp udp
+	#
 	# IP addresses can be configured per-server to avoid waking up more
 	# than one server when a packet comes in (thundering herd problem) or
 	# to partition sockets across servers to improve select/poll

--- a/options.h
+++ b/options.h
@@ -195,6 +195,8 @@ struct ip_address_option {
 	struct range_option* servers;
 	int dev;
 	int fib;
+	int udp;
+	int tcp;
 };
 
 struct cpu_option {

--- a/server.c
+++ b/server.c
@@ -721,9 +721,8 @@ set_cloexec(struct nsd_socket *sock)
 {
 	assert(sock != NULL);
 
-	if(fcntl(sock->s, F_SETFD, FD_CLOEXEC) == -1) {
-		const char *socktype =
-			sock->addr.ai_family == SOCK_DGRAM ? "udp" : "tcp";
+	if(fcntl(sock->socket, F_SETFD, FD_CLOEXEC) == -1) {
+		const char *socktype = sock->type == SOCK_DGRAM ? "udp" : "tcp";
 		log_msg(LOG_ERR, "fcntl(..., O_CLOEXEC) failed for %s: %s",
 			socktype, strerror(errno));
 		return -1;
@@ -751,7 +750,7 @@ set_reuseport(struct nsd_socket *sock)
 	static const char optname[] = "SO_REUSEPORT";
 #endif /* SO_REUSEPORT_LB */
 
-	if (0 == setsockopt(sock->s, SOL_SOCKET, opt, &on, sizeof(on))) {
+	if (0 == setsockopt(sock->socket, SOL_SOCKET, opt, &on, sizeof(on))) {
 		return 1;
 	} else if(verbosity >= 3 || errno != ENOPROTOOPT) {
 		log_msg(LOG_ERR, "setsockopt(..., %s, ...) failed: %s",
@@ -770,7 +769,7 @@ set_reuseaddr(struct nsd_socket *sock)
 {
 #ifdef SO_REUSEADDR
 	int on = 1;
-	if(setsockopt(sock->s, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) == 0) {
+	if(setsockopt(sock->socket, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) == 0) {
 		return 1;
 	}
 	log_msg(LOG_ERR, "setsockopt(..., SO_REUSEADDR, ...) failed: %s",
@@ -786,7 +785,7 @@ set_rcvbuf(struct nsd_socket *sock, int rcv)
 #ifdef SO_RCVBUF
 #ifdef SO_RCVBUFFORCE
 	if(0 == setsockopt(
-		sock->s, SOL_SOCKET, SO_RCVBUFFORCE, &rcv, sizeof(rcv)))
+		sock->socket, SOL_SOCKET, SO_RCVBUFFORCE, &rcv, sizeof(rcv)))
 	{
 		return 1;
 	}
@@ -798,7 +797,7 @@ set_rcvbuf(struct nsd_socket *sock, int rcv)
 	return -1;
 #else /* !SO_RCVBUFFORCE */
 	if (0 == setsockopt(
-		sock->s, SOL_SOCKET, SO_RCVBUF, &rcv, sizeof(rcv)))
+		sock->socket, SOL_SOCKET, SO_RCVBUF, &rcv, sizeof(rcv)))
 	{
 		return 1;
 	}
@@ -820,7 +819,7 @@ set_sndbuf(struct nsd_socket *sock, int snd)
 #ifdef SO_SNDBUF
 #ifdef SO_SNDBUFFORCE
 	if(0 == setsockopt(
-		sock->s, SOL_SOCKET, SO_SNDBUFFORCE, &snd, sizeof(snd)))
+		sock->socket, SOL_SOCKET, SO_SNDBUFFORCE, &snd, sizeof(snd)))
 	{
 		return 1;
 	}
@@ -832,7 +831,7 @@ set_sndbuf(struct nsd_socket *sock, int snd)
 	return -1;
 #else /* !SO_SNDBUFFORCE */
 	if(0 == setsockopt(
-		sock->s, SOL_SOCKET, SO_SNDBUF, &snd, sizeof(snd)))
+		sock->socket, SOL_SOCKET, SO_SNDBUF, &snd, sizeof(snd)))
 	{
 		return 1;
 	}
@@ -851,10 +850,9 @@ set_sndbuf(struct nsd_socket *sock, int snd)
 static int
 set_nonblock(struct nsd_socket *sock)
 {
-	const char *socktype =
-		sock->addr.ai_socktype == SOCK_DGRAM ? "udp" : "tcp";
+	const char *socktype = sock->type == SOCK_DGRAM ? "udp" : "tcp";
 
-	if(fcntl(sock->s, F_SETFL, O_NONBLOCK) == -1) {
+	if(fcntl(sock->socket, F_SETFL, O_NONBLOCK) == -1) {
 		log_msg(LOG_ERR, "fctnl(..., O_NONBLOCK) failed for %s: %s",
 			socktype, strerror(errno));
 		return -1;
@@ -869,11 +867,10 @@ set_ipv6_v6only(struct nsd_socket *sock)
 {
 #ifdef IPV6_V6ONLY
 	int on = 1;
-	const char *socktype =
-		sock->addr.ai_socktype == SOCK_DGRAM ? "udp" : "tcp";
+	const char *socktype = sock->type == SOCK_DGRAM ? "udp" : "tcp";
 
 	if(0 == setsockopt(
-		sock->s, IPPROTO_IPV6, IPV6_V6ONLY, &on, sizeof(on)))
+		sock->socket, IPPROTO_IPV6, IPV6_V6ONLY, &on, sizeof(on)))
 	{
 		return 1;
 	}
@@ -912,7 +909,7 @@ set_ipv6_use_min_mtu(struct nsd_socket *sock)
 	static const char optname[] = "IPV6_MTU";
 #endif
 	if(0 == setsockopt(
-		sock->s, IPPROTO_IPV6, opt, &optval, sizeof(optval)))
+		sock->socket, IPPROTO_IPV6, opt, &optval, sizeof(optval)))
 	{
 		return 1;
 	}
@@ -946,7 +943,7 @@ set_ipv4_no_pmtu_disc(struct nsd_socket *sock)
 	 */
 	optval = IP_PMTUDISC_OMIT;
 	if(0 == setsockopt(
-		sock->s, IPPROTO_IP, opt, &optval, sizeof(optval)))
+		sock->socket, IPPROTO_IP, opt, &optval, sizeof(optval)))
 	{
 		return 1;
 	}
@@ -958,7 +955,7 @@ set_ipv4_no_pmtu_disc(struct nsd_socket *sock)
 	/* Use IP_PMTUDISC_DONT if IP_PMTUDISC_OMIT failed / undefined. */
 	optval = IP_PMTUDISC_DONT;
 	if(0 == setsockopt(
-		sock->s, IPPROTO_IP, opt, &optval, sizeof(optval)))
+		sock->socket, IPPROTO_IP, opt, &optval, sizeof(optval)))
 	{
 		return 1;
 	}
@@ -970,7 +967,7 @@ set_ipv4_no_pmtu_disc(struct nsd_socket *sock)
 #elif defined(IP_DONTFRAG)
 	int off = 0;
 	if (0 == setsockopt(
-		sock->s, IPPROTO_IP, IP_DONTFRAG, &off, sizeof(off)))
+		sock->socket, IPPROTO_IP, IP_DONTFRAG, &off, sizeof(off)))
 	{
 		return 1;
 	}
@@ -990,9 +987,8 @@ set_ip_freebind(struct nsd_socket *sock)
 {
 #ifdef IP_FREEBIND
 	int on = 1;
-	const char *socktype =
-		sock->addr.ai_socktype == SOCK_DGRAM ? "udp" : "tcp";
-	if(setsockopt(sock->s, IPPROTO_IP, IP_FREEBIND, &on, sizeof(on)) == 0)
+	const char *socktype = sock->type == SOCK_DGRAM ? "udp" : "tcp";
+	if(setsockopt(sock->socket, IPPROTO_IP, IP_FREEBIND, &on, sizeof(on)) == 0)
 	{
 		return 1;
 	}
@@ -1051,12 +1047,11 @@ set_ip_transparent(struct nsd_socket *sock)
 #	endif
 
 	int on = 1;
-	const char *socktype =
-		sock->addr.ai_socktype == SOCK_DGRAM ? "udp" : "tcp";
-	const int is_ip6 = (sock->addr.ai_family == AF_INET6);
+	const char *socktype = sock->type == SOCK_DGRAM ? "udp" : "tcp";
+	const int is_ip6 = (sock->family == AF_INET6);
 
 	if(0 == setsockopt(
-		sock->s,
+		sock->socket,
 		is_ip6 ? NSD_SOCKET_OPTION_TRANSPARENT_OPTLEVEL6 : NSD_SOCKET_OPTION_TRANSPARENT_OPTLEVEL,
 		is_ip6 ? NSD_SOCKET_OPTION_TRANSPARENT6 : NSD_SOCKET_OPTION_TRANSPARENT,
 		&on, sizeof(on)))
@@ -1076,7 +1071,7 @@ static int
 set_tcp_maxseg(struct nsd_socket *sock, int mss)
 {
 #if defined(IPPROTO_TCP) && defined(TCP_MAXSEG)
-	if(setsockopt(sock->s, IPPROTO_TCP, TCP_MAXSEG, &mss, sizeof(mss)) == 0) {
+	if(setsockopt(sock->socket, IPPROTO_TCP, TCP_MAXSEG, &mss, sizeof(mss)) == 0) {
 		return 1;
 	}
 	log_msg(LOG_ERR, "setsockopt(..., TCP_MAXSEG, ...) failed for tcp: %s",
@@ -1108,7 +1103,7 @@ set_tcp_fastopen(struct nsd_socket *sock)
 	qlen = 5;
 #endif
 	if (0 == setsockopt(
-		sock->s, IPPROTO_TCP, TCP_FASTOPEN, &qlen, sizeof(qlen)))
+		sock->socket, IPPROTO_TCP, TCP_FASTOPEN, &qlen, sizeof(qlen)))
 	{
 		return 1;
 	}
@@ -1136,7 +1131,7 @@ static int
 set_bindtodevice(struct nsd_socket *sock)
 {
 #if defined(SO_BINDTODEVICE)
-	if(setsockopt(sock->s, SOL_SOCKET, SO_BINDTODEVICE,
+	if(setsockopt(sock->socket, SOL_SOCKET, SO_BINDTODEVICE,
 		sock->device, strlen(sock->device)) == -1)
 	{
 		log_msg(LOG_ERR, "setsockopt(..., %s, %s, ...) failed: %s",
@@ -1155,7 +1150,7 @@ static int
 set_setfib(struct nsd_socket *sock)
 {
 #if defined(SO_SETFIB)
-	if(setsockopt(sock->s, SOL_SOCKET, SO_SETFIB,
+	if(setsockopt(sock->socket, SOL_SOCKET, SO_SETFIB,
 	              (const void *)&sock->fib, sizeof(sock->fib)) == -1)
 	{
 		log_msg(LOG_ERR, "setsockopt(..., %s, %d, ...) failed: %s",
@@ -1174,13 +1169,12 @@ static int
 open_udp_socket(struct nsd *nsd, struct nsd_socket *sock, int *reuseport_works)
 {
 	int rcv = 1*1024*1024, snd = 1*1024*1024;
+	socklen_t addrlen = 0;
 
-	if(-1 == (sock->s = socket(
-		sock->addr.ai_family, sock->addr.ai_socktype, 0)))
-	{
+	if(-1 == (sock->socket = socket(sock->family, sock->type, 0))) {
 #ifdef INET6
-		if((sock->flags & NSD_SOCKET_IS_OPTIONAL) &&
-		   (sock->addr.ai_family == AF_INET6) &&
+		if((sock->flags & NSD_OPTIONAL_SOCKET) &&
+		   (sock->family == AF_INET6) &&
 		   (errno == EAFNOSUPPORT))
 		{
 			log_msg(LOG_WARNING, "fallback to UDP4, no IPv6: "
@@ -1207,13 +1201,16 @@ open_udp_socket(struct nsd *nsd, struct nsd_socket *sock, int *reuseport_works)
 	if(set_sndbuf(sock, snd) == -1)
 		return -1;
 #ifdef INET6
-	if(sock->addr.ai_family == AF_INET6) {
+	if(sock->family == AF_INET6) {
+		addrlen = sizeof(struct sockaddr_in6);
 		if(set_ipv6_v6only(sock) == -1 ||
 		   set_ipv6_use_min_mtu(sock) == -1)
 			return -1;
 	} else
 #endif /* INET6 */
-	if(sock->addr.ai_family == AF_INET) {
+	{
+		addrlen = sizeof(struct sockaddr_in);
+		assert(sock->family == AF_INET);
 		if(set_ipv4_no_pmtu_disc(sock) == -1)
 			return -1;
 	}
@@ -1233,9 +1230,9 @@ open_udp_socket(struct nsd *nsd, struct nsd_socket *sock, int *reuseport_works)
 	if(sock->fib != -1 && set_setfib(sock) == -1)
 		return -1;
 
-	if(bind(sock->s, (struct sockaddr *)&sock->addr.ai_addr, sock->addr.ai_addrlen) == -1) {
+	if(bind(sock->socket, (struct sockaddr *)&sock->address.inet, addrlen) == -1) {
 		char buf[256];
-		addrport2str((void*)&sock->addr.ai_addr, buf, sizeof(buf));
+		addrport2str((void*)&sock->address.inet, buf, sizeof(buf));
 		log_msg(LOG_ERR, "can't bind udp socket %s: %s",
 			buf, strerror(errno));
 		return -1;
@@ -1247,18 +1244,17 @@ open_udp_socket(struct nsd *nsd, struct nsd_socket *sock, int *reuseport_works)
 static int
 open_tcp_socket(struct nsd *nsd, struct nsd_socket *sock, int *reuseport_works)
 {
+	socklen_t addrlen = 0;
 #ifdef USE_TCP_FASTOPEN
 	report_tcp_fastopen_config();
 #endif
 
 	(void)reuseport_works;
 
-	if(-1 == (sock->s = socket(
-		sock->addr.ai_family, sock->addr.ai_socktype, 0)))
-	{
+	if(-1 == (sock->socket = socket(sock->family, sock->type, 0))) {
 #ifdef INET6
-		if((sock->flags & NSD_SOCKET_IS_OPTIONAL) &&
-		   (sock->addr.ai_family == AF_INET6) &&
+		if((sock->flags & NSD_OPTIONAL_SOCKET) &&
+		   (sock->family == AF_INET6) &&
 		   (errno == EAFNOSUPPORT))
 		{
 			log_msg(LOG_WARNING, "fallback to TCP4, no IPv6: "
@@ -1278,12 +1274,17 @@ open_tcp_socket(struct nsd *nsd, struct nsd_socket *sock, int *reuseport_works)
 	(void)set_reuseaddr(sock);
 
 #ifdef INET6
-	if(sock->addr.ai_family == AF_INET6) {
+	if(sock->family == AF_INET6) {
+		addrlen = sizeof(struct sockaddr_in6);
 		if (set_ipv6_v6only(sock) == -1 ||
 		    set_ipv6_use_min_mtu(sock) == -1)
 			return -1;
-	}
+	} else
 #endif
+	{
+		assert(sock->family == AF_INET);
+		addrlen = sizeof(struct sockaddr_in);
+	}
 
 	if(nsd->tcp_mss > 0)
 		set_tcp_maxseg(sock, nsd->tcp_mss);
@@ -1299,9 +1300,9 @@ open_tcp_socket(struct nsd *nsd, struct nsd_socket *sock, int *reuseport_works)
 	if(sock->fib != -1 && set_setfib(sock) == -1)
 		return -1;
 
-	if(bind(sock->s, (struct sockaddr *)&sock->addr.ai_addr, sock->addr.ai_addrlen) == -1) {
+	if(bind(sock->socket, (struct sockaddr *)&sock->address.inet, addrlen) == -1) {
 		char buf[256];
-		addrport2str((void*)&sock->addr.ai_addr, buf, sizeof(buf));
+		addrport2str((void*)&sock->address.inet, buf, sizeof(buf));
 		log_msg(LOG_ERR, "can't bind tcp socket %s: %s",
 			buf, strerror(errno));
 		return -1;
@@ -1311,7 +1312,7 @@ open_tcp_socket(struct nsd *nsd, struct nsd_socket *sock, int *reuseport_works)
 	(void)set_tcp_fastopen(sock);
 #endif
 
-	if(listen(sock->s, TCP_BACKLOG) == -1) {
+	if(listen(sock->socket, TCP_BACKLOG) == -1) {
 		log_msg(LOG_ERR, "can't listen: %s", strerror(errno));
 		return -1;
 	}
@@ -1328,51 +1329,42 @@ server_init(struct nsd *nsd)
 	size_t i;
 	int reuseport = 1; /* Determine if REUSEPORT works. */
 
-	/* open server interface ports */
-	for(i = 0; i < nsd->ifs; i++) {
-		if(open_udp_socket(nsd, &nsd->udp[i], &reuseport) == -1 ||
-		   open_tcp_socket(nsd, &nsd->tcp[i], &reuseport) == -1)
-		{
+	/* open server udp interface ports */
+	for (i = 0; i < nsd->udp.count; i++) {
+		if (open_udp_socket(nsd, &nsd->udp.sockets[i], &reuseport) == -1)
 			return -1;
-		}
 	}
 
-	if(nsd->reuseport && reuseport) {
-		size_t ifs = nsd->ifs * nsd->reuseport;
+	/* open server tcp interface ports */
+	for (i = 0; i < nsd->tcp.count; i++) {
+		if (open_tcp_socket(nsd, &nsd->tcp.sockets[i], &reuseport) == -1)
+			return -1;
+	}
 
-		/* increase the size of the interface arrays, there are going
+	if (nsd->reuseport && reuseport) {
+		size_t ifs = nsd->udp.count * nsd->reuseport;
+
+		/* increase the size of the udp interface array, there are going
 		 * to be separate interface file descriptors for every server
 		 * instance */
-		region_remove_cleanup(nsd->region, free, nsd->udp);
-		region_remove_cleanup(nsd->region, free, nsd->tcp);
+		region_remove_cleanup(nsd->region, free, nsd->udp.sockets);
 
-		nsd->udp = xrealloc(nsd->udp, ifs * sizeof(*nsd->udp));
-		nsd->tcp = xrealloc(nsd->tcp, ifs * sizeof(*nsd->tcp));
-		region_add_cleanup(nsd->region, free, nsd->udp);
-		region_add_cleanup(nsd->region, free, nsd->tcp);
-		if(ifs > nsd->ifs) {
-			memset(&nsd->udp[nsd->ifs], 0,
-				(ifs-nsd->ifs)*sizeof(*nsd->udp));
-			memset(&nsd->tcp[nsd->ifs], 0,
-				(ifs-nsd->ifs)*sizeof(*nsd->tcp));
+		nsd->udp.sockets = xrealloc(nsd->udp.sockets, ifs * sizeof(*nsd->udp.sockets));
+		region_add_cleanup(nsd->region, free, nsd->udp.sockets);
+
+		if (ifs > nsd->udp.count) {
+			memset(&nsd->udp.sockets[nsd->udp.count], 0,
+				(ifs - nsd->udp.count) * sizeof(*nsd->udp.sockets));
 		}
 
-		for(i = nsd->ifs; i < ifs; i++) {
-			nsd->udp[i] = nsd->udp[i%nsd->ifs];
-			nsd->udp[i].s = -1;
-			if(open_udp_socket(nsd, &nsd->udp[i], &reuseport) == -1) {
+		for (i = nsd->udp.count; i < ifs; i++) {
+			nsd->udp.sockets[i] = nsd->udp.sockets[i%nsd->udp.count];
+			nsd->udp.sockets[i].socket = -1;
+			if (open_udp_socket(nsd, &nsd->udp.sockets[i], &reuseport) == -1)
 				return -1;
-			}
-			/* Turn off REUSEPORT for TCP by copying the socket
-			 * file descriptor.
-			 * This means we should not close TCP used by
-			 * other servers in reuseport enabled mode, in
-			 * server_child().
-			 */
-			nsd->tcp[i] = nsd->tcp[i%nsd->ifs];
 		}
 
-		nsd->ifs = ifs;
+		nsd->udp.count = ifs;
 	} else {
 		nsd->reuseport = 0;
 	}
@@ -1469,20 +1461,20 @@ server_start_children(struct nsd *nsd, region_type* region, netio_type* netio,
 static void
 server_close_socket(struct nsd_socket *sock)
 {
-	if(sock->s != -1) {
-		close(sock->s);
-		sock->s = -1;
+	if(sock->socket != -1) {
+		close(sock->socket);
+		sock->socket = -1;
 	}
 }
 
 void
-server_close_all_sockets(struct nsd_socket sockets[], size_t n)
+server_close_all_sockets(struct nsd_socket_set *set)
 {
 	size_t i;
 
 	/* Close all the sockets... */
-	for (i = 0; i < n; ++i) {
-		server_close_socket(&sockets[i]);
+	for (i = 0; i < set->count; ++i) {
+		server_close_socket(&set->sockets[i]);
 	}
 }
 
@@ -1495,8 +1487,8 @@ server_shutdown(struct nsd *nsd)
 {
 	size_t i;
 
-	server_close_all_sockets(nsd->udp, nsd->ifs);
-	server_close_all_sockets(nsd->tcp, nsd->ifs);
+	server_close_all_sockets(&nsd->udp);
+	server_close_all_sockets(&nsd->tcp);
 	/* CHILD: close command channel to parent */
 	if(nsd->this_child && nsd->this_child->parent_fd != -1)
 	{
@@ -1689,8 +1681,8 @@ server_send_soa_xfrd(struct nsd* nsd, int shortsoa)
 		if(nsd->signal_hint_shutdown) {
 		shutdown:
 			log_msg(LOG_WARNING, "signal received, shutting down...");
-			server_close_all_sockets(nsd->udp, nsd->ifs);
-			server_close_all_sockets(nsd->tcp, nsd->ifs);
+			server_close_all_sockets(&nsd->udp);
+			server_close_all_sockets(&nsd->tcp);
 #ifdef HAVE_SSL
 			daemon_remote_close(nsd->rc);
 #endif
@@ -2737,8 +2729,8 @@ server_main(struct nsd *nsd)
 	log_msg(LOG_WARNING, "signal received, shutting down...");
 
 	/* close opened ports to avoid race with restart of nsd */
-	server_close_all_sockets(nsd->udp, nsd->ifs);
-	server_close_all_sockets(nsd->tcp, nsd->ifs);
+	server_close_all_sockets(&nsd->udp);
+	server_close_all_sockets(&nsd->tcp);
 #ifdef HAVE_SSL
 	daemon_remote_close(nsd->rc);
 #endif
@@ -2904,7 +2896,7 @@ add_udp_handler(
 	data->socket = sock;
 
 	memset(handler, 0, sizeof(*handler));
-	event_set(handler, sock->s, EV_PERSIST|EV_READ, handle_udp, data);
+	event_set(handler, sock->socket, EV_PERSIST|EV_READ, handle_udp, data);
 	if(event_base_set(nsd->event_base, handler) != 0)
 		log_msg(LOG_ERR, "nsd udp: event_base_set failed");
 	if(event_add(handler, NULL) != 0)
@@ -2925,12 +2917,12 @@ add_tcp_handler(
 #ifdef HAVE_SSL
 	if (nsd->tls_ctx &&
 	    nsd->options->tls_port &&
-	    using_tls_port((struct sockaddr *)&sock->addr.ai_addr, nsd->options->tls_port))
+	    using_tls_port((struct sockaddr *)&sock->address.inet, nsd->options->tls_port))
 	{
 		data->tls_accept = 1;
 		if(verbosity >= 2) {
 			char buf[48];
-			addrport2str((void*)(struct sockaddr_storage*)&sock->addr.ai_addr, buf, sizeof(buf));
+			addrport2str((void*)(struct sockaddr_storage*)&sock->address.inet, buf, sizeof(buf));
 			VERBOSITY(4, (LOG_NOTICE, "setup TCP for TLS service on interface %s", buf));
 		}
 	} else {
@@ -2939,7 +2931,7 @@ add_tcp_handler(
 #endif
 
 	memset(handler, 0, sizeof(*handler));
-	event_set(handler, sock->s, EV_PERSIST|EV_READ,	handle_tcp_accept, data);
+	event_set(handler, sock->socket, EV_PERSIST|EV_READ, handle_tcp_accept, data);
 	if(event_base_set(nsd->event_base, handler) != 0)
 		log_msg(LOG_ERR, "nsd tcp: event_base_set failed");
 	if(event_add(handler, NULL) != 0)
@@ -2982,10 +2974,10 @@ server_child(struct nsd *nsd)
 #endif
 
 	if (!(nsd->server_kind & NSD_SERVER_TCP)) {
-		server_close_all_sockets(nsd->tcp, nsd->ifs);
+		server_close_all_sockets(&nsd->tcp);
 	}
 	if (!(nsd->server_kind & NSD_SERVER_UDP)) {
-		server_close_all_sockets(nsd->udp, nsd->ifs);
+		server_close_all_sockets(&nsd->udp);
 	}
 
 	if (nsd->this_child->parent_fd != -1) {
@@ -3008,15 +3000,15 @@ server_child(struct nsd *nsd)
 	}
 
 	if(nsd->reuseport) {
-		numifs = nsd->ifs / nsd->reuseport;
+		numifs = nsd->udp.count / nsd->reuseport;
 		from = numifs * nsd->this_child->child_num;
-		if(from+numifs > nsd->ifs) { /* should not happen */
+		if(from+numifs > nsd->udp.count) { /* should not happen */
 			from = 0;
-			numifs = nsd->ifs;
+			numifs = nsd->udp.count;
 		}
 	} else {
 		from = 0;
-		numifs = nsd->ifs;
+		numifs = nsd->udp.count;
 	}
 
 	if (nsd->server_kind & NSD_SERVER_UDP) {
@@ -3035,19 +3027,19 @@ server_child(struct nsd *nsd)
 			msgs[i].msg_hdr.msg_namelen = queries[i]->addrlen;
 		}
 
-		for (i = 0; i < nsd->ifs; i++) {
+		for (i = 0; i < nsd->udp.count; i++) {
 			int listen;
 			struct udp_handler_data *data;
 
-			listen = nsd_bitset_isset(nsd->udp[i].servers, child);
+			listen = nsd_bitset_isset(nsd->udp.sockets[i].servers, child);
 
 			if(i >= from && i < (from + numifs) && listen) {
 				data = region_alloc_zero(
 					nsd->server_region, sizeof(*data));
-				add_udp_handler(nsd, &nsd->udp[i], data);
+				add_udp_handler(nsd, &nsd->udp.sockets[i], data);
 			} else {
 				/* close sockets intended for other servers */
-				server_close_socket(&nsd->udp[i]);
+				server_close_socket(&nsd->udp.sockets[i]);
 			}
 		}
 	}
@@ -3063,27 +3055,19 @@ server_child(struct nsd *nsd)
 		tcp_accept_handlers = region_alloc_array(server_region,
 			numifs, sizeof(*tcp_accept_handlers));
 
-		for (i = 0; i < nsd->ifs; i++) {
+		for (i = 0; i < nsd->tcp.count; i++) {
 			int listen;
 			struct tcp_accept_handler_data *data;
 
-			listen = nsd_bitset_isset(nsd->tcp[i].servers, child);
+			listen = nsd_bitset_isset(nsd->tcp.sockets[i].servers, child);
 
-			if(i >= from && i < (from + numifs) && listen) {
-				data = &tcp_accept_handlers[i-from];
+			if (listen) {
+				data = &tcp_accept_handlers[i];
 				memset(data, 0, sizeof(*data));
-				add_tcp_handler(nsd, &nsd->tcp[i], data);
+				add_tcp_handler(nsd, &nsd->tcp.sockets[i], data);
 			} else {
-				/* close sockets intended for other servers */
-				/*
-				 * uncomment this once tcp servers are no
-				 * longer copied in the tcp fd copy line
-				 * in server_init().
-				server_close_socket(&nsd->tcp[i]);
-				*/
-				/* close sockets not meant for this server*/
-				if(!listen)
-					server_close_socket(&nsd->tcp[i]);
+				/* close sockets not meant for this server */
+				server_close_socket(&nsd->tcp.sockets[i]);
 			}
 		}
 	} else {
@@ -3423,9 +3407,9 @@ handle_udp(int fd, short event, void* arg)
 
 		/* Account... */
 #ifdef BIND8_STATS
-		if (data->socket->addr.ai_family == AF_INET) {
+		if (data->socket->family == AF_INET) {
 			STATUP(data->nsd, qudp);
-		} else if (data->socket->addr.ai_family == AF_INET6) {
+		} else if (data->socket->family == AF_INET6) {
 			STATUP(data->nsd, qudp6);
 		}
 #endif

--- a/tpkg/checkconf.tdir/checkconf.check
+++ b/tpkg/checkconf.tdir/checkconf.check
@@ -516,3 +516,78 @@ checkconf.nsd09.conf:9: error: expected yes or no
 read checkconf.nsd09.conf failed: 1 errors in configuration file
 checkconf.nsd10.conf:10: error: expected a number
 read checkconf.nsd10.conf failed: 1 errors in configuration file
+# Read file checkconf.nsd11.conf: 0 patterns, 0 fixed-zones, 0 keys, 0 tls-auth.
+# Config settings.
+server:
+	debug-mode: no
+	ip-transparent: no
+	ip-freebind: no
+	reuseport: no
+	do-ip4: yes
+	do-ip6: yes
+	send-buffer-size: 0
+	receive-buffer-size: 0
+	hide-version: no
+	hide-identity: no
+	drop-updates: no
+	tcp-reject-overflow: no
+	database: "/var/db/nsd/nsd.db"
+	#identity:
+	#version:
+	#nsid:
+	#logfile:
+	log-only-syslog: no
+	server-count: 1
+	tcp-count: 100
+	tcp-query-count: 0
+	tcp-timeout: 120
+	tcp-mss: 0
+	outgoing-tcp-mss: 0
+	xfrd-tcp-max: 128
+	xfrd-tcp-pipeline: 128
+	ipv4-edns-size: 1232
+	ipv6-edns-size: 1232
+	pidfile: "/var/run/nsd.pid"
+	port: "53"
+	statistics: 0
+	#chroot:
+	username: "nsd"
+	zonesdir: "/etc/nsd"
+	xfrdfile: "/var/db/nsd/xfrd.state"
+	zonelistfile: "/var/db/nsd/zone.list"
+	xfrdir: "/tmp"
+	xfrd-reload-timeout: 1
+	log-time-ascii: yes
+	round-robin: no
+	minimal-responses: no
+	confine-to-zone: no
+	refuse-any: no
+	verbosity: 0
+	ip-address: 127.0.0.1@53053
+	ip-address: 127.0.0.1@53153 udp
+	ip-address: 127.0.0.1@53253 tcp
+	ip-address: 127.0.0.1@53453 udp tcp
+	ip-address: 127.0.0.1@53553 udp tcp
+	zonefiles-check: yes
+	zonefiles-write: 0
+	#tls-service-key:
+	#tls-service-pem:
+	#tls-service-ocsp:
+	tls-port: "853"
+	#tls-cert-bundle:
+	answer-cookie: no
+	cookie-secret-file: "/etc/nsd/nsd_cookiesecrets.txt"
+
+remote-control:
+	control-enable: no
+	control-port: 8952
+	server-key-file: "/etc/nsd/nsd_server.key"
+	server-cert-file: "/etc/nsd/nsd_server.pem"
+	control-key-file: "/etc/nsd/nsd_control.key"
+	control-cert-file: "/etc/nsd/nsd_control.pem"
+checkconf.nsd11.invalid.conf:4: at 'foo': error: syntax error
+read checkconf.nsd11.invalid.conf failed: 1 errors in configuration file
+checkconf.nsd11.tcp2x.conf:4: at 'tcp': error: syntax error
+read checkconf.nsd11.tcp2x.conf failed: 1 errors in configuration file
+checkconf.nsd11.udp2x.conf:4: at 'udp': error: syntax error
+read checkconf.nsd11.udp2x.conf failed: 1 errors in configuration file

--- a/tpkg/checkconf.tdir/checkconf.nsd11.conf
+++ b/tpkg/checkconf.tdir/checkconf.nsd11.conf
@@ -1,0 +1,9 @@
+# Configuration file to ensure proper handling of socket type per ip-address.
+# Accepted values are upd, tcp, and a combination of the two. The socket type
+# may also be omitted, in which case both udp and tcp sockets are opened.
+server:
+  ip-address: 127.0.0.1@53053
+  ip-address: 127.0.0.1@53153 udp
+  ip-address: 127.0.0.1@53253 tcp
+  ip-address: 127.0.0.1@53453 udp tcp
+  ip-address: 127.0.0.1@53553 tcp udp

--- a/tpkg/checkconf.tdir/checkconf.nsd11.invalid.conf
+++ b/tpkg/checkconf.tdir/checkconf.nsd11.invalid.conf
@@ -1,0 +1,4 @@
+# Configuration file to ensure proper handling of socket type per ip-address.
+# Specifying the same socket type twice is prohibited.
+server:
+  ip-address: 127.0.0.1@53053 foo bar

--- a/tpkg/checkconf.tdir/checkconf.nsd11.tcp2x.conf
+++ b/tpkg/checkconf.tdir/checkconf.nsd11.tcp2x.conf
@@ -1,0 +1,4 @@
+# Configuration file to ensure proper handling of socket type per ip-address.
+# Specifying the same socket type twice is prohibited.
+server:
+  ip-address: 127.0.0.1@53053 tcp tcp

--- a/tpkg/checkconf.tdir/checkconf.nsd11.udp2x.conf
+++ b/tpkg/checkconf.tdir/checkconf.nsd11.udp2x.conf
@@ -1,0 +1,4 @@
+# Configuration file to ensure proper handling of socket type per ip-address.
+# Specifying the same socket type twice is prohibited.
+server:
+  ip-address: 127.0.0.1@53053 udp udp

--- a/tpkg/socket_types.tdir/socket_types.conf
+++ b/tpkg/socket_types.tdir/socket_types.conf
@@ -1,0 +1,19 @@
+server:
+	ip-address: 127.0.0.1@NSD_PORT
+	ip-address: 127.0.0.1@NSD_TCP_PORT tcp
+	ip-address: 127.0.0.1@NSD_UDP_PORT udp
+	ip-address: 127.0.0.1@NSD_TCP_UDP_PORT tcp udp
+	logfile: "nsd.log"
+	difffile: ixfr.db
+	xfrdfile: xfrd.state
+	zonesdir: ""
+	username: ""
+	chroot: ""
+	pidfile: NSD_PID
+	database: ""
+	verbosity: 5
+	zonelistfile: "zone.list"
+
+zone:
+  name: example.com.
+  zonefile: socket_types.zone

--- a/tpkg/socket_types.tdir/socket_types.dsc
+++ b/tpkg/socket_types.tdir/socket_types.dsc
@@ -1,0 +1,16 @@
+BaseName: socket_types
+Version: 1.0
+Description: Test server only opens specific socket types if specified
+CreationDate: Thu Mar 24 12:43:57 PM CET 2022
+Maintainer: Jeroen Koekkoek
+Category:
+Component:
+CmdDepends:
+Depends:
+Help:
+Pre: socket_types.pre
+Post: socket_types.post
+Test: socket_types.test
+AuxFiles: socket_types.conf
+Passed:
+Failure:

--- a/tpkg/socket_types.tdir/socket_types.post
+++ b/tpkg/socket_types.tdir/socket_types.post
@@ -1,0 +1,14 @@
+# #-- socket_types.post --#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# source the test var file when it's there
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+# do your teardown here
+if ! test -e $NSD_PID ; then
+	exit 0
+fi
+
+# kill NSD
+kill_pid `cat $NSD_PID`

--- a/tpkg/socket_types.tdir/socket_types.pre
+++ b/tpkg/socket_types.tdir/socket_types.pre
@@ -1,0 +1,32 @@
+# #-- socket_types.pre--#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+get_random_port 4
+NSD_PORT=$RND_PORT
+NSD_TCP_PORT=$(($RND_PORT + 1))
+NSD_UDP_PORT=$(($RND_PORT + 2))
+NSD_TCP_UDP_PORT=$(($RND_PORT + 3))
+NSD_PID="nsd.pid"
+
+echo port: $NSD_PORT
+echo tcp port: $NSD_TCP_PORT
+echo udp port: $NSD_UDP_PORT
+echo tcp+udp port: $NSD_TCP_UDP_PORT
+
+# share the vars
+echo "export NSD_PORT=$NSD_PORT" >> .tpkg.var.test
+echo "export NSD_TCP_PORT=$NSD_TCP_PORT" >> .tpkg.var.test
+echo "export NSD_UDP_PORT=$NSD_UDP_PORT" >> .tpkg.var.test
+echo "export NSD_TCP_UDP_PORT=$NSD_TCP_UDP_PORT" >> .tpkg.var.test
+echo "export NSD_PID=$NSD_PID" >> .tpkg.var.test
+
+sed -e "s/NSD_PORT/$NSD_PORT/" \
+    -e "s/NSD_TCP_PORT/$NSD_TCP_PORT/" \
+    -e "s/NSD_UDP_PORT/$NSD_UDP_PORT/" \
+    -e "s/NSD_TCP_UDP_PORT/$NSD_TCP_UDP_PORT/" \
+    -e "s/NSD_PID/$NSD_PID/" \
+    < socket_types.conf > nsd.conf

--- a/tpkg/socket_types.tdir/socket_types.test
+++ b/tpkg/socket_types.tdir/socket_types.test
@@ -1,0 +1,50 @@
+# #-- socket_types.test --#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+# start NSD
+PRE="../.."
+TPKG_NSD="$PRE/nsd"
+
+$TPKG_NSD -c nsd.conf -p $NSD_PORT -V 5
+wait_nsd_up nsd.log
+wait_logfile nsd.log "nsd started"
+
+cat nsd.log
+
+# ensure server is listening on tcp sockets
+for PORT in $NSD_PORT $NSD_TCP_PORT $NSD_TCP_UDP_PORT; do
+  if dig @127.0.0.1 -p $PORT +tcp +timeout=1 ns1.example.com; then
+    echo "server is correctly accepting TCP queries on 127.0.0.1@$PORT"
+  else
+    echo "server is incorrectly not accepting TCP queries on 127.0.0.1@$PORT"
+    exit 1
+  fi
+done
+
+# ensure server is listening on udp sockets
+for PORT in $NSD_PORT $NSD_UDP_PORT $NSD_TCP_UDP_PORT; do
+  if dig @127.0.0.1 -p $PORT +notcp +timeout=1 ns1.example.com; then
+    echo "server is correctly accepting UDP queries on 127.0.0.1@$PORT"
+  else
+    echo "server is incorrectly not accepting UDP queries on 127.0.0.1@$PORT"
+    exit 1
+  fi
+done
+
+if dig @127.0.0.1 -p $NSD_UDP_PORT +tcp +timeout=1 ns1.example.com; then
+  echo "server is incorrectly accepting TCP queries on 127.0.0.1@$NSD_UDP_PORT"
+  exit 1
+else
+  echo "server is correctly not accepting TCP queries on 127.0.0.1@$NSD_UDP_PORT"
+fi
+
+if dig @127.0.0.1 -p $NSD_TCP_PORT +notcp +timeout=1 ns1.example.com; then
+  echo "server is incorrectly accepting UDP queries on 127.0.0.1@$NSD_TCP_PORT"
+  exit 1
+else
+  echo "server is correctly not accepting UDP queries on 127.0.0.1@$NSD_TCP_PORT"
+fi

--- a/tpkg/socket_types.tdir/socket_types.zone
+++ b/tpkg/socket_types.tdir/socket_types.zone
@@ -1,0 +1,7 @@
+$ORIGIN example.com.
+$TTL 86400
+@    IN  SOA  ns1.example.com. hostmaster.example.com. (2022032401 21600 3600 604800 86400)
+         NS   ns1.example.com.
+         NS   ns2.example.com.
+ns1      A    127.0.0.1
+ns2      A    127.0.0.2


### PR DESCRIPTION
Listening on both UDP and TCP is likely unwanted behavior when support for XDP lands. Allow the user to configure listening on UDP, TCP or both per ip-address option in preparation. Specifying no socket type at all ensures both UDP and TCP are opened, which is the current default behavior, thereby remaining backwards compatible configuration wise.