### PR TITLE
Always log command line control actions

### DIFF
--- a/remote.c
+++ b/remote.c
@@ -2443,7 +2443,8 @@ handle_req(struct daemon_remote* rc, struct rc_state* s, RES* res)
 		(void)ssl_printf(res, "error version mismatch\n");
 		return;
 	}
-	VERBOSITY(2, (LOG_INFO, "control cmd: %s", buf));
+	/* always log control commands */
+	VERBOSITY(0, (LOG_INFO, "control cmd: %s", buf));
 
 	/* figure out what to do */
 	execute_cmd(rc, res, buf, s);


### PR DESCRIPTION
As discussed recently; change the verbosity of logging of command line controls to the lowest, so we always log command line control actions. Adresses #212.