### PR TITLE
XFR clients have to be able to query SOA at apex

### DIFF
--- a/query.c
+++ b/query.c
@@ -1365,6 +1365,18 @@ answer_lookup_zone(struct nsd *nsd, struct query *q, answer_type *answer,
 				why->ip_address_spec,
 				why->nokey?"NOKEY":
 				(why->blocked?"BLOCKED":why->key_name)));
+		} else if(q->qtype == TYPE_SOA
+		       &&  0 == dname_compare(q->qname,
+				(const dname_type*)q->zone->opts->node.key)
+		       && -1 != acl_check_incoming(
+				q->zone->opts->pattern->provide_xfr, q,&why)) {
+			assert(why);
+			DEBUG(DEBUG_QUERY,1, (LOG_INFO, "SOA apex query %s "
+				"passed request-xfr acl %s %s",
+				dname_to_string(q->qname, NULL),
+				why->ip_address_spec,
+				why->nokey?"NOKEY":
+				(why->blocked?"BLOCKED":why->key_name)));
 		} else {
 			if (verbosity >= 2) {
 				char address[128];

--- a/tpkg/allow_query.tdir/allow_query.conf
+++ b/tpkg/allow_query.tdir/allow_query.conf
@@ -2,6 +2,9 @@
 server:
 	logfile: "nsd.log"
 	zonesdir: ""
+	username: ""
+	database: ""
+	verbosity: 2
 	zonelistfile: "zone.list"
 	interface: 127.0.0.1
 	interface: ::1
@@ -34,7 +37,7 @@ zone:
 
 zone:
 	name: example.edu
-	zonefile: allow_query.example.com.zone
+	zonefile: allow_query.example.edu.zone
 	allow-query: 0.0.0.0/0 hopsa.kidee
 
 zone:

--- a/tpkg/allow_query.tdir/allow_query.pre
+++ b/tpkg/allow_query.tdir/allow_query.pre
@@ -5,17 +5,19 @@
 [ -f .tpkg.var.test ] && source .tpkg.var.test
 . ../common.sh
 
-# start NSD
-get_random_port 1
-TPKG_PORT=$RND_PORT
+if [ -z "${TPKG_PORT}" ]; then
+	# start NSD
+	get_random_port 1
+	TPKG_PORT=$RND_PORT
+
+	TPKG_NSD_PID="nsd.pid.$$"
+	# share the vars
+	echo "export TPKG_PORT=$TPKG_PORT" >> .tpkg.var.test
+	echo "export TPKG_NSD_PID=$TPKG_NSD_PID" >> .tpkg.var.test
+fi
 
 PRE="../.."
-TPKG_NSD_PID="nsd.pid.$$"
 TPKG_NSD="$PRE/nsd"
-
-# share the vars
-echo "export TPKG_PORT=$TPKG_PORT" >> .tpkg.var.test
-echo "export TPKG_NSD_PID=$TPKG_NSD_PID" >> .tpkg.var.test
-
-$TPKG_NSD -c allow_query.conf -u "" -p $TPKG_PORT -P $TPKG_NSD_PID
+$TPKG_NSD -c allow_query.conf -p $TPKG_PORT -P $TPKG_NSD_PID -L 5 -F 0xFFFF \
+|| $TPKG_NSD -c allow_query.conf -p $TPKG_PORT -P $TPKG_NSD_PID
 wait_nsd_up nsd.log

--- a/tpkg/allow_query.tdir/allow_query.test
+++ b/tpkg/allow_query.tdir/allow_query.test
@@ -121,27 +121,31 @@ else
 fi
 
 # zone example.com, allow-query: 0.0.0.0/0 BLOCKED
-# No queries allowed whatsoever
+# zone example.com, provide-xfr: 127.0.0.1/8 hopsa.kidee
+# SOA apex queries are allowed for the proivde-xfr ACL
 #
-$DIG @127.0.0.1 -p $TPKG_PORT -y hmac-sha256:hopsa.kidee:K7/uC0yQoo4xCjYCYQ+HOC+Ng1wajK+3/t6PdneMAqw= SOA example.com. +norec >example.com.refused3
-if ! grep -q ', status: REFUSED, ' example.com.refused3
+$DIG @127.0.0.1 -p $TPKG_PORT -y hmac-sha256:hopsa.kidee:K7/uC0yQoo4xCjYCYQ+HOC+Ng1wajK+3/t6PdneMAqw= SOA example.com. +norec >example.com.noerror
+if ! grep -q ', status: NOERROR, ' example.com.noerror
 then
 	cat example.com.refused3
 	echo "zone example.com, allow-query: 0.0.0.0/0 BLOCKED"
-	echo "No queries allowed whatsoever"
+	echo "zone example.com, provide-xfr: 127.0.0.1/8 hopsa.kidee"
+	echo "SOA query at the apex with provide-xfr acl allowed"
 	echo "FAILED"
 	exit 1
 fi
 
+# zone example.com, allow-query: 0.0.0.0/0 BLOCKED
 # zone example.com, provide-xfr: 127.0.0.1/8 hopsa.kidee
-# No queries allowed whatsoever, but transfer works!
+# No queries allowed, but transfer works!
 #
 $DIG @127.0.0.1 -p $TPKG_PORT -y hmac-sha256:hopsa.kidee:K7/uC0yQoo4xCjYCYQ+HOC+Ng1wajK+3/t6PdneMAqw= AXFR example.com. +norec >example.com.axfr
 if ! grep -q '^example.com.[[:space:]][[:space:]]*3600[[:space:]][[:space:]]*IN[[:space:]][[:space:]]*SOA' example.com.axfr
 then
 	cat example.com.axfr
+	echo "zone example.com, allow-query: 0.0.0.0/0 BLOCKED"
 	echo "zone example.com, provide-xfr: 127.0.0.1/8 hopsa.kidee"
-	echo "No queries allowed whatsoever, but transfer works"
+	echo "No queries allowed, but transfer works"
 	echo "FAILED"
 	exit 1
 fi


### PR DESCRIPTION
Clients that are allowed to transfer a zone because they match a provide-xfr acl, should also be able to query for the SOA at the apex (because such a client does that query before it starts the actual transfer).
This PR allows transfer clients to do a SOA query at the apex, even if queries are blocked for the zone with the `allow-query` option.