### PR TITLE
Update e-mail addresses, add ref to support contracts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ dnl
 sinclude(acx_nlnetlabs.m4)
 sinclude(dnstap/dnstap.m4)
 
-AC_INIT([NSD],[4.7.1],[nsd-bugs@nlnetlabs.nl])
+AC_INIT([NSD],[4.7.1],[https://github.com/NLnetLabs/nsd/issues or nsd-bugs@nlnetlabs.nl])
 AC_CONFIG_HEADERS([config.h])
 
 #

--- a/doc/CREDITS
+++ b/doc/CREDITS
@@ -2,7 +2,7 @@ The NSD was primarily developed by NLnet Labs on request from and close
 cooperation with RIPE NCC, as an alternative name server software to be
 run on the root name server RIPE NCC operates.
 
-Below is the NSD team (nsd-team@nlnetlabs.nl) in alphabetical order:
+Below is the NSD team in alphabetical order:
 
 Alexis Yushin, NLnet Labs       - design and implementation for NSD 1.0.x 
                                   and 1.1.x.

--- a/doc/README
+++ b/doc/README
@@ -875,7 +875,7 @@ offered through a mailing lists and the 'bugzilla' web interface.
 If for any reason NLnet Labs would stop community support of NSD such 
 would be announced on our web pages at least two years in advance.
 
-The community mailing list nsd-users@nlnetlabs.nl can be used to discuss 
+The community mailing list nsd-users@lists.NLnetLabs.nl can be used to discuss
 issues with other users of NSD. Subscribe here
 
 	http://lists.nlnetlabs.nl/mailman/listinfo/nsd-users
@@ -885,9 +885,7 @@ community support is not sufficient and that support needs to be codified.
 We therefore offer paid support contracts that come in 3 varieties. 
 
 More information about these support varieties can be found at 
-	<url on support varieties on www.nlnetlabs.nl>
-
-Alternatively you can contact mailto:nsd-support@nlnetlabs.nl .
+	https://nlnetlabs.nl/services/contracts/
 
 Support goes two ways.  By acquiring one of the support contracts you
 also support NLnet Labs to continue to participate in the development
@@ -896,11 +894,10 @@ the (IETF) standards process and by developing and maintaining
 reference implementations of standards and tools to support operation
 and deployment of new and existing Internet technology. 
 
-We are interested in our users and in the environment you use NSD. Please 
-drop us a mail when you use NSD. Indicate in what kind of operation you 
-deploy NSD and let us know what your positive and negative experiences are.
-http://www.nlnetlabs.nl/nsd  and  mailto:nsd-info@nlnetlabs.nl
-
+We are interested in our users and in the environment you use NSD. Please drop
+us a mail when you use NSD at users@NLnetLabs.nl. Indicate in what kind of
+operation you deploy NSD and let us know what your positive and negative
+experiences are.
 
 4.1 Your Support
 


### PR DESCRIPTION
Minimal changes to support e-mail migration.

There are also e-mail references in the following places, which I have not touched:
  - `.cirrus.yml`, references spam@ which does not exist, ACK'ed by Jeroen
  - `tpkg/credns-setup/configure`  has a bunch of references to willem@
  - `doc/differences.tex` references jelte@ (no longer exists), but seems mostly of historic value.

I have left in the references to users@, even though that alias may go to more people than makes sense. Suggestions welcome.