### PR TITLE
Point the user towards tcpdump for logging individual queries

### DIFF
--- a/doc/manual/running/logging.rst
+++ b/doc/manual/running/logging.rst
@@ -7,6 +7,11 @@ in order to keep NSD focused and minimise its complexity.
 It is better to leave logging and tracing to separate dedicated tools. Do note,
 however, that NSD can be compiled with support for DNSTAP (see ``nsd.conf(5)``).
 
+If some visibility on individual queries is required, consider running
+``tcpdump(1)`` on the server, using an appropriate filter rule to capture UDP
+and TCP packets to port 53. The tcpdump on most systems will decode the packets
+into readable requests and responses.
+
 The `CAIDA dnsstat tool <https://www.caida.org/catalog/software/dnsstat/>`_ can
 easily be configured and/or modified to suit local statistics requirements
 without any danger of affecting the name server itself. We have run ``dnsstat``


### PR DESCRIPTION
The lack of logging is explained, but appears to assume the user is interested in aggregate log. For simple debugging there is no equivalent to "log-queries" (or "log-replies") in unbound(8).

If the method described in [*] is the recommended one then it should be documented as such and also saves time.

It's not clear to me what the difference between doc/*.rst and doc/README is. This patch assumes README is already out of date.

[*] https://lists.nlnetlabs.nl/pipermail/nsd-users/2020-June/002880.html