### PR TITLE
improve the logging of ixfr fallbacks to axfr

### DIFF
--- a/ixfr.c
+++ b/ixfr.c
@@ -820,6 +820,8 @@ query_state_type query_ixfr(struct nsd *nsd, struct query *query)
 			/* we have no ixfr information for the zone, make an AXFR */
 			if(query->tsig_prepare_it)
 				query->tsig_sign_it = 1;
+			VERBOSITY(2, (LOG_INFO, "ixfr fallback to axfr, no ixfr info for zone: %s",
+				dname_to_string(query->qname, NULL)));
 			return query_axfr(nsd, query, 0);
 		}
 		ixfr_data = zone_ixfr_find_serial(zone->ixfr, qserial);
@@ -827,6 +829,8 @@ query_state_type query_ixfr(struct nsd *nsd, struct query *query)
 			/* the specific version is not available, make an AXFR */
 			if(query->tsig_prepare_it)
 				query->tsig_sign_it = 1;
+			VERBOSITY(2, (LOG_INFO, "ixfr fallback to axfr, no history for serial for zone: %s",
+				dname_to_string(query->qname, NULL)));
 			return query_axfr(nsd, query, 0);
 		}
 		/* see if the IXFRs connect to the next IXFR, and if it ends
@@ -835,6 +839,8 @@ query_state_type query_ixfr(struct nsd *nsd, struct query *query)
 			end_serial != current_serial) {
 			if(query->tsig_prepare_it)
 				query->tsig_sign_it = 1;
+			VERBOSITY(2, (LOG_INFO, "ixfr fallback to axfr, incomplete history from this serial for zone: %s",
+				dname_to_string(query->qname, NULL)));
 			return query_axfr(nsd, query, 0);
 		}
 


### PR DESCRIPTION
hi,

When nsd is used as a primary (like serving the zone after verification) it does not properly log if the zone transfer was ixfr or axfr.
It only logs what the client asked for. This is misleading because someone could think it was an ixfr reply, but with default configuration it falls back to axfr unless ixfr-out is explicitly configured.

This meant to fix that by properly logging when it falls back.

Regards,
 Tamás