### PR TITLE
Fix the path to use doc/manual/ 

### DIFF
--- a/doc/manual/conf.py.in
+++ b/doc/manual/conf.py.in
@@ -157,7 +157,7 @@ html_context = {
         'rtd_language': language,
         'canonical_url': html_baseurl,
 
-        'conf_py_path': "/source/",
+        'conf_py_path': "/doc/manual/",
 
         'github_user': "NLnetLabs",
         'github_repo': "nsd",


### PR DESCRIPTION
Fix the GitHub Edit link towards the git repository.

Fixes: #393

For Unbound see PR: https://github.com/NLnetLabs/unbound-manual/pull/53