### PR TITLE
Fix Hurd build error due to log_err.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -116,7 +116,7 @@ task:
   build_script:
     - git submodule update --init
     - autoconf && autoheader
-    - (cd simdzone && autoconf)
+    - (cd simdzone && autoconf && autoheader)
     - libtoolize -c -i || glibtoolize -c -i
     - ./configure --enable-checking --disable-flto --with-ssl=${OPENSSL:-yes} --with-libevent=${LIBEVENT:-yes}
     - make -j 2

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,6 @@
+25 July 2025: Jeroen
+	- Merge #358 from @jas4711: Fix Hurd build error due to log_Err.
+
 23 July 2024: Jeroen
 	- Update simdzone.
 	- Tag for 4.10.1rc2.

--- a/doc/RELNOTES
+++ b/doc/RELNOTES
@@ -6,6 +6,7 @@ FEATURES:
 	- Merge #352 from orlitzky: contrib: add OpenRC service script, config
 	  file, and tmpfiles entry.
 	- Merge #337 from bilias: Mutual TLS-AUTH.
+
 BUG FIXES:
 	- Fix incorrect punctuation of log messages.
 	- Fix for #317, document more text on pidfile permissions.
@@ -26,6 +27,7 @@ BUG FIXES:
 	- Do not log ACL mismatch on followed CNAMEs.
 	- Fix link of xfr-inspect for libssl dependency.
 	- Initialize tls_auth_port and tls_auth_xfr_only options.
+	- Merge #358: Fix Hurd build error due to log_err.
 
 4.10.0
 ================

--- a/util.c
+++ b/util.c
@@ -1069,7 +1069,7 @@ int number_of_cpus(void)
  * with a linker error, we print an error when it is used */
 int set_cpu_affinity(cpuset_t *ATTR_UNUSED(set))
 {
-	log_err("sched_setaffinity: not available on this system");
+	log_msg(LOG_ERR, "sched_setaffinity: not available on this system");
 	return -1;
 }
 #elif defined(HAVE_SCHED_SETAFFINITY)


### PR DESCRIPTION
Build log at https://buildd.debian.org/status/fetch.php?pkg=nsd&arch=hurd-i386&ver=4.9.1-1&stamp=1712912870&raw=0 failing like this:

util.c: In function ‘set_cpu_affinity’:
util.c:1226:9: error: implicit declaration of function ‘log_err’ [-Werror=implicit-function-declaration]
 1226 |         log_err("sched_setaffinity: not available on this system");
      |         ^~~~~~~
cc1: some warnings being treated as errors