### PR TITLE
Check for c99 with autoconf versions prior to 2.70

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -174,7 +174,7 @@ AC_ARG_WITH([user],
 AC_SUBST(user)
 AC_DEFINE_UNQUOTED(USER, ["$user"], [the user name to drop privileges to])
 
-AC_PROG_CC
+m4_version_prereq([2.70], [AC_PROG_CC], [AC_PROG_CC_STDC])
 AC_PROG_SED
 AC_PROG_AWK
 AC_PROG_GREP

--- a/doc/RELNOTES
+++ b/doc/RELNOTES
@@ -7,6 +7,7 @@ BUG FIXES:
 	- Fix static analyzer reports, fix wrong log print when skipping xfr,
 	  fix to print error on pipe read fail, and assert an xfr is in
 	  progress during packet checks.
+	- Use AC_PROG_CC_STDC with autoconf versions prior to 2.70.
 
 4.6.0
 ================


### PR DESCRIPTION
Autoconf versions 2.70 and later check for the newest C version and work their way down. `AC_PROG_CC_STDC` does the same for versions prior to 2.70.

Closes #222