### PR TITLE
contrib: add OpenRC service script, config file, and tmpfiles entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 /udb-inspect
 /xfr-inspect
 /contrib/nsd.openrc
+/contrib/nsd-tmpfiles.conf
 /dnstap/dnstap.pb-c.c
 /dnstap/dnstap.pb-c.h
 /dnstap/dnstap_config.h

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 /popen3_echo
 /udb-inspect
 /xfr-inspect
+/contrib/nsd.openrc
 /dnstap/dnstap.pb-c.c
 /dnstap/dnstap.pb-c.h
 /dnstap/dnstap_config.h

--- a/Makefile.in
+++ b/Makefile.in
@@ -78,7 +78,7 @@ EDIT		= $(SED) \
 			-e 's,@dnstap_socket_path\@,@opt_dnstap_socket_path@,g' \
 			-e 's,@user\@,$(user),g'
 
-TARGETS=nsd nsd-checkconf nsd-checkzone nsd-control nsd.conf.sample nsd-control-setup.sh contrib/nsd.openrc
+TARGETS=nsd nsd-checkconf nsd-checkzone nsd-control nsd.conf.sample nsd-control-setup.sh contrib/nsd.openrc contrib/nsd-tmpfiles.conf
 MANUALS=nsd.8 nsd-checkconf.8 nsd-checkzone.8 nsd-control.8 nsd.conf.5
 
 COMMON_OBJ=answer.o axfr.o ixfr.o ixfrcreate.o buffer.o configlexer.o configparser.o dname.o dns.o edns.o iterated_hash.o lookup3.o namedb.o nsec3.o options.o packet.o query.o rbtree.o radtree.o rdata.o region-allocator.o rrl.o siphash.o tsig.o tsig-openssl.o udb.o util.o bitset.o popen3.o proxy_protocol.o
@@ -125,6 +125,9 @@ nsd-control.8:	$(srcdir)/nsd-control.8.in config.h
 	$(EDIT) $(srcdir)/nsd-control.8.in > nsd-control.8
 
 contrib/nsd.openrc: contrib/nsd.openrc.in
+	$(EDIT) $< > $@
+
+contrib/nsd-tmpfiles.conf: contrib/nsd-tmpfiles.conf.in
 	$(EDIT) $< > $@
 
 install: all

--- a/Makefile.in
+++ b/Makefile.in
@@ -14,6 +14,7 @@ exec_prefix = @exec_prefix@
 sbindir	= @sbindir@
 mandir = @mandir@
 datarootdir = @datarootdir@
+runstatedir = @runstatedir@
 
 # NSD specific pathnames
 configdir = @configdir@
@@ -65,6 +66,7 @@ EDIT		= $(SED) \
 			-e 's,@configdir\@,$(configdir),g' \
 			-e 's,@zonesdir\@,$(zonesdir),g' \
 			-e 's,@chrootdir\@,$(chrootdir),g' \
+			-e 's,@runstatedir\@,$(runstatedir),g' \
 			-e 's,@pidfile\@,$(pidfile),g' \
 			-e 's,@logfile\@,$(logfile),g' \
 			-e 's,@xfrdir\@,$(xfrdir),g' \

--- a/Makefile.in
+++ b/Makefile.in
@@ -78,7 +78,7 @@ EDIT		= $(SED) \
 			-e 's,@dnstap_socket_path\@,@opt_dnstap_socket_path@,g' \
 			-e 's,@user\@,$(user),g'
 
-TARGETS=nsd nsd-checkconf nsd-checkzone nsd-control nsd.conf.sample nsd-control-setup.sh
+TARGETS=nsd nsd-checkconf nsd-checkzone nsd-control nsd.conf.sample nsd-control-setup.sh contrib/nsd.openrc
 MANUALS=nsd.8 nsd-checkconf.8 nsd-checkzone.8 nsd-control.8 nsd.conf.5
 
 COMMON_OBJ=answer.o axfr.o ixfr.o ixfrcreate.o buffer.o configlexer.o configparser.o dname.o dns.o edns.o iterated_hash.o lookup3.o namedb.o nsec3.o options.o packet.o query.o rbtree.o radtree.o rdata.o region-allocator.o rrl.o siphash.o tsig.o tsig-openssl.o udb.o util.o bitset.o popen3.o proxy_protocol.o
@@ -123,6 +123,9 @@ nsd-checkzone.8:	$(srcdir)/nsd-checkzone.8.in config.h
 nsd-control.8:	$(srcdir)/nsd-control.8.in config.h
 	rm -f nsd-control.8
 	$(EDIT) $(srcdir)/nsd-control.8.in > nsd-control.8
+
+contrib/nsd.openrc: contrib/nsd.openrc.in
+	$(EDIT) $< > $@
 
 install: all
 	$(INSTALL) -d $(DESTDIR)$(sbindir)

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,8 @@ dnl
 sinclude(acx_nlnetlabs.m4)
 sinclude(dnstap/dnstap.m4)
 
+# autoconf-2.70 is needed for @runstatedir@
+AC_PREREQ([2.70])
 AC_INIT([NSD],[4.10.1],[https://github.com/NLnetLabs/nsd/issues or nsd-bugs@nlnetlabs.nl])
 AC_CONFIG_HEADERS([config.h])
 

--- a/contrib/nsd-tmpfiles.conf.in
+++ b/contrib/nsd-tmpfiles.conf.in
@@ -1,0 +1,3 @@
+# Create a writable directory in case the user wants to
+# use a local control socket.
+d @runstatedir@/nsd 0750 @user@ @user@

--- a/contrib/nsd.openrc.conf
+++ b/contrib/nsd.openrc.conf
@@ -1,0 +1,2 @@
+# Extra command-line arguments to pass to the NSD daemon.
+#NSD_EXTRA_OPTS=""

--- a/contrib/nsd.openrc.in
+++ b/contrib/nsd.openrc.in
@@ -1,0 +1,71 @@
+#!/sbin/openrc-run
+
+description="The NLnet Labs Name Server Daemon (NSD)"
+extra_commands="configtest"
+extra_started_commands="reload"
+
+# For the config file, we use a combination of --with-configdir and
+# the service name instead of (say) the value passed to
+# --with-nsd_conf_file, because OpenRC supports running multiple
+# instances of the same daemon from one service script using symlinks.
+config_file="@configdir@/${RC_SVCNAME}.conf"
+
+checkconf="@sbindir@/nsd-checkconf"
+command="@sbindir@/nsd"
+
+# Run the daemon in the foreground and allow OpenRC to background it
+# and manage its PID file. This is the simplest way to ensure that a
+# PID file owned and writable only by the superuser is created outside
+# of e.g. the socket directory that must be writable by the nsd
+# user. It also happens to agree with what the nsd.service systemd
+# unit does. The PID file is named after the service name (and ignores
+# --with-pidfile) to support multiple instances running simultaneously.
+command_args="-c ${config_file} -d -P '' ${NSD_EXTRA_OPTS}"
+command_background=true
+pidfile="@runstatedir@/${RC_SVCNAME}.pid"
+required_files="${config_file}"
+
+depend() {
+	use logger
+}
+
+checkconfig() {
+	if ! "${checkconf}" "${config_file}" ; then
+		eerror "You have errors in your config file (${config_file})"
+		return $?
+	fi
+	return 0
+}
+
+configtest() {
+	ebegin "Checking ${RC_SVCNAME} configuration"
+	checkconfig
+	eend $?
+}
+
+start_pre() {
+	# If this isn't a restart, make sure that the configuration is
+	# usable before we try to start the daemon. Without this, the
+	# service will start successfully but then immediately crash.
+	# If this *is* a restart, then the stop_pre action will have
+	# already checked the config.
+	if [ "${RC_CMD}" != "restart" ] ; then
+		checkconfig || return $?
+	fi
+}
+
+stop_pre() {
+	# If this is a restart, check to make sure the user's config
+	# isn't busted before we stop the running daemon. If it's a
+	# regular "stop," however, then we shouldn't interfere.
+	if [ "${RC_CMD}" = "restart" ] ; then
+		checkconfig || return $?
+	fi
+}
+
+reload() {
+	checkconfig || return $?
+	ebegin "Reloading config and zone files"
+	start-stop-daemon --signal HUP --pidfile "${pidfile}"
+	eend $?
+}

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -325,11 +325,13 @@ remote-control:
 	# interfaces can be specified by IP address or interface name.
 	# with an interface name, all IP addresses associated with that
 	# interface are used.
-	# with an absolute path, a unix local named pipe is used for control
-	# (and key and cert files are not needed, use directory permissions).
 	# control-interface: 127.0.0.1
 	# control-interface: ::1
 	# control-interface: lo
+
+	# with an absolute path, a unix local named pipe is used for control
+	# (and key and cert files are not needed, use directory permissions).
+	# control-interface: @runstatedir@/nsd/nsd.sock
 
 	# port number for remote control operations (uses TLS over TCP).
 	# control-port: 8952


### PR DESCRIPTION
1. Add an OpenRC service script and config file under `contrib/`. The service script is integrated with the build system so that the correct paths are obtained from `./configure` and do not need to be hard-coded. (This requires >=autoconf-2.70.) Tested on Gentoo, but it should work on other distros that use OpenRC as well.

2. Add a tmpfiles entry under `contrib/` for both systemd and OpenRC. If installed, this will create at a boot a temporary "nsd" directory writable by the nsd user. This makes it easier to use a local control socket because the user no longer has to worry about creating the directory where the socket will live.

3. Tweak the default config to show an example of using a local socket in the tmpfiles location.