### PR TITLE
Mutual TLS-AUTH

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -162,7 +162,7 @@ nsd:	simdzone/libzone.a $(NSD_OBJ) $(LIBOBJS)
 	$(LINK) -o $@ $(NSD_OBJ) $(LIBOBJS) simdzone/libzone.a $(SSL_LIBS) $(LIBS)
 
 nsd-checkconf:	simdzone/libzone.a $(NSD_CHECKCONF_OBJ) $(LIBOBJS)
-	$(LINK) -o $@ $(NSD_CHECKCONF_OBJ) simdzone/libzone.a $(LIBOBJS) $(LIBS)
+	$(LINK) -o $@ $(NSD_CHECKCONF_OBJ) simdzone/libzone.a $(LIBOBJS) $(SSL_LIBS) $(LIBS)
 
 nsd-checkzone:	simdzone/libzone.a $(NSD_CHECKZONE_OBJ) $(LIBOBJS)
 	$(LINK) -o $@ $(NSD_CHECKZONE_OBJ) $(LIBOBJS) simdzone/libzone.a $(SSL_LIBS) $(LIBS)

--- a/axfr.c
+++ b/axfr.c
@@ -195,7 +195,7 @@ static int axfr_ixfr_can_admit_query(struct nsd* nsd, struct query* q)
 			char address[128], proxy[128];
 			addr2str(&q->client_addr, address, sizeof(address));
 			addr2str(&q->remote_addr, proxy, sizeof(proxy));
-			VERBOSITY(2, (LOG_INFO, "%s for %s from %s refused (tls-auth-xfr-only)",
+			VERBOSITY(2, (LOG_INFO, "%s for %s from %s refused tls-auth-xfr-only",
 				(q->qtype==TYPE_AXFR?"axfr":"ixfr"),
 				dname_to_string(q->qname, NULL),
 				address));
@@ -255,20 +255,27 @@ static int axfr_ixfr_can_admit_query(struct nsd* nsd, struct query* q)
 		}
 		return 0;
 	}
+#ifdef HAVE_SSL
+	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "%s admitted acl %s %s %s",
+		(q->qtype==TYPE_AXFR?"axfr":"ixfr"),
+		acl->ip_address_spec, acl->key_name?acl->key_name:"NOKEY",
+		(q->tls||q->tls_auth)?(q->tls?"tls":"tls-auth"):""));
+#else
 	DEBUG(DEBUG_XFRD,1, (LOG_INFO, "%s admitted acl %s %s",
 		(q->qtype==TYPE_AXFR?"axfr":"ixfr"),
 		acl->ip_address_spec, acl->key_name?acl->key_name:"NOKEY"));
+#endif
 	if (verbosity >= 1) {
 		char a[128];
 		addr2str(&q->client_addr, a, sizeof(a));
 #ifdef HAVE_SSL
-		VERBOSITY(1, (LOG_INFO, "%s for %s from %s %s",
+		VERBOSITY(1, (LOG_INFO, "%s for %s from %s %s %s",
 			(q->qtype==TYPE_AXFR?"axfr":"ixfr"),
 			dname_to_string(q->qname, NULL), a,
-			(q->tls||q->tls_auth)?(q->tls?"(tls)":"(tls-auth)"):""));
-			// XXX ADD VERIFIED
+			(q->tls||q->tls_auth)?(q->tls?"tls":"tls-auth"):"",
+			q->cert_cn?q->cert_cn:"not-verified"));
 #else
-		VERBOSITY(1, (LOG_INFO, "%s for %s from %s %s",
+		VERBOSITY(1, (LOG_INFO, "%s for %s from %s",
 			(q->qtype==TYPE_AXFR?"axfr":"ixfr"),
 			dname_to_string(q->qname, NULL), a));
 #endif

--- a/axfr.c
+++ b/axfr.c
@@ -187,6 +187,27 @@ static int axfr_ixfr_can_admit_query(struct nsd* nsd, struct query* q)
 {
 	struct acl_options *acl = NULL;
 	struct zone_options* zone_opt;
+
+#ifdef HAVE_SSL
+	/* tls-auth-xfr-only is set and this is not an authenticated TLS */
+	if (nsd->options->tls_auth_xfr_only && !q->tls_auth) {
+		if (verbosity >= 2) {
+			char address[128], proxy[128];
+			addr2str(&q->client_addr, address, sizeof(address));
+			addr2str(&q->remote_addr, proxy, sizeof(proxy));
+			VERBOSITY(2, (LOG_INFO, "%s for %s from %s refused (tls-auth-xfr-only)",
+				(q->qtype==TYPE_AXFR?"axfr":"ixfr"),
+				dname_to_string(q->qname, NULL),
+				address));
+		}
+		RCODE_SET(q->packet, RCODE_REFUSE);
+		/* RFC8914 - Extended DNS Errors
+		 * 4.19.  Extended DNS Error Code 18 - Prohibited */
+		q->edns.ede = EDE_PROHIBITED;
+		return 0;
+	}
+#endif
+
 	zone_opt = zone_options_find(nsd->options, q->qname);
 	if(zone_opt && q->is_proxied && acl_check_incoming_block_proxy(
 		zone_opt->pattern->provide_xfr, q, &acl) == -1) {
@@ -240,9 +261,17 @@ static int axfr_ixfr_can_admit_query(struct nsd* nsd, struct query* q)
 	if (verbosity >= 1) {
 		char a[128];
 		addr2str(&q->client_addr, a, sizeof(a));
-		VERBOSITY(1, (LOG_INFO, "%s for %s from %s",
+#ifdef HAVE_SSL
+		VERBOSITY(1, (LOG_INFO, "%s for %s from %s %s",
+			(q->qtype==TYPE_AXFR?"axfr":"ixfr"),
+			dname_to_string(q->qname, NULL), a,
+			(q->tls||q->tls_auth)?(q->tls?"(tls)":"(tls-auth)"):""));
+			// XXX ADD VERIFIED
+#else
+		VERBOSITY(1, (LOG_INFO, "%s for %s from %s %s",
 			(q->qtype==TYPE_AXFR?"axfr":"ixfr"),
 			dname_to_string(q->qname, NULL), a));
+#endif
 	}
 	return 1;
 }

--- a/configlexer.lex
+++ b/configlexer.lex
@@ -305,6 +305,7 @@ tls-service-ocsp{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_SERVICE_OCS
 tls-service-pem{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_SERVICE_PEM;}
 tls-port{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_PORT;}
 tls-auth-port{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_AUTH_PORT;}
+tls-auth-xfr-only{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_AUTH_XFR_ONLY;}
 tls-cert-bundle{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_CERT_BUNDLE; }
 proxy-protocol-port{COLON} { LEXOUT(("v(%s) ", yytext)); return VAR_PROXY_PROTOCOL_PORT; }
 answer-cookie{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_ANSWER_COOKIE;}

--- a/configlexer.lex
+++ b/configlexer.lex
@@ -304,6 +304,7 @@ tls-service-key{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_SERVICE_KEY;
 tls-service-ocsp{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_SERVICE_OCSP;}
 tls-service-pem{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_SERVICE_PEM;}
 tls-port{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_PORT;}
+tls-auth-port{COLON}		{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_AUTH_PORT;}
 tls-cert-bundle{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_TLS_CERT_BUNDLE; }
 proxy-protocol-port{COLON} { LEXOUT(("v(%s) ", yytext)); return VAR_PROXY_PROTOCOL_PORT; }
 answer-cookie{COLON}	{ LEXOUT(("v(%s) ", yytext)); return VAR_ANSWER_COOKIE;}

--- a/configparser.y
+++ b/configparser.y
@@ -938,7 +938,7 @@ pattern_or_zone_option:
         yyerror("address range used for request-xfr");
       append_acl(&cfg_parser->pattern->request_xfr, acl);
     }
-	tlsauth_option
+	request_xfr_tlsauth_option
 	{ }
   | VAR_REQUEST_XFR VAR_AXFR STRING STRING
     {
@@ -950,7 +950,7 @@ pattern_or_zone_option:
         yyerror("address range used for request-xfr");
       append_acl(&cfg_parser->pattern->request_xfr, acl);
     }
-	tlsauth_option
+	request_xfr_tlsauth_option
 	{ }
   | VAR_REQUEST_XFR VAR_UDP STRING STRING
     {
@@ -981,6 +981,8 @@ pattern_or_zone_option:
       acl_options_type *acl = parse_acl_info(cfg_parser->opt->region, $2, $3);
       append_acl(&cfg_parser->pattern->provide_xfr, acl);
     }
+	provide_xfr_tlsauth_option
+	{ }
   | VAR_ALLOW_QUERY STRING STRING
     {
       acl_options_type *acl = parse_acl_info(cfg_parser->opt->region, $2, $3);
@@ -1191,10 +1193,15 @@ boolean:
       }
     } ;
 
-tlsauth_option:
+request_xfr_tlsauth_option:
 	| STRING
 	{ char *tls_auth_name = region_strdup(cfg_parser->opt->region, $1);
 	  add_to_last_acl(&cfg_parser->pattern->request_xfr, tls_auth_name);} ;
+
+provide_xfr_tlsauth_option:
+	| STRING
+	{ char *tls_auth_name = region_strdup(cfg_parser->opt->region, $1);
+	  add_to_last_acl(&cfg_parser->pattern->provide_xfr, tls_auth_name);} ;
 
 catalog_role:
     STRING

--- a/configparser.y
+++ b/configparser.y
@@ -128,6 +128,7 @@ struct component {
 %token VAR_TLS_SERVICE_OCSP
 %token VAR_TLS_PORT
 %token VAR_TLS_AUTH_PORT
+%token VAR_TLS_AUTH_XFR_ONLY
 %token VAR_TLS_CERT_BUNDLE
 %token VAR_PROXY_PROTOCOL_PORT
 %token VAR_CPU_AFFINITY
@@ -486,6 +487,14 @@ server_option:
       char buf[16];
       (void)snprintf(buf, sizeof(buf), "%lld", $2);
       cfg_parser->opt->tls_auth_port = region_strdup(cfg_parser->opt->region, buf);
+    }
+  | VAR_TLS_AUTH_XFR_ONLY boolean
+    {
+      if (!cfg_parser->opt->tls_auth_port) {
+        yyerror("tls-auth-xfr-only set without or before tls-auth-port");
+        YYABORT;
+      }
+      cfg_parser->opt->tls_auth_xfr_only = $2;
     }
   | VAR_TLS_CERT_BUNDLE STRING
     { cfg_parser->opt->tls_cert_bundle = region_strdup(cfg_parser->opt->region, $2); }

--- a/configparser.y
+++ b/configparser.y
@@ -127,6 +127,7 @@ struct component {
 %token VAR_TLS_SERVICE_PEM
 %token VAR_TLS_SERVICE_OCSP
 %token VAR_TLS_PORT
+%token VAR_TLS_AUTH_PORT
 %token VAR_TLS_CERT_BUNDLE
 %token VAR_PROXY_PROTOCOL_PORT
 %token VAR_CPU_AFFINITY
@@ -478,6 +479,13 @@ server_option:
       char buf[16];
       (void)snprintf(buf, sizeof(buf), "%lld", $2);
       cfg_parser->opt->tls_port = region_strdup(cfg_parser->opt->region, buf);
+    }
+  | VAR_TLS_AUTH_PORT number
+    {
+      /* port number, stored as string */
+      char buf[16];
+      (void)snprintf(buf, sizeof(buf), "%lld", $2);
+      cfg_parser->opt->tls_auth_port = region_strdup(cfg_parser->opt->region, buf);
     }
   | VAR_TLS_CERT_BUNDLE STRING
     { cfg_parser->opt->tls_cert_bundle = region_strdup(cfg_parser->opt->region, $2); }

--- a/configure.ac
+++ b/configure.ac
@@ -1045,7 +1045,7 @@ if test x$HAVE_SSL = x"yes"; then
 	fi
 	SSL_LIBS="-lssl"
 	AC_SUBST(SSL_LIBS)
-	AC_CHECK_HEADERS([openssl/ssl.h openssl/err.h openssl/rand.h openssl/ocsp.h openssl/core_names.h],,, [AC_INCLUDES_DEFAULT])
+	AC_CHECK_HEADERS([openssl/ssl.h openssl/err.h openssl/rand.h openssl/ocsp.h openssl/core_names.h openssl/x509v3.h],,, [AC_INCLUDES_DEFAULT])
 	AC_CHECK_FUNCS([HMAC_CTX_reset HMAC_CTX_new EVP_cleanup ERR_load_crypto_strings OPENSSL_init_crypto CRYPTO_memcmp EC_KEY_new_by_curve_name EVP_MAC_CTX_new EVP_MAC_CTX_set_params EVP_MAC_CTX_get_mac_size SHA1_Init])
 	if test "$ac_cv_func_SHA1_Init" = "yes"; then
 		ACX_FUNC_DEPRECATED([SHA1_Init], [(void)SHA1_Init(NULL);], [
@@ -1071,6 +1071,9 @@ AC_INCLUDES_DEFAULT
 #endif
 #include <openssl/ssl.h>
 #include <openssl/evp.h>
+#ifdef HAVE_OPENSSL_X509V3_h
+#include <openssl/x509v3.h>
+#endif
 ])
 	AC_CHECK_DECL([TLS1_3_VERSION], 
 		[AC_DEFINE([HAVE_TLS_1_3], [1], [Define if TLS 1.3 is supported by OpenSSL])],
@@ -1078,7 +1081,7 @@ AC_INCLUDES_DEFAULT
 
 	BAKLIBS="$LIBS"
 	LIBS="-lssl $LIBS"
-	AC_CHECK_FUNCS([OPENSSL_init_ssl SSL_get1_peer_certificate SSL_CTX_set_security_level ERR_load_SSL_strings])
+	AC_CHECK_FUNCS([OPENSSL_init_ssl SSL_get1_peer_certificate SSL_CTX_set_security_level X509_get_ext_d2i OPENSSL_sk_num OPENSSL_sk_value OPENSSL_sk_pop_free ASN1_STRING_get0_data ASN1_STRING_length X509_get_subject_name X509_NAME_get_index_by_NID X509_NAME_get_entry X509_NAME_ENTRY_get_data ERR_load_SSL_strings])
 	if test "$ac_cv_func_ERR_load_SSL_strings" = "yes"; then
 		ACX_FUNC_DEPRECATED([ERR_load_SSL_strings], [(void)ERR_load_SSL_strings();], [
 #include <openssl/ssl.h>

--- a/configure.ac
+++ b/configure.ac
@@ -1081,7 +1081,7 @@ AC_INCLUDES_DEFAULT
 
 	BAKLIBS="$LIBS"
 	LIBS="-lssl $LIBS"
-	AC_CHECK_FUNCS([OPENSSL_init_ssl SSL_get1_peer_certificate SSL_CTX_set_security_level X509_get_ext_d2i OPENSSL_sk_num OPENSSL_sk_value OPENSSL_sk_pop_free ASN1_STRING_get0_data ASN1_STRING_length X509_get_subject_name X509_NAME_get_index_by_NID X509_NAME_get_entry X509_NAME_ENTRY_get_data ERR_load_SSL_strings])
+	AC_CHECK_FUNCS([OPENSSL_init_ssl SSL_get1_peer_certificate SSL_CTX_set_security_level ERR_load_SSL_strings])
 	if test "$ac_cv_func_ERR_load_SSL_strings" = "yes"; then
 		ACX_FUNC_DEPRECATED([ERR_load_SSL_strings], [(void)ERR_load_SSL_strings();], [
 #include <openssl/ssl.h>

--- a/nsd.c
+++ b/nsd.c
@@ -1205,6 +1205,7 @@ main(int argc, char *argv[])
 	nsd.ipv6_edns_size = nsd.options->ipv6_edns_size;
 #ifdef HAVE_SSL
 	nsd.tls_ctx = NULL;
+	nsd.tls_auth_ctx = NULL;
 #endif
 
 	if(udp_port == 0)
@@ -1577,9 +1578,17 @@ main(int argc, char *argv[])
 #if defined(HAVE_SSL)
 	if(nsd.options->tls_service_key && nsd.options->tls_service_key[0]
 	   && nsd.options->tls_service_pem && nsd.options->tls_service_pem[0]) {
+		/* normal tls port with no client authentication */
 		if(!(nsd.tls_ctx = server_tls_ctx_create(&nsd, NULL,
-			nsd.options->tls_service_ocsp)))
+		     nsd.options->tls_service_ocsp)))
 			error("could not set up tls SSL_CTX");
+		/* tls-auth port with required client authentication */
+		if(nsd.options->tls_auth_port) {
+			if(!(nsd.tls_auth_ctx = server_tls_ctx_create(&nsd,
+			     (char*)nsd.options->tls_cert_bundle,
+			     nsd.options->tls_service_ocsp)))
+				error("could not set up tls SSL_CTX");
+		}
 	}
 #endif /* HAVE_SSL */
 

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -580,6 +580,14 @@ and enable
 .BR tls-auth
 in zone configuration in order to authenticate to a remote (primary) server.
 .TP
+.B tls\-auth\-xfr\-only:\fR <yes or no>
+Allow zone transfers only on the
+.BR tls-auth-port
+port and only to authenticated clients. This works globally for all zones.
+.BR provide-xfr
+access control list is also required to allow a connection.
+Requests for zone transfers on other ports are refused.
+.TP
 .B tls\-cert\-bundle:\fR <filename>
 If null or "", the default verify locations are used. Set it to the certificate
 bundle file, for example "/etc/pki/tls/certs/ca-bundle.crt". These certificates

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -563,6 +563,23 @@ openssl ocsp -no_nonce \\
 The port number on which to provide TCP TLS service, default is 853, only
 interfaces configured with that port number as @number get DNS over TLS service.
 .TP
+.B tls\-auth\-port:\fR <number>
+The port number on which to provide TCP TLS service to authenticated clients only.
+If you want to use mutual TLS authentication in Transfer over TLS (XoT) connections,
+this is where the primary server enables a dedicated port for this purpose. Certificates in
+.BR tls-cert-bundle
+are used for verifying the authenticity of a client or a secondary server.
+.IP
+Client (secondary) must enable
+.BR tls-auth ,
+configure
+.BR client-cert
+and
+.BR client-key
+and enable
+.BR tls-auth
+in zone configuration in order to authenticate to a remote (primary) server.
+.TP
 .B tls\-cert\-bundle:\fR <filename>
 If null or "", the default verify locations are used. Set it to the certificate
 bundle file, for example "/etc/pki/tls/certs/ca-bundle.crt". These certificates

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -119,7 +119,8 @@ attribute is used to define keys for authentication. The
 attribute is followed by the zone options for zones that use the pattern.
 A
 .B tls-auth:
-attribute is used to define credentials for authenticating an outgoing TLS connection used for XFR-over-TLS.
+attribute is used to define authentication attributes for TLS connections used
+for XFR-over-TLS.
 .P
 Files can be included using the
 .B include:
@@ -584,8 +585,11 @@ in zone configuration in order to authenticate to a remote (primary) server.
 Allow zone transfers only on the
 .BR tls-auth-port
 port and only to authenticated clients. This works globally for all zones.
+A
 .BR provide-xfr
-access control list is also required to allow a connection.
+access control list with
+.BR tls-auth
+is also required to allow and verify a connection.
 Requests for zone transfers on other ports are refused.
 .TP
 .B tls\-cert\-bundle:\fR <filename>
@@ -877,8 +881,8 @@ Kaminsky\-style attacks. If the UDP option is left out then IXFR will be
 transmitted using TCP.
 .P
 If a tls-auth-name is given then TLS (by default on port 853) will be used
-for all zone transfers for the zone. If authentication of the primary based on
-the specified tls-auth authentication information fails, the XFR request will
+for all zone transfers for the zone. If authentication of the primary, based on
+the specified tls-auth authentication information, fails the XFR request will
 not be sent. Support for TLS 1.3 is required for XFR-over-TLS.
 .RE
 .TP
@@ -902,7 +906,7 @@ time).
 This option should be accompanied by notify. It sets the number of retries
 when sending notifies.
 .TP
-.B provide\-xfr:\fR <ip\-spec> <key\-name | NOKEY | BLOCKED>
+.B provide\-xfr:\fR <ip\-spec> <key\-name | NOKEY | BLOCKED> [tls\-auth\-name]
 Access control list. The listed address (a secondary) is allowed to
 request XFR from this server. Zone data will be provided to the
 address. The specified key is used during XFR. For unlisted or
@@ -917,6 +921,25 @@ a subnet of the form 1.2.3.4/24, or masked like
 A port number can be added using a suffix of @number, for example
 1.2.3.4@5300 or 1.2.3.4/24@5300 for port 5300. Note the ip\-spec
 ranges do not use spaces around the /, &, @ and \- symbols.
+.P
+If a tls-auth-name is given then TLS authentication of the secondary will be performed
+for zone transfer requests for the zone. The remote end must connect to the
+.BR tls-auth-port
+and must present a certificate with a
+SAN (Subject Alternative Name) DNS entry or CN (Common Name) entry equal to
+.BR auth-domain-name
+of the defined
+.BR tls-auth .
+The certificate validify is also verified with
+.BR tls-cert-bundle .
+If authentication of the secondary, based on the specified tls-auth authentication
+information, fails the XFR zone transfer will be refused. If the connection is performed
+on the
+.BR tls-port
+then no authentication will be performed and the transfer will not be refused.
+To enforce only authenticated zone transfers,
+.BR tls-auth-xfr-only
+should also be enabled. Support for TLS 1.3 is required for XFR-over-TLS.
 .RE
 .TP
 .B outgoing\-interface:\fR <ip\-address>
@@ -1108,16 +1131,21 @@ dev-random output through a base64 encode filter.
 .SS "TLS Auth Declarations"
 The
 .B tls-auth:
-clause establishes authentication attributes to use when authenticating
-the far end of an outgoing TLS connection used in access control lists for XFR-over-TLS.
-It has the following attributes.
+clause establishes attributes to use when authenticating the far end of a TLS connection
+as well as to define credentials to authenticate to a remote server. It is used in
+access control lists for XFR-over-TLS. It has the following attributes.
 .TP
 .B name:\fR <string>
 The tls-auth name. Used to refer to this TLS authentication information in the
 access control list.
 .TP
 .B auth\-domain\-name:\fR <string>
-The authentication domain name as defined in RFC8310.
+The authentication domain name as defined in RFC8310. Used to verify the certificate
+of the remote connecting server. When used by a primary server in
+.BR provide-xfr
+it verifies the secondary. When used by a secondary server in
+.BR request-xfr
+it verifies the primary.
 .TP
 .B client\-cert: <file name of clientcert.pem>
 If you want to use mutual TLS authentication, this is where the client

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -256,6 +256,13 @@ server:
 	# tls-service-ocsp: "path/to/ocsp.pem"
 	# tls-port: 853
 	
+	# Provides a dedidated TLS port where only authenticated clients can
+	# connect. Used for zone transfers to secondary servers. It uses
+	# tls-service-key and tls-service-pem and verifies client certificates
+	# using tls-cert-bundle.
+	# Default is "" (disabled). Requires restart to take effect.
+	# tls-auth-port: 8853
+
 	# Certificates used to authenticate connections made upstream for
 	# Transfers over TLS (XoT). Default is "" (default verify locations).
 	# tls-cert-bundle: "path/to/ca-bundle.pem"

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -263,6 +263,11 @@ server:
 	# Default is "" (disabled). Requires restart to take effect.
 	# tls-auth-port: 8853
 
+	# Allow zone transfers only on the tls-auth-port port and only to
+	# authenticated clients. Requests for zone transfers on other ports
+	# are refused. Default is no. Requires restart to change it.
+	# tls-auth-xfr-only: yes
+
 	# Certificates used to authenticate connections made upstream for
 	# Transfers over TLS (XoT). Default is "" (default verify locations).
 	# tls-cert-bundle: "path/to/ca-bundle.pem"

--- a/nsd.h
+++ b/nsd.h
@@ -374,6 +374,7 @@ struct	nsd
 #ifdef HAVE_SSL
 	/* TLS specific configuration */
 	SSL_CTX *tls_ctx;
+	SSL_CTX *tls_auth_ctx;
 #endif
 };
 

--- a/options.c
+++ b/options.c
@@ -1986,11 +1986,13 @@ acl_check_incoming(struct acl_options* acl, struct query* q,
 					VERBOSITY(3, (LOG_WARNING,
 							"client cert %s does not match %s %s",
 							(q->cert_cn?q->cert_cn:"(null)"), acl->tls_auth_name, acl->tls_auth_options->auth_domain_name));
+					free(q->cert_cn);
 					q->cert_cn = NULL;
 					return -1;
 				}
 				VERBOSITY(5, (LOG_INFO, "%s %s verified",
 					acl->tls_auth_name, acl->tls_auth_options->auth_domain_name));
+				free(q->cert_cn);
 				q->cert_cn = acl->tls_auth_options->auth_domain_name;
 			} else {
 				/* nsd gives error on start for this, but check just in case */

--- a/options.h
+++ b/options.h
@@ -137,6 +137,8 @@ struct nsd_options {
 	const char* tls_auth_port;
 	/* TLS certificate bundle */
 	const char* tls_cert_bundle;
+	/* Answer XFR only from tls_auth_port and after authentication */
+	int tls_auth_xfr_only;
 
 	/* proxy protocol port list */
 	struct proxy_protocol_port_list* proxy_protocol_port;

--- a/options.h
+++ b/options.h
@@ -133,6 +133,8 @@ struct nsd_options {
 	char* tls_service_pem;
 	/* TLS dedicated port */
 	const char* tls_port;
+	/* TLS-AUTH dedicated port */
+	const char* tls_auth_port;
 	/* TLS certificate bundle */
 	const char* tls_cert_bundle;
 

--- a/options.h
+++ b/options.h
@@ -11,6 +11,9 @@
 #define OPTIONS_H
 
 #include <stdarg.h>
+#ifdef HAVE_SSL
+#include <openssl/ssl.h>
+#endif
 #include "region-allocator.h"
 #include "rbtree.h"
 struct query;
@@ -561,6 +564,9 @@ int acl_check_incoming(struct acl_options* acl, struct query* q,
 int acl_addr_matches_host(struct acl_options* acl, struct acl_options* host);
 int acl_addr_matches(struct acl_options* acl, struct query* q);
 int acl_addr_matches_proxy(struct acl_options* acl, struct query* q);
+#ifdef HAVE_SSL
+int acl_tls_hostname_matches(SSL* ssl, const char* acl_cert_cn, char** cert_cn);
+#endif
 int acl_key_matches(struct acl_options* acl, struct query* q);
 int acl_addr_match_mask(uint32_t* a, uint32_t* b, uint32_t* mask, size_t sz);
 int acl_addr_match_range_v6(uint32_t* minval, uint32_t* x, uint32_t* maxval, size_t sz);

--- a/query.h
+++ b/query.h
@@ -79,6 +79,14 @@ struct query {
 
 	buffer_type *packet;
 
+#ifdef HAVE_SSL
+	/*
+	 * TLS objects.
+	*/
+	SSL* tls;
+	SSL* tls_auth;
+#endif
+
 	/* Normalized query domain name.  */
 	const dname_type *qname;
 

--- a/query.h
+++ b/query.h
@@ -85,6 +85,7 @@ struct query {
 	*/
 	SSL* tls;
 	SSL* tls_auth;
+	char* cert_cn;
 #endif
 
 	/* Normalized query domain name.  */

--- a/server.c
+++ b/server.c
@@ -286,7 +286,7 @@ struct tcp_handler_data
 
 #ifdef HAVE_SSL
 	/*
-	 * TLS object.
+	 * TLS objects.
 	 */
 	SSL* tls;
 	SSL* tls_auth;
@@ -5360,6 +5360,7 @@ handle_tcp_accept(int fd, short event, void* arg)
 			close(s);
 			return;
 		}
+		tcp_data->query->tls = tcp_data->tls;
 		tcp_data->shake_state = tls_hs_read;
 		memset(&tcp_data->event, 0, sizeof(tcp_data->event));
 		event_set(&tcp_data->event, s, EV_PERSIST | EV_READ | EV_TIMEOUT,
@@ -5372,6 +5373,7 @@ handle_tcp_accept(int fd, short event, void* arg)
 			close(s);
 			return;
 		}
+		tcp_data->query->tls_auth = tcp_data->tls_auth;
 		tcp_data->shake_state = tls_hs_read;
 		memset(&tcp_data->event, 0, sizeof(tcp_data->event));
 		event_set(&tcp_data->event, s, EV_PERSIST | EV_READ | EV_TIMEOUT,

--- a/server.c
+++ b/server.c
@@ -5316,10 +5316,8 @@ handle_tcp_accept(int fd, short event, void* arg)
 #ifdef HAVE_SSL
 	tcp_data->shake_state = tls_hs_none;
 	/* initialize both incase of dangling pointers */
-	if (data->tls_accept || data->tls_auth_accept) {
-		tcp_data->tls = NULL;
-		tcp_data->tls_auth = NULL;
-	}
+	tcp_data->tls = NULL;
+	tcp_data->tls_auth = NULL;
 #endif
 	tcp_data->query_needs_reset = 1;
 	tcp_data->pp2_enabled = data->pp2_enabled;

--- a/server.c
+++ b/server.c
@@ -2142,8 +2142,7 @@ server_tls_ctx_setup(char* key, char* pem, char* verifypem)
 	}
 	listen_sslctx_setup_2(ctx);
 	if(verifypem && verifypem[0]) {
-		if(!SSL_CTX_load_verify_locations(ctx, verifypem, NULL) ||
-		   !SSL_CTX_set_default_verify_paths(ctx)) {
+		if(!SSL_CTX_load_verify_locations(ctx, verifypem, NULL)) {
 			log_crypto_err("Error in SSL_CTX verify locations");
 			SSL_CTX_free(ctx);
 			return NULL;

--- a/xfrd-tcp.c
+++ b/xfrd-tcp.c
@@ -904,14 +904,6 @@ xfrd_tcp_open(struct xfrd_tcp_set* set, struct xfrd_tcp_pipeline* tp,
 	if (zone->master->tls_auth_options &&
 		zone->master->tls_auth_options->auth_domain_name) {
 #ifdef HAVE_TLS_1_3
-		if (!setup_ssl(tp, set, zone->master->tls_auth_options->auth_domain_name)) {
-			log_msg(LOG_ERR, "xfrd: Cannot setup TLS on pipeline for %s to %s",
-					zone->apex_str, zone->master->ip_address_spec);
-			close(fd);
-			xfrd_set_refresh_now(zone);
-			return 0;
-		}
-
 		/* Load client certificate (if provided) */
 		if (zone->master->tls_auth_options->client_cert &&
 		    zone->master->tls_auth_options->client_key) {
@@ -928,6 +920,14 @@ xfrd_tcp_open(struct xfrd_tcp_set* set, struct xfrd_tcp_pipeline* tp,
 			if (SSL_CTX_use_PrivateKey_file(set->ssl_ctx, zone->master->tls_auth_options->client_key, SSL_FILETYPE_PEM) != 1) {
 				log_msg(LOG_ERR, "xfrd tls: Unable to load private key from file %s", zone->master->tls_auth_options->client_key);
 			}
+		}
+
+		if (!setup_ssl(tp, set, zone->master->tls_auth_options->auth_domain_name)) {
+			log_msg(LOG_ERR, "xfrd: Cannot setup TLS on pipeline for %s to %s",
+					zone->apex_str, zone->master->ip_address_spec);
+			close(fd);
+			xfrd_set_refresh_now(zone);
+			return 0;
 		}
 
 		tp->handshake_done = 0;


### PR DESCRIPTION
First part: Client side TLS-auth (client is authenticating to server).
[client's authentication of the server is fine]

commit 10eca881c6b27d62d95d0eee97f67bb08a0a632c

When request-xfr is setup on secondary with tls-auth and client-cert/client-key defined,
client/secondary makes initial connection to server/primary without having setup it's client-cert and client-key at an early stage.
The order that is done on the client is:
SSL_CTX_new
SSL_CTX_set_default_verify_paths
SSL_CTX_load_verify_locations

SSL_new()
SSL_set_connect_state()
SSL_set_mode(tp->ssl, SSL_MODE_AUTO_RETRY);
SSL_set_verify(tp->ssl, SSL_VERIFY_PEER, tls_verify_callback);
SSL_set1_host(tp->ssl, auth_domain_name)
SSL_CTX_use_certificate_chain_file()
SSL_CTX_use_PrivateKey_file()
ssl_handshake()

So the first SSL_new() does not have certificate_chain_file/PrivateKey_file which are loaded on CTX and not inherited in that first SSL_new().

Subsequent connections have the key but the first connection does not.

If server is setup to require/force client cert/key, on server we see:
error: TLS handshake failed from 127.0.0.1 crypto error:0A0000C7:SSL routines::peer did not return a certificate

If we load first the cert/key on the client and then make connection to server,
client will reply to server's request for client authentication. I've just changed the order things are done.

This is the first patch, for the client side, in order for the client to authenticate correctly to server using tls-auth.
I'm preparing another patch for the server.c in order for the server to require/force client to authenticate on a provide-xfr using tls-auth and complete mutual auth. 
#336 