### PR TITLE
DNS Out Of Protocol Signaling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -956,6 +956,24 @@ case "$enable_ipv6" in
 		;;
 esac
 
+AC_ARG_ENABLE(dbus, AS_HELP_STRING([--disable-dbus],[Disables DBus support]))
+case "$enable_dbus" in
+no)
+	;;
+yes|*)
+	AC_SEARCH_LIBS([sd_bus_open_system], [systemd], [
+		LDFLAGS="$LDFLAGS -Lsystemd"
+		AC_DEFINE_UNQUOTED([ENABLE_DBUS], [], [Define this to enable DBus support.])
+		AC_DEFINE_UNQUOTED(NSD_DBUS_NAME, ["nl.nlnetlabs.nsd"], [Name for NSD DBus signalling])
+		AC_DEFINE_UNQUOTED(NSD_DBUS_PATH, ["/nl/nlnetlabs/nsd"], [Path of DBus object])
+		AC_DEFINE_UNQUOTED(NSD_DBUS_EVENT_STARTED, ["started"], [DBus signal for just started])
+		AC_DEFINE_UNQUOTED(NSD_DBUS_EVENT_STOPPED, ["stopped"], [DBus signal for about to stop])
+		AC_DEFINE_UNQUOTED(NSD_DBUS_EVENT_ZONE_UPD, ["zone_updated"], [DBus signal for an updated zone])
+	])
+	;;
+esac
+
+
 AC_ARG_ENABLE(bind8-stats, AS_HELP_STRING([--enable-bind8-stats],[Enables BIND8 like NSTATS & XSTATS and statistics in nsd-control]))
 
 case "$enable_bind8_stats" in

--- a/nsd.c
+++ b/nsd.c
@@ -57,11 +57,45 @@
 #include "dnstap/dnstap_collector.h"
 #endif
 
+#ifdef ENABLE_DBUS
+#include <systemd/sd-bus.h>
+
+static sd_bus *_dbus = NULL;
+#endif
+
 /* The server handler... */
 struct nsd nsd;
 static char hostname[MAXHOSTNAMELEN];
 extern config_parser_state_type* cfg_parser;
 static void version(void) ATTR_NORETURN;
+
+
+void systemd_dbus_close(void)
+{
+#ifdef ENABLE_DBUS
+	_dbus = sd_bus_unref(_dbus);
+#endif
+}
+
+int systemd_dbus_open(void)
+{
+#ifdef ENABLE_DBUS
+	int ret = sd_bus_open_system(&_dbus);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Take a well-known service name so that clients can find us. */
+	ret = sd_bus_request_name(_dbus, NSD_DBUS_NAME, 0);
+	if (ret < 0) {
+		systemd_dbus_close();
+		return ret;
+	}
+	return 0;
+#else
+	return -1;
+#endif
+}
 
 /*
  * Print the help text.
@@ -927,7 +961,7 @@ int
 main(int argc, char *argv[])
 {
 	/* Scratch variables... */
-	int c;
+	int c, r;
 	pid_t	oldpid;
 	size_t i;
 	struct sigaction action;
@@ -1612,6 +1646,10 @@ main(int argc, char *argv[])
 	/* Get our process id */
 	nsd.pid = getpid();
 
+
+	if ((r = systemd_dbus_open())) {
+		log_msg(LOG_ERR, "error opening DBus: %d", r);
+	}
 	/* Set user context */
 #ifdef HAVE_GETPWNAM
 	if (*nsd.username) {


### PR DESCRIPTION
This draft PR will be used to develop DNS Out Of Protocol Signalling as specified in https://datatracker.ietf.org/doc/draft-grubto-dnsop-dns-out-of-protocol-signalling/
 