### PR TITLE
Use MAKE variable rather than make command

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -195,7 +195,7 @@ audit: nsd nsd-checkconf nsd-checkzone nsd-control nsd-mem checksec
 
 clean:
 	rm -f *.o $(TARGETS) $(MANUALS) cutest popen3_echo xfr-inspect nsd-mem
-	make -C simdzone $(MAKECMDGOALS)
+	$(MAKE) -C simdzone $(MAKECMDGOALS)
 
 distclean: clean
 	rm -f Makefile config.h config.log config.status dnstap/dnstap_config.h

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,9 @@
+12 July 2024: Jeroen
+	- Use MAKE variable rather than make command.
+	  On platforms where make is not the same make executing the Makefile,
+	  build issues might arise. The MAKE variable expands to the command
+	  used on the command line.
+
 8 July 2024: Wouter
 	- Merge #349: log file name before loading.
 

--- a/doc/RELNOTES
+++ b/doc/RELNOTES
@@ -17,6 +17,7 @@ BUG FIXES:
 	- For #347: Also adjust verbosity of log message for remaining TCP
 	  connections.
 	- Merge #349: log file name before loading.
+	- Use MAKE variable rather than make command directly in Makefile.
 
 4.10.0
 ================


### PR DESCRIPTION
Calling `make` directly resulted in the wrong make being executed for simdzone. This fixes that.