### PR TITLE
Add systemd service unit

### DIFF
--- a/contrib/README
+++ b/contrib/README
@@ -28,8 +28,7 @@ USE AT YOUR OWN RISK.
   You may also need to create a number of symbolic links under the names
   of the graphs you want to create (documented at head of file).
 
-* nsd.socket and nsd.service : example systemd service scripts for NSD.
-  They are copies from Unbound's service files, edited for NSD.
+* nsd.service : example systemd service script for NSD.
 
 * patch_for_s6_startup_and_other_service_supervisors.diff : patch to
   use -r option for nsd to signal readiness with READY_FD, from Cameron Nemo.

--- a/contrib/nsd.service
+++ b/contrib/nsd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=NSD DNS Server
+After=syslog.target network-online.target
+
+[Service]
+Type=notify
+ExecStart=/usr/sbin/nsd -d -c /etc/nsd/nsd.conf $NSD_EXTRA_OPTS
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=mixed
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/nsd.socket
+++ b/contrib/nsd.socket
@@ -1,6 +1,0 @@
-[Socket]
-ListenDatagram=127.0.0.1:1153
-ListenStream=127.0.0.1:1153
-# ListenStream=/usr/local/etc/nsd/control
-[Install]
-WantedBy=sockets.target


### PR DESCRIPTION
There was a fairly complex systemd unit that got deleted by its author in commit e502f434d0ca54c1ac83fba84339e822540e63f0. The commit did not removed the `nsd.socket` that got created together and did not updated the README file, so I did so.

Differently from the old systemd unit, this one is way simpler. It might be improved over time, but I think it is a good starting point.