### PR TITLE
Fix IXFR-out after intermediate update fails verification

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,6 +1,9 @@
 31 October 2023: Wouter
 	- Merge #301: improve the logging of ixfr fallbacks to axfr.
 
+30 October 2023: Jeroen
+	- Fix processing of consolidated IXFRs.
+
 30 October 2023: Wouter
 	- Fix for interprocess communication to set quit sync command from
 	  main process explicitly.

--- a/doc/RELNOTES
+++ b/doc/RELNOTES
@@ -21,6 +21,7 @@ BUG FIXES:
 	- Merge #295: Update e-mail addresses, add ref to support contracts
 	- Fix for interprocess communication to set quit sync command from
 	  main process explicitly.
+	- Fix processing of consolidated IXFRs.
 
 4.7.0
 ================

--- a/ixfr.c
+++ b/ixfr.c
@@ -948,15 +948,12 @@ size_t ixfr_data_size(struct ixfr_data* data)
 }
 
 struct ixfr_store* ixfr_store_start(struct zone* zone,
-	struct ixfr_store* ixfr_store_mem, uint32_t old_serial,
-	uint32_t new_serial)
+	struct ixfr_store* ixfr_store_mem)
 {
 	struct ixfr_store* ixfr_store = ixfr_store_mem;
 	memset(ixfr_store, 0, sizeof(*ixfr_store));
 	ixfr_store->zone = zone;
 	ixfr_store->data = xalloc_zero(sizeof(*ixfr_store->data));
-	ixfr_store->data->oldserial = old_serial;
-	ixfr_store->data->newserial = new_serial;
 	return ixfr_store;
 }
 
@@ -1145,12 +1142,12 @@ static void store_soa(uint8_t* soa, struct zone* zone, uint32_t ttl,
 	write_uint32(sp, minimum);
 }
 
-void ixfr_store_add_newsoa(struct ixfr_store* ixfr_store,
-	struct buffer* packet, size_t ttlpos)
+void ixfr_store_add_newsoa(struct ixfr_store* ixfr_store, uint32_t ttl,
+	struct buffer* packet, size_t rrlen)
 {
 	size_t oldpos, sz = 0;
-	uint32_t ttl, serial, refresh, retry, expire, minimum;
-	uint16_t rdlen_uncompressed, rdlen_wire;
+	uint32_t serial, refresh, retry, expire, minimum;
+	uint16_t rdlen_uncompressed;
 	int primns_len = 0, email_len = 0;
 	uint8_t primns[MAXDOMAINLEN + 1], email[MAXDOMAINLEN + 1];
 
@@ -1162,24 +1159,11 @@ void ixfr_store_add_newsoa(struct ixfr_store* ixfr_store,
 		ixfr_store->data->newsoa_len = 0;
 	}
 	oldpos = buffer_position(packet);
-	buffer_set_position(packet, ttlpos);
 
 	/* calculate the length */
 	sz = domain_dname(ixfr_store->zone->apex)->name_size;
-	sz += 2 /* type */ + 2 /* class */;
-	/* read ttl */
-	if(!buffer_available(packet, 4/*ttl*/+2/*rdlen*/)) {
-		/* not possible already parsed, but fail nicely anyway */
-		log_msg(LOG_ERR, "ixfr_store: not enough space in packet");
-		ixfr_store_cancel(ixfr_store);
-		buffer_set_position(packet, oldpos);
-		return;
-	}
-	ttl = buffer_read_u32(packet);
-	sz += 4;
-	rdlen_wire = buffer_read_u16(packet);
-	sz += 2;
-	if(!buffer_available(packet, rdlen_wire)) {
+	sz += 2 /* type */ + 2 /* class */ + 4 /* ttl */ + 2 /* rdlen */;
+	if(!buffer_available(packet, rrlen)) {
 		/* not possible already parsed, but fail nicely anyway */
 		log_msg(LOG_ERR, "ixfr_store: not enough rdata space in packet");
 		ixfr_store_cancel(ixfr_store);
@@ -1194,6 +1178,8 @@ void ixfr_store_add_newsoa(struct ixfr_store* ixfr_store,
 		return;
 	}
 	rdlen_uncompressed = primns_len + email_len + 4 + 4 + 4 + 4 + 4;
+
+	ixfr_store->data->newserial = serial;
 
 	/* store the soa record */
 	ixfr_store->data->newsoa = xalloc(sz);
@@ -1246,6 +1232,8 @@ void ixfr_store_add_oldsoa(struct ixfr_store* ixfr_store, uint32_t ttl,
 		return;
 	}
 	rdlen_uncompressed = primns_len + email_len + 4 + 4 + 4 + 4 + 4;
+
+	ixfr_store->data->oldserial = serial;
 
 	/* store the soa record */
 	ixfr_store->data->oldsoa = xalloc(sz);
@@ -1393,6 +1381,9 @@ int ixfr_store_add_newsoa_rdatas(struct ixfr_store* ixfr_store,
 	size_t capacity = 0;
 	if(ixfr_store->cancelled)
 		return 1;
+	if(rdata_num < 2 || rdata_atom_size(rdatas[2]) < 4)
+		return 0;
+	ixfr_store->data->newserial = ntohl((uint32_t)*rdatas[2].data);
 	if(!ixfr_putrr(dname, type, klass, ttl, rdatas, rdata_num,
 		&ixfr_store->data->newsoa, &ixfr_store->data->newsoa_len,
 		&ixfr_store->add_capacity))
@@ -1449,6 +1440,23 @@ int ixfr_store_delrr_uncompressed(struct ixfr_store* ixfr_store,
 		&ixfr_store->data->del_len, &ixfr_store->del_capacity);
 }
 
+static size_t skip_dname(uint8_t* rdata, size_t rdata_len)
+{
+	for (size_t index=0; index < rdata_len; ) {
+		uint8_t label_size = rdata[index];
+		if (label_size == 0) {
+			return index + 1;
+		} else if ((label_size & 0xc0) != 0) {
+			index += 1;
+		} else {
+			/* loop breaks if index exceeds rdata_len */
+			index += label_size;
+		}
+	}
+
+	return 0;
+}
+
 int ixfr_store_oldsoa_uncompressed(struct ixfr_store* ixfr_store,
 	uint8_t* dname, size_t dname_len, uint16_t type, uint16_t klass,
 	uint32_t ttl, uint8_t* rdata, size_t rdata_len)
@@ -1460,6 +1468,20 @@ int ixfr_store_oldsoa_uncompressed(struct ixfr_store* ixfr_store,
 		ttl, rdata, rdata_len, &ixfr_store->data->oldsoa,
 		&ixfr_store->data->oldsoa_len, &capacity))
 		return 0;
+	{
+		uint32_t serial;
+		size_t index, count = 0;
+		if (!(count = skip_dname(rdata, rdata_len)))
+			return 0;
+		index = count;
+		if (!(count = skip_dname(rdata+index, rdata_len-index)))
+			return 0;
+		index += count;
+		if (rdata_len - index < 4)
+			return 0;
+		memcpy(&serial, rdata+index, sizeof(serial));
+		ixfr_store->data->oldserial = ntohl(serial);
+	}
 	ixfr_trim_capacity(&ixfr_store->data->oldsoa,
 		&ixfr_store->data->oldsoa_len, &capacity);
 	return 1;

--- a/ixfr.h
+++ b/ixfr.h
@@ -133,8 +133,7 @@ struct ixfr_store {
  * 	IXFR with this serial number. The NULL is on error.
  */
 struct ixfr_store* ixfr_store_start(struct zone* zone,
-	struct ixfr_store* ixfr_store_mem, uint32_t old_serial,
-	uint32_t new_serial);
+	struct ixfr_store* ixfr_store_mem);
 
 /*
  * Cancel the ixfr store in progress. The pointer remains valid, no store done.
@@ -163,14 +162,13 @@ void ixfr_store_finish_data(struct ixfr_store* ixfr_store);
 /*
  * Add the new SOA record to the ixfr store.
  * ixfr_store: stores ixfr data that is collected.
+ * ttl: the TTL of the SOA record
  * packet: DNS packet that contains the SOA. position restored on function
  * 	exit.
- * ttlpos: position, just before the ttl, rdatalen, rdata of the SOA record.
- * 	we do not need to pass the name, because that is the zone name, or
- * 	the type or class of the record, because we already know.
+ * rrlen: wire rdata length of the SOA.
  */
-void ixfr_store_add_newsoa(struct ixfr_store* ixfr_store,
-	struct buffer* packet, size_t ttlpos);
+void ixfr_store_add_newsoa(struct ixfr_store* ixfr_store, uint32_t ttl,
+	struct buffer* packet, size_t rrlen);
 
 /*
  * Add the old SOA record to the ixfr store.

--- a/ixfrcreate.c
+++ b/ixfrcreate.c
@@ -945,8 +945,7 @@ static int ixfr_perform_init(struct ixfr_create* ixfrcr, struct zone* zone,
 		return 0;
 	}
 	ixfrcr->new_serial = zone_get_current_serial(zone);
-	*store = ixfr_store_start(zone, store_mem, ixfrcr->old_serial,
-		ixfrcr->new_serial);
+	*store = ixfr_store_start(zone, store_mem);
 	if(!ixfr_create_store_newsoa(*store, zone)) {
 		fclose(*spool);
 		ixfr_store_free(*store);

--- a/tpkg/ixfrout-add-delete.tdir/ixfrout-add-delete.conf
+++ b/tpkg/ixfrout-add-delete.tdir/ixfrout-add-delete.conf
@@ -1,0 +1,28 @@
+server:
+	logfile: "nsd.log"
+	difffile: ixfr.db
+	xfrdfile: xfrd.state
+	zonesdir: ""
+	username: ""
+	chroot: ""
+	pidfile: nsd.pid
+	database: ""
+	verbosity: 5
+	zonelistfile: "zone.list"
+
+pattern:
+	name: acls
+	request-xfr: UDP 127.0.0.1@LDNS_PORT NOKEY
+	allow-notify: 127.0.0.1 NOKEY
+	allow-notify: ::1 NOKEY
+	provide-xfr: 127.0.0.1 NOKEY
+	provide-xfr: ::1 NOKEY
+	min-refresh-time: 0
+	min-retry-time: 0
+
+zone:
+	name: example.com.
+	zonefile: ixfrout-add-delete.zone
+	include-pattern: acls
+	store-ixfr: yes
+	create-ixfr: yes

--- a/tpkg/ixfrout-add-delete.tdir/ixfrout-add-delete.datafile
+++ b/tpkg/ixfrout-add-delete.tdir/ixfrout-add-delete.datafile
@@ -1,0 +1,26 @@
+$ORIGIN example.com.
+$TTL 3600
+
+ENTRY_BEGIN
+MATCH opcode qtype qname serial=0
+REPLY QUERY
+REPLY NOERROR
+REPLY AA AD
+ADJUST copy_id
+SECTION QUESTION
+example.com. IN IXFR
+SECTION ANSWER
+example.com.  3600  IN  SOA     ns.example.com. hostmaster.example.com. 2 300 4 3000 5
+example.com.  3600  IN  SOA     ns.example.com. hostmaster.example.com. 0 300 4 3000 5
+example.com.  3600  IN  ZONEMD  0 1 1 eb0812df3a81dac068bef25ac10322b301f09e93761c73f63b9af35a1684179992de6732bf928892bdff39b6ea45287b
+example.com.  3600  IN  SOA     ns.example.com. hostmaster.example.com. 1 300 4 3000 5
+ns            3600  IN  A       2.3.4.5
+example.com.  3600  IN  ZONEMD  1 1 1 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+example.com.  3600  IN  SOA     ns.example.com. hostmaster.example.com. 1 300 4 3000 5
+ns            3600  IN  A       2.3.4.5
+example.com.  3600  IN  ZONEMD  1 1 1 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+example.com.  3600  IN  SOA     ns.example.com. hostmaster.example.com. 2 300 4 3000 5
+ns            3600  IN  A       3.4.5.6
+example.com.  3600  IN  ZONEMD  2 1 1 9079299c183db2165a420d05fb666e7ced980217e64678b87c6e52f1a3b408ecc6eb58613021fdcbb0f96addd8889cf5
+example.com.  3600  IN  SOA     ns.example.com. hostmaster.example.com. 2 300 4 3000 5
+ENTRY_END

--- a/tpkg/ixfrout-add-delete.tdir/ixfrout-add-delete.dsc
+++ b/tpkg/ixfrout-add-delete.tdir/ixfrout-add-delete.dsc
@@ -1,0 +1,16 @@
+BaseName: ixfrout-add-delete
+Version: 1.0
+Description: Test outgoing IXFRs are correct if RRs are added and deleted in the same IXFR response
+CreationDate: Mon Oct 23 10:32:00 CEST 2023
+Maintainer: Jeroen Koekkoek
+Category:
+Component:
+CmdDepends:
+Depends:
+Help:
+Pre: ixfrout-add-delete.pre
+Post: ixfrout-add-delete.post
+Test: ixfrout-add-delete.test
+AuxFiles: ixfrout-add-delete.datafile, ixfrout-add-delete.conf, ixfrout-add-delete.script, ixfrout-add-delete.zone
+Passed:
+Failure:

--- a/tpkg/ixfrout-add-delete.tdir/ixfrout-add-delete.post
+++ b/tpkg/ixfrout-add-delete.tdir/ixfrout-add-delete.post
@@ -1,0 +1,11 @@
+# #-- ixfrout-add-delete.post --#
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# Use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+kill_pid ${LDNS_PID}
+
+if test -e nsd.pid; then
+	kill_pid $(head -n 1 nsd.pid)
+fi

--- a/tpkg/ixfrout-add-delete.tdir/ixfrout-add-delete.pre
+++ b/tpkg/ixfrout-add-delete.tdir/ixfrout-add-delete.pre
@@ -1,0 +1,23 @@
+# #-- ixfrout-add-delete.pre --#
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# Use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+get_random_port 2
+LDNS_PORT=${RND_PORT}
+NSD_PORT=$((${RND_PORT} + 1))
+
+# generate configuration files
+sed -e "s#LDNS_PORT#${LDNS_PORT}#" \
+    -e "s#NSD_PORT#${NSD_PORT}#" \
+    ixfrout-add-delete.conf > nsd.conf
+
+# share the vars
+echo "LDNS_PORT=${LDNS_PORT}" >> .tpkg.var.test
+echo "NSD_PORT=${NSD_PORT}" >> .tpkg.var.test
+
+ldns-testns -v -p ${LDNS_PORT} ixfrout-add-delete.datafile >ldns.log 2>&1 &
+LDNS_PID="${!}"
+echo "LDNS_PID=${LDNS_PID}" >> .tpkg.var.test
+wait_ldns_testns_up ldns.log

--- a/tpkg/ixfrout-add-delete.tdir/ixfrout-add-delete.test
+++ b/tpkg/ixfrout-add-delete.tdir/ixfrout-add-delete.test
@@ -1,0 +1,29 @@
+# #-- ixfrout-add-delete.test --#
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# Use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+
+PRE="../.."
+NSD="${PRE}/nsd"
+
+${NSD} -c $(pwd)/nsd.conf -p ${NSD_PORT} -V 5 -L 5 -F 0xFFFF
+wait_nsd_up nsd.log
+
+# notify nsd updates are available
+ldns-notify -z example.com -p ${NSD_PORT} -s 2 127.0.0.1
+# wait for update to be applied
+wait_logfile nsd.log "zone example.com. serial 0 is updated to 2" 10
+
+dig @127.0.0.1 -p ${LDNS_PORT} -t ixfr=0 IXFR example.com. | sed -n -e '/^[^;]/p' > ldns.ixfr
+dig @127.0.0.1 -p ${NSD_PORT} -t ixfr=0 IXFR example.com. | sed -n -e '/^[^;]/p' > nsd.ixfr
+
+if diff nsd.ixfr ldns.ixfr; then
+	exit 0
+else
+	echo "expected:" 1>&2
+	cat ldns.ixfr 1>&2
+	echo "result:" 1>&2
+	cat nsd.ixfr 1>&2
+	exit 1
+fi

--- a/tpkg/ixfrout-add-delete.tdir/ixfrout-add-delete.zone
+++ b/tpkg/ixfrout-add-delete.tdir/ixfrout-add-delete.zone
@@ -1,0 +1,4 @@
+example.com.	3600	IN	NS	ns.example.com.
+example.com.	3600	IN	SOA	ns.example.com. hostmaster.example.com. 0 300 4 3000 5
+example.com.	3600	IN	ZONEMD	0 1 1 eb0812df3a81dac068bef25ac10322b301f09e93761c73f63b9af35a1684179992de6732bf928892bdff39b6ea45287b
+ns.example.com.	3600	IN	A	1.2.3.4


### PR DESCRIPTION
This PR is work in progress! Currently it merely adds a test to reproduce faulty behavior reported by an NSD user.