### PR TITLE
Implement fallback to ASN1_STRING_data

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -359,11 +359,11 @@ AC_DEFUN([CHECK_SSL], [
         ])
     if test x_$withval != x_no; then
         AC_MSG_CHECKING(for SSL)
-	if test -n "$withval"; then
-        	dnl look for openssl install with different version, eg.
-                dnl in /usr/include/openssl11/openssl/ssl.h
-                dnl and /usr/lib64/openssl11/libssl.so
-                dnl with the --with-ssl=/usr/include/openssl11
+        if test -n "$withval"; then
+            dnl look for openssl install with different version, eg.
+            dnl in /usr/include/openssl11/openssl/ssl.h
+            dnl and /usr/lib64/openssl11/libssl.so
+            dnl with the --with-ssl=/usr/include/openssl11
                 if test ! -f "$withval/include/openssl/ssl.h" -a -f "$withval/openssl/ssl.h"; then
                         ssldir="$withval"
                         found_ssl="yes"
@@ -383,7 +383,7 @@ AC_DEFUN([CHECK_SSL], [
                                 fi
                         fi
                 fi
-	fi
+            fi
         if test x_$withval = x_ -o x_$withval = x_yes; then
             withval="/usr/local/ssl /usr/lib/ssl /usr/ssl /usr/pkg /usr/sfw /usr/local /usr /usr/local/opt/openssl"
         fi
@@ -394,12 +394,12 @@ AC_DEFUN([CHECK_SSL], [
                 if test x_$ssldir != x_/usr; then
                     CPPFLAGS="$CPPFLAGS -I$ssldir/include";
                 fi
-		ssldir_include="$ssldir/include"
-		if test ! -d "$ssldir/lib" -a -d "$ssldir/lib64"; then
-			ssldir_lib="$ssldir/lib64"
-		else
-			ssldir_lib="$ssldir/lib"
-		fi
+                ssldir_include="$ssldir/include"
+                if test ! -d "$ssldir/lib" -a -d "$ssldir/lib64"; then
+                    ssldir_lib="$ssldir/lib64"
+                else
+                    ssldir_lib="$ssldir/lib"
+                fi
                 break;
             fi
         done
@@ -412,9 +412,9 @@ AC_DEFUN([CHECK_SSL], [
             if test x_$ssldir != x_/usr; then
                 LDFLAGS="$LDFLAGS -L$ssldir_lib";
             fi
-	    if test x_$ssldir = x_/usr/sfw; then
-		LDFLAGS="$LDFLAGS -R$ssldir_lib";
-	    fi
+            if test x_$ssldir = x_/usr/sfw; then
+                LDFLAGS="$LDFLAGS -R$ssldir_lib";
+            fi
         fi
         AC_SUBST(HAVE_SSL)
     fi
@@ -1048,7 +1048,7 @@ if test x$HAVE_SSL = x"yes"; then
 	SSL_LIBS="-lssl"
 	AC_SUBST(SSL_LIBS)
 	AC_CHECK_HEADERS([openssl/ssl.h openssl/err.h openssl/rand.h openssl/ocsp.h openssl/core_names.h openssl/x509v3.h],,, [AC_INCLUDES_DEFAULT])
-	AC_CHECK_FUNCS([HMAC_CTX_reset HMAC_CTX_new EVP_cleanup ERR_load_crypto_strings OPENSSL_init_crypto CRYPTO_memcmp EC_KEY_new_by_curve_name EVP_MAC_CTX_new EVP_MAC_CTX_set_params EVP_MAC_CTX_get_mac_size SHA1_Init])
+	AC_CHECK_FUNCS([HMAC_CTX_reset HMAC_CTX_new EVP_cleanup ERR_load_crypto_strings OPENSSL_init_crypto CRYPTO_memcmp EC_KEY_new_by_curve_name EVP_MAC_CTX_new EVP_MAC_CTX_set_params EVP_MAC_CTX_get_mac_size SHA1_Init ASN1_STRING_get0_data])
 	if test "$ac_cv_func_SHA1_Init" = "yes"; then
 		ACX_FUNC_DEPRECATED([SHA1_Init], [(void)SHA1_Init(NULL);], [
 #include <openssl/sha.h>

--- a/options.h
+++ b/options.h
@@ -565,7 +565,7 @@ int acl_addr_matches_host(struct acl_options* acl, struct acl_options* host);
 int acl_addr_matches(struct acl_options* acl, struct query* q);
 int acl_addr_matches_proxy(struct acl_options* acl, struct query* q);
 #ifdef HAVE_SSL
-int acl_tls_hostname_matches(SSL* ssl, const char* acl_cert_cn, char** cert_cn);
+int acl_tls_hostname_matches(SSL* ssl, const char* acl_cert_cn);
 #endif
 int acl_key_matches(struct acl_options* acl, struct query* q);
 int acl_addr_match_mask(uint32_t* a, uint32_t* b, uint32_t* mask, size_t sz);


### PR DESCRIPTION
The version used of OpenSSL used by the opencsw project is too old and does not offer `ASN1_STRING_get0_data`. Implement falling back to `ANS1_STRING_data` instead. Also fixes `sk_GENERAL_NAME_pop_free` not being called if the subject alternative name matched previously. Apart from that, I also removed duplication of the common name, I'm not sure it adds useful debugging info.