### PR TITLE
Make catalog zone settings local to zone

### DIFF
--- a/cat-zones.c
+++ b/cat-zones.c
@@ -83,6 +83,8 @@ void catalog_consumer_process(
 	catzonezone_type* catzonezones = NULL;
 	region_type* catzonezones_region = region_create(xalloc, free);
 
+	// FIXME: verify this zone is a consumer, NOT a producer
+
 	for (struct radnode* n = radix_first(nsd->db->zonetree);
 	n;
 	n = radix_next(n)) {
@@ -212,7 +214,7 @@ void catalog_consumer_process(
 				if (!zone_exists) {
 					char* pname = region_strdup(
 						catzonezones_region,
-						zone->opts->pattern->catalog_member_pattern
+						zone->opts->catalog_member_pattern->pname
 					);
 					c = region_alloc(catzonezones_region, sizeof(catzonezone_type));
 					c->member_id = (dname_type*)member_id;

--- a/dbaccess.c
+++ b/dbaccess.c
@@ -619,9 +619,8 @@ namedb_read_zonefile(struct nsd* nsd, struct zone* zone, udb_base* taskudb,
 			zone->opts->name));
 		zone->is_ok = 1;
 		zone->is_changed = 0;
-		if (zone->opts->pattern->is_catalog) {
+		if (zone_is_consumer(zone->opts))
 			catalog_consumer_process(nsd, zone, taskudb, last_task);
-		}
 		/* store zone into udb */
 		if(nsd->db->udb) {
 			if(!write_zone_to_udb(nsd->db->udb, zone, &mtime,
@@ -697,7 +696,8 @@ void namedb_check_zonefiles(struct nsd* nsd, struct nsd_options* opt,
 		if(!zone) {
 			zone = namedb_zone_create(nsd->db, dname, zo);
 		}
-		if (zone->catalog_member_id || zo->pattern->is_catalog) {
+		// FIXME: not quite correct
+		if (zone->catalog_member_id || zone_is_consumer(zo)) {
 			/* Ensure catalog zone members are loaded last */
 			zone_linkedlist* zl2 = region_alloc(zl_region, sizeof(zone_linkedlist));
 			zl2->me = zone;

--- a/namedb.h
+++ b/namedb.h
@@ -150,7 +150,9 @@ struct zone
 	unsigned     is_skipped : 1; /* subsequent zone updates are skipped */
 	unsigned     is_checked : 1; /* zone already verified */
 	unsigned     is_bad : 1; /* zone failed verification */
+	// FIXME: make from_catalog a pointer to a zone?
 	char*        from_catalog; /* zone originates from catalog zone */
+	// FIXME: make catalog_member_id a pointer to a domain?
 	dname_type*  catalog_member_id; /* member id in the catalog zone */
 } ATTR_PACKED;
 

--- a/nsd-checkconf.c
+++ b/nsd-checkconf.c
@@ -580,18 +580,6 @@ static void print_zone_content_elems(pattern_options_type* pat)
 	if(pat->verifier_timeout != VERIFIER_TIMEOUT_INHERIT) {
 		printf("\tverifier-timeout: %d\n", pat->verifier_timeout);
 	}
-
-	if(pat->is_catalog) {
-		printf("\tcatalog: ");
-		if(pat->is_catalog) {
-			printf("yes\n");
-		} else {
-			printf("no\n");
-		}
-	}
-
-	if(pat->catalog_member_pattern) 
-		print_string_var("catalog-member-pattern:", pat->catalog_member_pattern);	
 }
 
 void
@@ -785,6 +773,9 @@ config_test_print_server(nsd_options_type* opt)
 			continue;
 		printf("\nzone:\n");
 		print_string_var("name:", zone->name);
+		printf("catalog: %s\n", zone->catalog ? "yes" : "no");
+		if (zone->catalog_member_pattern)
+			printf("catalog-member-pattern: %s\n", zone->catalog_member_pattern->pname);
 		print_zone_content_elems(zone->pattern);
 	}
 }
@@ -815,6 +806,10 @@ additional_checks(nsd_options_type* opt, const char* filename)
 				"no zonefile. Where can the data come from?\n",
 				filename, zone->name);
 			errors ++;
+		}
+		if (zone_is_consumer(zone) && !zone->catalog_member_pattern) {
+			fprintf(stderr, "%s: zone %s is a catalog zone but does not "
+				"specify a catalog-member-pattern\n", filename, zone->name);
 		}
 	}
 

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -487,11 +487,6 @@ remote-control:
 	# Number of seconds before verifier is killed (0 is forever).
 	# Default is verifier-timeout in verify.
 	# verifier-timeout: 0
-	
-	# Turn this zone into a catalog zone. If set to "yes", the 
-	# catalog-member-pattern option MUST be present.
-	# catalog: yes
-	# catalog-member-pattern: "example-pattern"
 
 # Fixed zone entries.  Here you can config zones that cannot be deleted.
 # Zones that are dynamically added and deleted are put in the zonelist file.
@@ -504,6 +499,14 @@ remote-control:
 	# You can also specify (additional) options directly for this zone.
 	# zonefile: "example.com.zone"
 	# request-xfr: 192.0.2.1 example.com.key
+
+	# Specify zone is a catalog zone. Default is no.
+	# catalog: no
+
+	# Pattern applied to member zones by default. Mandatory for catalog zones
+	# on catalog consumers. The group property in the catalog zone may be used
+	# to override the pattern that is applied to a member zone.
+	# catalog-member-pattern: "member-zones"
 
 	# RRLconfig
 	# Response Rate Limiting, whitelist types

--- a/options.c
+++ b/options.c
@@ -807,8 +807,10 @@ zone_options_create(region_type* region)
 		struct zone_options));
 	zone->node = *RBTREE_NULL;
 	zone->name = 0;
-	zone->pattern = 0;
+	zone->pattern = NULL;
 	zone->part_of_config = 0;
+	zone->catalog = 0;
+	zone->catalog_member_pattern = NULL;
 	return zone;
 }
 
@@ -914,8 +916,6 @@ pattern_options_create(region_type* region)
 	p->verifier_feed_zone_is_default = 1;
 	p->verifier_timeout = VERIFIER_TIMEOUT_INHERIT;
 	p->verifier_timeout_is_default = 1;
-	p->is_catalog = 0;
-	p->catalog_member_pattern = NULL;
 
 	return p;
 }
@@ -1977,12 +1977,6 @@ key_options_tsig_add(struct nsd_options* opt)
 	}
 }
 #endif
-
-int
-zone_is_slave(struct zone_options* opt)
-{
-	return opt && opt->pattern && opt->pattern->request_xfr != 0;
-}
 
 /* get a character in string (or replacement char if not long enough) */
 static const char*

--- a/remote.c
+++ b/remote.c
@@ -1064,10 +1064,8 @@ print_zonestatus(RES* ssl, xfrd_state_type* xfrd, struct zone_options* zo)
 		if(!ssl_printf(ssl, "	pattern: %s\n", zo->pattern->pname))
 			return 0;
 	}
-	if(zo->pattern->is_catalog) {
-		if(!ssl_printf(ssl, "	catalog: %s\n", zo->pattern->is_catalog ? "yes" : "no"))
-			return 0;
-	}
+	if(!ssl_printf(ssl, "	catalog: %s\n", zo->catalog ? "yes" : "no"))
+		return 0;
 	if(nz) {
 		if(nz->is_waiting) {
 			if(!ssl_printf(ssl, "	notify: \"waiting-for-fd\"\n"))

--- a/server.c
+++ b/server.c
@@ -2351,14 +2351,11 @@ server_reload(struct nsd *nsd, region_type* server_region, netio_type* netio,
 			   update(s), communicate soainfo_gone */
 			task_new_soainfo(nsd->task[nsd->mytask], &last_task,
 			                 zone, soainfo_gone);
-		} 
-		
-		if(zone->opts && 
-		zone->opts->pattern && 
-		zone->opts->pattern->is_catalog && 
-		zone->is_updated) {
+		}
+
+		if(zone_is_consumer(zone->opts) && zone->is_updated) {
 			DEBUG(DEBUG_CATZ, 1, (LOG_INFO, "Start catalog consumption"));
-			catalog_consumer_process(nsd, zone, 
+			catalog_consumer_process(nsd, zone,
 				nsd->task[nsd->mytask], &last_task);
 		}
 		zone->is_updated = 0;
@@ -2538,16 +2535,10 @@ server_main(struct nsd *nsd)
 	    node = radix_next(node))
 	{
 		zone = (zone_type *)node->elem;
-		if (zone->opts->pattern->is_catalog && 
-		!zone->opts->pattern->catalog_member_pattern) {
-			log_msg(LOG_ERR,
-				"Zone %s is a catalog but misses the mandatory catalog-member-pattern configuration option!",
-				dname_to_string(zone->apex->dname, NULL));
-				nsd->mode = NSD_SHUTDOWN;
-		}
-		if (zone->opts->pattern->is_catalog) {
+		if (zone_is_consumer(zone->opts)) {
 			udb_ptr last_task;
-			log_msg(LOG_INFO, "scheduling zone %s for reload", 
+			assert(zone->opts->catalog_member_pattern);
+			log_msg(LOG_INFO, "scheduling zone %s for reload",
 				dname_to_string(zone->apex->dname, NULL));
 			catalog_consumer_process(nsd, zone, nsd->task[nsd->mytask], &last_task);
 		}

--- a/tpkg/catz-maybe-consume.tdir/catz-maybe-consume.dsc
+++ b/tpkg/catz-maybe-consume.tdir/catz-maybe-consume.dsc
@@ -1,0 +1,15 @@
+BaseName: catz-maybe-consume
+Version: 1.0
+Description: Verify secondary consumes, primary does not.
+CreationDate: Thu Sep 21 15:02:13 CET 2023
+Maintainer: Jeroen Koekkoek
+Category: catalog-zones
+Component:
+Depends: 0000_nsd-compile.tpkg
+Help:
+Pre: catz-maybe-consume.pre
+Post: catz-maybe-consume.post
+Test: catz-maybe-consume.test
+AuxFiles:
+Passed:
+Failure:

--- a/tpkg/catz-maybe-consume.tdir/catz-maybe-consume.post
+++ b/tpkg/catz-maybe-consume.tdir/catz-maybe-consume.post
@@ -1,0 +1,16 @@
+# #-- catz-maybe-consume.post --#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+if [ -n producer.pid ]; then
+	kill_pid `cat producer.pid`
+fi
+
+if [ -n consumer.pid ]; then
+	kill_pid `cat consumer.pid`
+fi
+
+exit 0

--- a/tpkg/catz-maybe-consume.tdir/catz-maybe-consume.pre
+++ b/tpkg/catz-maybe-consume.tdir/catz-maybe-consume.pre
@@ -1,0 +1,61 @@
+# #-- catz-maybe-consume.pre --#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+# start NSD
+get_random_port 2
+PRODUCER_PORT=${RND_PORT}
+CONSUMER_PORT=`expr $RND_PORT + 1`
+
+echo "PRODUCER_PORT=${PRODUCER_PORT}" >> .tpkg.var.test
+echo "CONSUMER_PORT=${CONSUMER_PORT}" >> .tpkg.var.test
+
+# producer.conf
+cat << EOF > producer.conf
+server:
+	zonesdir: "."
+	username: ""
+	database: ""
+	verbosity: 5
+	ip-address: 127.0.0.1
+	port: ${PRODUCER_PORT}
+	pidfile: "producer.pid"
+	xfrdfile: "xfrd.state"
+	logfile: "producer.log"
+
+zone:
+	name: catz
+	zonefile: catz.zone
+	notify: 127.0.0.1@${CONSUMER_PORT} NOKEY
+	provide-xfr: 127.0.0.1 NOKEY
+	catalog: yes
+EOF
+
+# consumer.conf
+cat << EOF > consumer.conf
+server:
+	zonesdir: "."
+	username: ""
+	database: ""
+	verbosity: 5
+	ip-address: 127.0.0.1
+	port: ${CONSUMER_PORT}
+	pidfile: "consumer.pid"
+	xfrdfile: "xfrd.state"
+	logfile: "consumer.log"
+
+pattern:
+	name: catz-members
+	allow-notify: 127.0.0.1 NOKEY
+	request-xfr: 127.0.0.1@${PRODUCER_PORT} NOKEY
+
+zone:
+	name: catz
+	allow-notify: 127.0.0.1 NOKEY
+	request-xfr: 127.0.0.1@${PRODUCER_PORT} NOKEY
+	catalog: yes
+	catalog-member-pattern: catz-members
+EOF

--- a/tpkg/catz-maybe-consume.tdir/catz-maybe-consume.test
+++ b/tpkg/catz-maybe-consume.tdir/catz-maybe-consume.test
@@ -1,0 +1,29 @@
+# #-- catz-maybe-consume.test --#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+
+PRE="../.."
+NSD="$PRE/nsd"
+
+$NSD -c producer.conf -V 5
+$NSD -c consumer.conf -V 5
+
+wait_logfile producer.log "zone catz read with success" 45
+wait_logfile consumer.log "zone catz. received update" 45
+
+if grep "zone example.com. received error code SERVER NOT AUTHORITATIVE FOR ZONE" consumer.log; then
+	echo OK
+	exit 0
+else
+	echo "----- producer.log -----"
+	cat producer.log
+	echo "----- consumer.log -----"
+	cat consumer.log
+	echo "producer is authoritative for example.com, but zone is not configured"
+	echo "catz.zone. has probably been consumed, which the producer MUST not do"
+	exit 1
+fi

--- a/tpkg/catz-maybe-consume.tdir/catz.zone
+++ b/tpkg/catz-maybe-consume.tdir/catz.zone
@@ -1,0 +1,6 @@
+$ORIGIN catz.
+
+@ SOA invalid. invalid. 1625079951 3600 600 2147483646 0
+@ NS invalid.
+version.catz. TXT "2"
+example.zones.catz. PTR example.com.

--- a/tpkg/catz-query.tdir/catz-query-allowed.conf
+++ b/tpkg/catz-query.tdir/catz-query-allowed.conf
@@ -1,0 +1,22 @@
+server:
+	zonesdir: "."
+	username: ""
+	database: ""
+	verbosity: 5
+	ip-address: 127.0.0.1
+	port: PORT
+	pidfile: "nsd.allowed.pid"
+	xfrdfile: "xfrd.allowed.state"
+	logfile: "nsd.allowed.log"
+
+zone:
+	name: catz
+	zonefile: catz.zone
+	allow-query: 127.0.0.1/8 NOKEY
+	provide-xfr: 127.0.0.1/8 NOKEY
+	catalog: yes
+
+zone:
+	name: example.com
+	zonefile: example.zone
+	provide-xfr: 127.0.0.1/8 NOKEY

--- a/tpkg/catz-query.tdir/catz-query-not-allowed.conf
+++ b/tpkg/catz-query.tdir/catz-query-not-allowed.conf
@@ -1,0 +1,19 @@
+server:
+	zonesdir: "."
+	username: ""
+	database: ""
+	verbosity: 5
+	ip-address: 127.0.0.1
+	port: PORT
+	pidfile: "nsd.not-allowed.pid"
+	xfrdfile: "xfrd.not-allowed.state"
+	logfile: "nsd.not-allowed.log"
+
+zone:
+	name: catz
+	zonefile: catz.zone
+	catalog: yes
+
+zone:
+	name: example.com
+	zonefile: example.zone

--- a/tpkg/catz-query.tdir/catz-query.dsc
+++ b/tpkg/catz-query.tdir/catz-query.dsc
@@ -1,0 +1,15 @@
+BaseName: catz-query
+Version: 1.0
+Description: Test catalog zones cannot be queried by default.
+CreationDate: Thu Sep 21 21:07:46 CET 2023
+Maintainer: Jeroen Koekkoek
+Category: catalog-zones
+Component:
+Depends: 0000_nsd-compile.tpkg
+Help:
+Pre: catz-query.pre
+Post: catz-query.post
+Test: catz-query.test
+AuxFiles:
+Passed:
+Failure:

--- a/tpkg/catz-query.tdir/catz-query.pre
+++ b/tpkg/catz-query.tdir/catz-query.pre
@@ -1,0 +1,22 @@
+# #-- catz-query.pre --#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+# start NSD
+get_random_port 1
+TPKG_PORT=${RND_PORT}
+
+echo "TPKG_PORT=${TPKG_PORT}" >> .tpkg.var.test
+
+sed -e "s/PORT/${TPKG_PORT}/g" \
+    catz-query-not-allowed.conf > not-allowed.conf
+
+[[ ${?} -eq 0 ]] || exit 1
+
+sed -e "s/PORT/${TPKG_PORT}/g" \
+    catz-query-allowed.conf > allowed.conf
+
+[[ ${?} -eq 0 ]] || exit 1

--- a/tpkg/catz-query.tdir/catz-query.test
+++ b/tpkg/catz-query.tdir/catz-query.test
@@ -1,0 +1,129 @@
+# #-- catz-query.test --#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+
+PRE="../.."
+NSD="$PRE/nsd"
+
+exit_code=0
+
+# start nsd using not-allowed.conf (allow-query + provide-xfr not configured).
+# queries and transfers for catalog zones should not be allowed. queries for
+# regular zones should be allowed. transfers for regular zones  should not be
+# allowed.
+$NSD -c not-allowed.conf -L 5 -F 0xFFFF
+wait_nsd_up nsd.not-allowed.log
+
+# query catalog zone for SOA record, should not be allowed
+dig -4 @127.0.0.1 -p $TPKG_PORT catz.zone. SOA \
+  > catz.not-allowed.soa 2>&1
+if [ ${?} -eq 0 ] && grep 'status: REFUSED' catz.not-allowed.soa > /dev/null; then
+  echo "SOA QUERY for catz. in not-allowed was correct"
+else
+  exit_code=1
+  echo "SOA QUERY for catz. in not-allowed was incorrect"
+  echo "dig:"
+  cat catz.not-allowed.soa
+fi
+
+# query regular zone for SOA record, should be allowed
+dig -4 @127.0.0.1 -p $TPKG_PORT example.com. SOA \
+  > example.com.not-allowed.soa 2>&1
+if [ ${?} -eq 0 ] && grep 'status: NOERROR' example.com.not-allowed.soa > /dev/null; then
+  echo "SOA QUERY for example.com. in not-allowed was correct"
+else
+  exit_code=1
+  echo "SOA QUERY for example.com. in not-allowed was incorrect"
+  echo "dig:"
+  cat example.not-allowed.soa
+fi
+
+# query catalog zone for AXFR, should not be allowed
+dig -4 @127.0.0.1 -p $TPKG_PORT catz. AXFR \
+  > catz.not-allowed.axfr 2>&1
+if [ ${?} -eq 0 ] && grep 'Transfer failed' catz.not-allowed.axfr > /dev/null; then
+  echo "AXFR QUERY for catz. in not-allowed was correct"
+else
+  exit_code=1
+  echo "AXFR QUERY for catz. in not-allowed was incorrect"
+  echo "dig:"
+  cat catz.not-allowed.axfr
+fi
+
+# query regular zone for AXFR, should not be allowed
+dig -4 @127.0.0.1 -p $TPKG_PORT example.com. AXFR \
+  > example.com.not-allowed.axfr 2>&1
+if [ ${?} -eq 0 ] && grep 'Transfer failed' example.com.not-allowed.axfr > /dev/null; then
+  echo "AXFR QUERY for example.com. in not-allowed was correct"
+else
+  exit_code=1
+  echo "AXFR QUERY for example.com. in not-allowed was incorrect"
+  echo "dig:"
+  cat example.com.not-allowed.axfr
+fi
+
+# stop nsd
+if [ -f nsd.not-allowed.pid ]; then
+  kill_pid `cat nsd.not-allowed.pid`
+fi
+
+
+# start nsd using allowed.conf (allow-query and provide-xfr configured).
+# queries and transfers for (catalog) zones should be allowed.
+$NSD -c allowed.conf
+wait_nsd_up nsd.allowed.log
+
+dig -4 @127.0.0.1 -p $TPKG_PORT catz. SOA \
+  > catz.allowed.soa 2>&1
+if [ ${?} -eq 0 ] && grep 'status: NOERROR' catz.allowed.soa > /dev/null; then
+  echo "SOA QUERY for catz. in allowed was correct"
+else
+  exit_code=1
+  echo "SOA QUERY for catz. in allowed was incorrect"
+  echo "dig:"
+  cat catz.allowed.soa
+fi
+
+dig -4 @127.0.0.1 -p $TPKG_PORT example.com. SOA \
+  > example.com.allowed.soa 2>&1
+if [ ${?} -eq 0 ] && grep 'status: NOERROR' example.com.allowed.soa > /dev/null; then
+  echo "SOA QUERY for example.com. in allowed was correct"
+else
+  exit_code=1
+  echo "SOA QUERY for example.com. in allowed was incorrect"
+  echo "dig:"
+  cat example.allowed.soa
+fi
+
+# query catalog zone for AXFR, should be allowed
+dig -4 @127.0.0.1 -p $TPKG_PORT catz. AXFR > catz.allowed.axfr 2>&1
+if [ ${?} -eq 0 ] && ! grep 'Transfer failed' catz.allowed.axfr > /dev/null; then
+  echo "AXFR QUERY for catz. in allowed was correct"
+else
+  exit_code=1
+  echo "AXFR QUERY for catz. in allowed was incorrect"
+  echo "dig:"
+  cat catz.allowed.axfr
+fi
+
+# query regular zone for AXFR, should be allowed
+dig -4 @127.0.0.1 -p $TPKG_PORT example.com. AXFR > example.com.allowed.axfr 2>&1
+if [ ${?} -eq 0 ] && ! grep 'Transfer failed' example.com.allowed.axfr > /dev/null; then
+  echo "AXFR QUERY for example.com. in allowed was correct"
+else
+  exit_code=1
+  echo "AXFR QUERY for example.com. in allowed was incorrect"
+  echo "dig:"
+  cat example.com.allowed.axfr
+fi
+
+# stop nsd
+if [ -f nsd.allowed.pid ]; then
+  kill_pid `cat nsd.allowed.pid`
+fi
+
+exit ${exit_code}

--- a/tpkg/catz-query.tdir/catz.zone
+++ b/tpkg/catz-query.tdir/catz.zone
@@ -1,0 +1,6 @@
+$ORIGIN catz.
+
+@ SOA invalid. invalid. 1625079951 3600 600 2147483646 0
+@ NS invalid.
+version.catz. TXT "2"
+example.zones.catz. PTR example.com.

--- a/tpkg/catz-query.tdir/example.zone
+++ b/tpkg/catz-query.tdir/example.zone
@@ -1,0 +1,8 @@
+$ORIGIN example.com.
+$TTL 86400
+
+@ SOA ns.example.com. hostmaster.example.com. (
+  2023092101 21600 3600 604800 86400 )
+
+  NS ns.example.com.
+  A 192.0.2.1


### PR DESCRIPTION
This PR moves catalog zone specific settings out of the pattern. I've also included a test that ensures catalog produces do not magically instantiate zones that are in the catalog zone but not configured. I've also added that queries to catalog zones are disallowed by default (still need to add a test for that). @Koenvh1, @wtoorop, do we agree the producer should not instantiate zones based on the catalog zone?