### PR TITLE
More RFC 8499 compliance

### DIFF
--- a/nsd-control.8.in
+++ b/nsd-control.8.in
@@ -80,7 +80,7 @@ Same as stats, but does not zero the counters.
 .B addzone <zone name> <pattern name>
 Add a new zone to the running server.  The zone is added to the zonelist
 file on disk, so it stays after a restart.  The pattern name determines
-the options for the new zone.  For slave zones a zone transfer is
+the options for the new zone.  For secondary zones a zone transfer is
 immediately attempted.  For zones with a zonefile, the zone file is
 attempted to be read in.
 .TP
@@ -114,28 +114,28 @@ path are created if necessary. With argument that zone is written if it
 was modified, without argument, all modified zones are written.
 .TP
 .B notify [<zone>]
-Send NOTIFY messages to slave servers.  Sends to the IP addresses
-configured in the 'notify:' lists for the master zones hosted on this
-server.  Usually NSD sends NOTIFY messages right away when a master zone
+Send NOTIFY messages to secondary servers.  Sends to the IP addresses
+configured in the 'notify:' lists for the primary zones hosted on this
+server.  Usually NSD sends NOTIFY messages right away when a primary zone
 serial is updated.  If a zone is given, notifies are sent for that zone.
-These slave servers are supposed to initiate a zone transfer request
-later (to this server or another master), this can be allowed via
+These secondary servers are supposed to initiate a zone transfer request
+later (to this server or another primary), this can be allowed via
 the 'provide\-xfr:' acl list configuration. With argument that zone is
 processed, without argument, all zones are processed.
 .TP
 .B transfer [<zone>]
-Attempt to update slave zones that are hosted on this server by contacting
-the masters.  The masters are configured via 'request\-xfr:' lists.
+Attempt to update secondary zones that are hosted on this server by contacting
+the primaries.  The primaries are configured via 'request\-xfr:' lists.
 If a zone is given, that zone is updated.  Usually NSD receives a NOTIFY
-from the masters (configured via 'allow\-notify:' acl list) that a new zone
+from the primaries (configured via 'allow\-notify:' acl list) that a new zone
 serial has to be transferred.  For zones with no content, NSD may have backed
-off from asking often because the masters did not respond, but this command
+off from asking often because the primaries did not respond, but this command
 will reset the backoff to its initial timeout, for frequent retries. With
 argument that zone is transferred, without argument, all zones are transferred.
 .TP
 .B force_transfer [<zone>]
-Force update slave zones that are hosted on this server.  Even if the
-master hosts the same serial number of the zone, a full AXFR is performed
+Force update secondary zones that are hosted on this server.  Even if the
+primary hosts the same serial number of the zone, a full AXFR is performed
 to fetch it.  If you want to use IXFR and check that the serial number
 increases, use the 'transfer' command. With argument that zone is
 transferred, without argument, all zones are transferred.
@@ -143,9 +143,9 @@ transferred, without argument, all zones are transferred.
 .B zonestatus [<zone>]
 Print state of the zone, the serial numbers and since when they have
 been acquired.  Also prints the notify action (to which server), and
-zone transfer (and from which master) if there is activity right now.
-The state of the zone is printed as: 'master' (master zones), 'ok' (slave
-zone is up\-to\-date), 'expired' (slave zone has expired), 'refreshing' (slave
+zone transfer (and from which primary) if there is activity right now.
+The state of the zone is printed as: 'master' (primary zones), 'ok' (secondary
+zone is up\-to\-date), 'expired' (secondary zone has expired), 'refreshing' (secondary
 zone has transfers active).  The serial numbers printed are
 the 'served\-serial' (currently active), the 'commit\-serial' (is in reload),
 the 'notified\-serial' (got notify, busy fetching the data).  The serial
@@ -324,11 +324,11 @@ number of answers with TC flag set.
 number of queries that were dropped because they failed sanity check.
 .TP
 .I zone.master
-number of master zones served.  These are zones with no 'request\-xfr:'
+number of primary zones served.  These are zones with no 'request\-xfr:'
 entries.
 .TP
 .I zone.slave
-number of slave zones served.  These are zones with 'request\-xfr'
+number of secondary zones served.  These are zones with 'request\-xfr'
 entries.
 .SH "FILES"
 .TP

--- a/nsd-control.c
+++ b/nsd-control.c
@@ -124,9 +124,9 @@ usage()
 	printf("  addzones			add zone list on stdin {name space pattern newline}\n");
 	printf("  delzones			remove zone list on stdin {name newline}\n");
 	printf("  write [<zone>]		write changed zonefiles to disk\n");
-	printf("  notify [<zone>]		send NOTIFY messages to slave servers\n");
-	printf("  transfer [<zone>]		try to update slave zones to newer serial\n");
-	printf("  force_transfer [<zone>]	update slave zones with AXFR, no serial check\n");
+	printf("  notify [<zone>]		send NOTIFY messages to secondary servers\n");
+	printf("  transfer [<zone>]		try to update secondary zones to newer serial\n");
+	printf("  force_transfer [<zone>]	update secondary zones with AXFR, no serial check\n");
 	printf("  zonestatus [<zone>]		print state, serial, activity\n");
 	printf("  serverpid			get pid of server process\n");
 	printf("  verbosity <number>		change logging detail\n");


### PR DESCRIPTION
Update nsd-control's output to use "secondary" instead of "slave".
Update the nsd-control man page to use "primary" and "secondary" instead of "master" and "slave".