### PR TITLE
Clarify 'ok' result in nsd-control

### DIFF
--- a/nsd-control.8.in
+++ b/nsd-control.8.in
@@ -16,7 +16,8 @@
 .B nsd\-control
 performs remote administration on the \fInsd\fR(8) DNS server.  It reads
 the configuration file, contacts the nsd server over SSL, sends the
-command and displays the result.
+command and displays the result.  Commands that require a reload are queued
+and the result indicates the command was accepted.
 .P
 The available options are:
 .TP


### PR DESCRIPTION
`nsd-control` commands that require a reload are asynchronous and the response from `nsd` indicates it was accepted rather than successful. Doesn't really fix #264, but should help avoid possible confusion for new users in the future.