### PR TITLE
Don't log ACL mismatches of CNAME targets

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,6 @@
+19 July 2024: Willem
+	- Do not log ACL mismatch on followed CNAMEs.
+
 18 July 2024: Jeroen
 	- Fix propagation of Makefile targets to simdzone.
 

--- a/doc/RELNOTES
+++ b/doc/RELNOTES
@@ -23,6 +23,7 @@ BUG FIXES:
 	- Use MAKE variable rather than make command directly in Makefile.
 	- Serialize WKS RRs using numeric values rather than names.
 	- Fix propagation of Makefile targets to simdzone
+	- Do not log ACL mismatch on followed CNAMEs.
 
 4.10.0
 ================

--- a/query.c
+++ b/query.c
@@ -1381,7 +1381,7 @@ answer_lookup_zone(struct nsd *nsd, struct query *q, answer_type *answer,
 				why->nokey?"NOKEY":
 				(why->blocked?"BLOCKED":why->key_name)));
 		} else {
-			if (verbosity >= 2) {
+			if (q->cname_count == 0 && verbosity >= 2) {
 				char address[128];
 				addr2str(&q->client_addr, address, sizeof(address));
 				VERBOSITY(2, (LOG_INFO, "query %s from %s refused, %s%s%s",


### PR DESCRIPTION
This came from an e-mail to the nsd-users list.

If a CNAME is followed and it reaches a domain which as an allow-query list and the querier is blocked (because no ACL matches or by other reasons), do not log an message about the ACL not matching.

Is it desirable if no message is logged in such cases? Or is there still value in logging if CNAME targets do not match an ACL for a queries?