### PR TITLE
Update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NSD
 
-[![Cirrus Build Status](https://api.cirrus-ci.com/github/NLnetLabs/nsd.svg?branch=master)](https://cirrus-ci.com/github/NLnetLabs/nsd)
+[![GitHub Build Status](https://github.com/NLnetLabs/nsd/actions/workflows/build-test.yml/badge.svg?branch=master)](https://github.com/NLnetLabs/nsd/actions)
+[![Coverity Scan Status](https://scan.coverity.com/projects/18867/badge.svg)](https://scan.coverity.com/projects/nlnetlabs-nsd)
 [![Packaging status](https://repology.org/badge/tiny-repos/nsd.svg)](https://repology.org/project/nsd/versions)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1462/badge)](https://bestpractices.coreinfrastructure.org/projects/1462)
 [![Mastodon Follow](https://img.shields.io/mastodon/follow/109262826617293067?domain=https%3A%2F%2Ffosstodon.org&style=social)](https://fosstodon.org/@nlnetlabs)


### PR DESCRIPTION
What it says on the tin. Replaces the Cirrus CI badge with a GitHub Actions one and adds a Coverity Scan badge.