### PR TITLE
specify protocols used in NOTIFY

### DIFF
--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -844,7 +844,7 @@ symbols.
 .TP
 .B allow\-notify:\fR <ip\-spec> <key\-name | NOKEY | BLOCKED>
 Access control list. The listed (primary) address is allowed to
-send notifies to this (secondary) server. Notifies from unlisted or
+send notifies to this (secondary) server via UDP or TCP. Notifies from unlisted or
 specifically BLOCKED addresses are discarded. If NOKEY is given no
 TSIG signature is required.
 BLOCKED supersedes other entries, other entries are scanned for a match
@@ -896,7 +896,7 @@ If this option is 0, unlimited. Default value is 0.
 .TP
 .B notify:\fR <ip\-address> <key\-name | NOKEY>
 Access control list. The listed address (a secondary) is notified
-of updates to this zone. A port number can be added using a suffix of @number,
+of updates to this zone via UDP. A port number can be added using a suffix of @number,
 for example 1.2.3.4@5300. The specified key is used to sign the
 notify. Only on secondary configurations will NSD be able to detect
 zone updates (as it gets notified itself, or refreshes after a


### PR DESCRIPTION
add information on whether UDP and/or TCP are used in notify: and allow-notify: