### PR TITLE
Various fixes to the manpages `nsd-checkzone(8)` and `nsd.conf(5)`

### DIFF
--- a/nsd-checkzone.8.in
+++ b/nsd-checkzone.8.in
@@ -24,7 +24,8 @@ Print usage help information and exit.
 The name of the zone to check, eg. "example.com".
 .TP
 .I zonefile
-The file to read, eg. "zones/example.com.zone.signed".
+The file to read, eg. "zones/example.com.zone.signed". Use "-" to read
+from stdin.
 .TP
 .B \-p
 Print the zone contents to stdout if the zone is ok. This prints the

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -1370,7 +1370,7 @@ default
 .B NSD
 configuration file
 .SH "SEE ALSO"
-\fInsd\fR(8), \fInsd\-checkconf\fR(8), \fInsd\-control\fR(8)
+\fInsd\fR(8), \fInsd\-checkconf\fR(8), \fInsd\-checkzone\fR(8), \fInsd\-control\fR(8)
 .SH "AUTHORS"
 .B NSD
 was written by a combined team from NLnet Labs and RIPE NCC. Please see the

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -396,7 +396,8 @@ once per the number of seconds. The default is 1 second.
 This value specifies the verbosity level for (non\-debug) logging.
 Default is 0. 1 gives more information about incoming notifies and
 zone transfers. 2 lists soft warnings that are encountered. 3 prints
-more information.
+more information. Same as command-line option
+.BR \-V .
 .IP
 Verbosity 0 will print warnings and errors, and other events that are
 important to keep NSD running.

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -1094,7 +1094,7 @@ that have a missing or an invalid group property will be added using pattern
 .TP
 .B catalog\-producer\-zone:\fR <zone\-name>
 This option can only be used in a pattern. Adding a zone using
-"\fInsd\-control addzone <zone> <pattern>\fR with a <pattern> containing this
+"\fInsd\-control addzone <zone> <pattern>\fR" with a <pattern> containing this
 option, will cause a catalog member entry to be created in the catalog producer
 zone <zone\-name>.  <zone\-name> must exist and must be a valid catalog
 producer zone.

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -251,19 +251,16 @@ option
 .TP
 .B cpu\-affinity:\fR <number> <number> ...
 Overall CPU affinity for NSD server(s). Default is no affinity.
-.BR \-n .
 .TP
 .B server\-N\-cpu\-affinity:\fR <number>
 Bind NSD server specified by N to a specific core. Default is to have affinity
 set to every core specified in cpu\-affinity. This setting only takes effect
 if cpu\-affinity is enabled.
-.BR \-n
 .TP
 .B xfrd\-cpu\-affinity:\fR <number>
 Bind xfrd to a specific core. Default is to have affinity set to every core
 specified in cpu\-affinity. This setting only takes effect if cpu\-affinity is
 enabled.
-.BR \-n
 .TP
 .B tcp\-count:\fR <number>
 The maximum number of concurrent, active TCP connections by each server.

--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -555,7 +555,7 @@ openssl ocsp -no_nonce \\
    -CAfile /path/to/ca_and_any_intermediate.pem \\
    -issuer /path/to/direct_issuer.pem \\
    -cert /path/to/cert.pem \\
-   -url "$( openssl x509 -noout -text -in /path/to/cert.pem | grep 'OCSP - URI:' | cut -d: -f2,3 )"
+   -url "$( openssl x509 -noout -ocsp_uri -in /path/to/cert.pem )"
 .RE
 .TP
 .B tls\-port:\fR <number>


### PR DESCRIPTION
In `nsd-checkzone(8)`:

- Document that `nsd-checkzone(8)` can read zones from stdin (again) as per NLnetLabs/simdzone#205

In `nsd.conf(5)`:

- Remove bogus references to the `-n` command-line option
- Reference command-line option `-V` which corresponds to the `verbosity` setting
- Simplify the extraction of the OCSP responder URL in the example given at the `tls-service-ocsp` setting as any non-ancient `openssl x509` has a support for that
- Typo fix and reference to `nsd-checkzone(8)` in the "SEE ALSO" section as it is mentioned in the `create-ixfr` stanza