### PR TITLE
Fix checking if nonblocking sockets work on OpenBSD

### DIFF
--- a/acx_nlnetlabs.m4
+++ b/acx_nlnetlabs.m4
@@ -963,6 +963,9 @@ AC_LANG_SOURCE([[
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
+#ifdef HAVE_SYS_SELECT_H
+#include <sys/select.h>
+#endif
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif


### PR DESCRIPTION
diff by Todd C. Miller

https://marc.info/?l=openbsd-tech&m=166189857323524&w=2