### PR TITLE
Fix two ignored return values

### DIFF
--- a/server.c
+++ b/server.c
@@ -3034,7 +3034,11 @@ void server_verify(struct nsd *nsd, int cmdsocket)
 	nsd->verifier_count = 0;
 	nsd->verifier_limit = nsd->options->verifier_count;
 	size = sizeof(struct verifier) * nsd->verifier_limit;
-	pipe(nsd->verifier_pipe);
+	if(pipe(nsd->verifier_pipe) == -1) {
+		log_msg(LOG_ERR, "verify: could not create pipe: %s",
+				strerror(errno));
+		goto fail;
+	}
 	fcntl(nsd->verifier_pipe[0], F_SETFD, FD_CLOEXEC);
 	fcntl(nsd->verifier_pipe[1], F_SETFD, FD_CLOEXEC);
 	nsd->verifiers = region_alloc_zero(nsd->server_region, size);

--- a/server.c
+++ b/server.c
@@ -3037,7 +3037,7 @@ void server_verify(struct nsd *nsd, int cmdsocket)
 	if(pipe(nsd->verifier_pipe) == -1) {
 		log_msg(LOG_ERR, "verify: could not create pipe: %s",
 				strerror(errno));
-		goto fail;
+		goto fail_pipe;
 	}
 	fcntl(nsd->verifier_pipe[0], F_SETFD, FD_CLOEXEC);
 	fcntl(nsd->verifier_pipe[1], F_SETFD, FD_CLOEXEC);
@@ -3128,9 +3128,10 @@ void server_verify(struct nsd *nsd, int cmdsocket)
 	assert(nsd->next_zone_to_verify == NULL || nsd->mode == NSD_QUIT);
 	assert(nsd->verifier_count == 0 || nsd->mode == NSD_QUIT);
 fail:
-	event_base_free(nsd->event_base);
 	close(nsd->verifier_pipe[0]);
 	close(nsd->verifier_pipe[1]);
+fail_pipe:
+	event_base_free(nsd->event_base);
 	region_destroy(nsd->server_region);
 
 	nsd->event_base = NULL;

--- a/verify.c
+++ b/verify.c
@@ -274,7 +274,10 @@ void verify_handle_signal(int sig, short event, void *arg)
 	assert(arg != NULL);
 
 	nsd = (struct nsd *)arg;
-	(void)write(nsd->verifier_pipe[1], buf, sizeof(buf));
+	if(write(nsd->verifier_pipe[1], buf, sizeof(buf)) == -1) {
+		log_msg(LOG_ERR, "verify_handle_signal: write failed: %s",
+				strerror(errno));
+	}
 }
 
 /*


### PR DESCRIPTION
That were reported when compiling:
```
server.c: In function ‘server_verify’:
server.c:3037:9: warning: ignoring return value of ‘pipe’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
 3037 |         pipe(nsd->verifier_pipe);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~

verify.c: In function ‘verify_handle_signal’:
verify.c:277:15: warning: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  277 |         (void)write(nsd->verifier_pipe[1], buf, sizeof(buf));
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```