### PR TITLE
Fix build with --without-ssl

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -85,7 +85,7 @@ NSD_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) difffile.o ipc.o mini_event.o netio.o nsd.o se
 ALL_OBJ=$(NSD_OBJ) nsd-checkconf.o nsd-checkzone.o nsd-control.o nsd-mem.o xfr-inspect.o
 NSD_CHECKCONF_OBJ=$(COMMON_OBJ) nsd-checkconf.o
 NSD_CHECKZONE_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o zparser.o zlexer.o nsd-checkzone.o verify.o
-NSD_CONTROL_OBJ=$(COMMON_OBJ) nsd-control.o
+NSD_CONTROL_OBJ=@NSD_CONTROL_COMMON_OBJ@ nsd-control.o
 CUTEST_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o verify.o zonec.o zparser.o zlexer.o cutest_dname.o cutest_dns.o cutest_iterated_hash.o cutest_run.o cutest_radtree.o cutest_rbtree.o cutest_namedb.o cutest_options.o cutest_region.o cutest_rrl.o cutest_udb.o cutest_udbrad.o cutest_util.o cutest_bitset.o cutest_popen3.o cutest_iter.o cutest_event.o cutest.o qtest.o
 NSD_MEM_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o verify.o server.o zonec.o zparser.o zlexer.o nsd-mem.o
 all:	$(TARGETS) $(MANUALS)

--- a/configure.ac
+++ b/configure.ac
@@ -1021,6 +1021,7 @@ AC_SUBST(ratelimit_default)
 # we need SSL for TSIG (and maybe also for NSEC3).
 CHECK_SSL
 if test x$HAVE_SSL = x"yes"; then
+	AC_SUBST(NSD_CONTROL_COMMON_OBJ,'$(COMMON_OBJ)')
 	ACX_LIB_SSL
 	# remove space after -ldl if there.
 	LIBS=`echo "$LIBS" | sed -e 's/ $//'`
@@ -1097,6 +1098,7 @@ AC_INCLUDES_DEFAULT
 else
 	AC_MSG_WARN([No SSL, therefore remote-control is disabled])
 	AC_MSG_WARN([No SSL, therefore TLS is disabled])
+	AC_SUBST(NSD_CONTROL_COMMON_OBJ,)
 fi
 
 AC_ARG_ENABLE(nsec3, AS_HELP_STRING([--disable-nsec3],[Disable NSEC3 support]))


### PR DESCRIPTION
Don't include COMMON_OBJ when compiling nsd-control without SSL.

Without SSL, nsd-control's only purpose is to print out an error message.  There's no need to include any other object files then.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

----

Here's how the build fails with OpenWrt:

```
aarch64-openwrt-linux-musl-gcc -O3 -pipe -mcpu=cortex-a53 -funsafe-math-optimizations -fno-plt -fhonour-copts -fmacro-prefix-map=/home/equeiroz/src/openwrt/build_dir/target-aarch64_cortex-a53_musl/nsd-nossl/nsd-4.6.1=nsd-4.6.1 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro  -Wno-address-of-packed-member -L/home/equeiroz/src/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/usr/lib -L/home/equeiroz/src/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib -znow -zrelro  -o nsd-control answer.o axfr.o ixfr.o ixfrcreate.o buffer.o configlexer.o configparser.o dname.o dns.o edns.o iterated_hash.o lookup3.o namedb.o nsec3.o options.o packet.o query.o rbtree.o radtree.o rdata.o region-allocator.o rrl.o siphash.o tsig.o tsig-openssl.o udb.o udbradtree.o udbzone.o util.o bitset.o popen3.o nsd-control.o memcmp.o cpuset.o b64_pton.o b64_ntop.o setproctitle.o
/home/equeiroz/src/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/../../../../aarch64-openwrt-linux-musl/bin/ld: ixfr.o: in function `ixfr_data_readrr':
ixfr.c:(.text+0x370): undefined reference to `zonec_parse_string'
collect2: error: ld returned 1 exit status
make[3]: *** [Makefile:167: nsd-control] Error 1
```

This was compile-tested with OpenWrt both without SSL and with OpenSSL 3.0.