### PR TITLE
log file name before loading

### DIFF
--- a/dbaccess.c
+++ b/dbaccess.c
@@ -258,6 +258,8 @@ namedb_read_zonefile(struct nsd* nsd, struct zone* zone, udb_base* taskudb,
 	zone->nsec3_param = NULL;
 #endif
 	delete_zone_rrs(nsd->db, zone);
+	VERBOSITY(9, (LOG_INFO, "zone %s zonec_read(%s)",
+		zone->opts->name, fname));
 	errors = zonec_read(nsd->db, nsd->db->domains, zone->opts->name, fname, zone);
 	if(errors > 0) {
 		log_msg(LOG_ERR, "zone %s file %s read with %u errors",


### PR DESCRIPTION
in the event there is a fatal error inside zonec_read provide ability to log the zone and file names prior to entry