### PR TITLE
draft-fregly-dnsop-slh-dsa-mtl-dnssec support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -988,6 +988,24 @@ case "$enable_log_role" in
                 ;;
 esac
 
+AC_ARG_ENABLE(draft-slh-dsa-mtl, AS_HELP_STRING([--enable-draft-slh-dsa-mtl[=optcode]],[Enables responding with SLH-DSA-MTL signatures as described in draft-fregly-dnsop-slh-dsa-mtl-dnssec. Opcode defaults to 65050]))
+mtl_mode_full_code=""
+case "$enable_draft_slh_dsa_mtl" in
+	""|no)
+		;;
+	yes)
+		AC_DEFINE_UNQUOTED([MTL_MODE_FULL_CODE], [65050], [Define this to enable answering with the full SLH-DSA-MTL signatures when queried with this EDNS opcode])
+		;;
+	*)
+		AC_DEFINE_UNQUOTED([MTL_MODE_FULL_CODE], [$enable_draft_slh_dsa_mtl], [Define this to enable answering with the full SLH-DSA-MTL signatures when queried with this EDNS opcode])
+		;;
+esac
+mtl_dnssec_alg=50
+AC_ARG_WITH([slh-dsa-mtl-dnssec-alg],
+	AS_HELP_STRING([--with-slh-dsa-mtl-dnssec-alg=alg],[The algorithm used for SLH-DSA-MTL keys and signatures. Only relevant with draft-slh-dsa-mtl enabled. Defaults to 50.]),
+	[mtl_dnssec_alg=$withval])
+AC_SUBST(mtl_dnssec_alg)
+AC_DEFINE_UNQUOTED(MTL_DNSSEC_ALG, [$mtl_dnssec_alg], [The algorithm used for SLH-DSA-MTL keys and signatures. Default 50.])
 
 AC_ARG_ENABLE(memclean, AS_HELP_STRING([--enable-memclean],[Cleanup memory (at exit) for eg. valgrind, memcheck]))
 if test "$enable_memclean" = "yes"; then AC_DEFINE_UNQUOTED([MEMCLEAN], [1], [Define this to cleanup memory at exit (eg. for valgrind, etc.)])

--- a/edns.c
+++ b/edns.c
@@ -70,6 +70,9 @@ edns_init_record(edns_record_type *edns)
 	edns->opt_reserved_space = 0;
 	edns->dnssec_ok = 0;
 	edns->nsid = 0;
+#ifdef MTL_MODE_FULL_CODE
+	edns->mtl_mode_full = 0;
+#endif
 	edns->cookie_status = COOKIE_NOT_PRESENT;
 	edns->cookie_len = 0;
 	edns->ede = -1; /* -1 means no Extended DNS Error */
@@ -116,6 +119,11 @@ edns_handle_option(uint16_t optcode, uint16_t optlen, buffer_type* packet,
 			buffer_skip(packet, optlen);
 		}
 		break;
+#ifdef MTL_MODE_FULL_CODE
+	case MTL_MODE_FULL_CODE:
+		edns->mtl_mode_full = 1;
+		break;
+#endif
 	default:
 		buffer_skip(packet, optlen);
 		break;

--- a/edns.h
+++ b/edns.h
@@ -65,6 +65,9 @@ struct edns_record
 	int                ede; /* RFC 8914 - Extended DNS Errors */
 	char*              ede_text; /* RFC 8914 - Extended DNS Errors text*/
 	uint16_t           ede_text_len;
+#ifdef MTL_MODE_FULL_CODE
+	int                mtl_mode_full;
+#endif
 };
 typedef struct edns_record edns_record_type;
 

--- a/namedb.c
+++ b/namedb.c
@@ -656,6 +656,28 @@ rr_rrsig_type_covered(rr_type* rr)
 	return ntohs(* (uint16_t *) rdata_atom_data(rr->rdatas[0]));
 }
 
+#ifdef MTL_MODE_FULL_CODE
+uint8_t
+rr_rrsig_algorithm(rr_type* rr)
+{
+	assert(rr->type == TYPE_RRSIG);
+	assert(rr->rdata_count > 1);
+	assert(rdata_atom_size(rr->rdatas[1]) == sizeof(uint8_t));
+
+	return *(uint8_t*)rdata_atom_data(rr->rdatas[1]);
+}
+
+uint16_t
+rr_rrsig_keytag(rr_type* rr)
+{
+	assert(rr->type == TYPE_RRSIG);
+	assert(rr->rdata_count > 6);
+	assert(rdata_atom_size(rr->rdatas[6]) == sizeof(uint16_t));
+
+	return *(uint16_t*)rdata_atom_data(rr->rdatas[6]);
+}
+#endif
+
 zone_type *
 namedb_find_zone(namedb_type* db, const dname_type* dname)
 {

--- a/namedb.h
+++ b/namedb.h
@@ -333,6 +333,18 @@ static inline const char* domain_to_string_buf(domain_type* domain, char *buf)
  */
 uint16_t rr_rrsig_type_covered(rr_type* rr);
 
+#ifdef MTL_MODE_FULL_CODE
+/*
+ * The algorithm field of the specified RRSIG RR
+ */
+uint8_t rr_rrsig_algorithm(rr_type* rr);
+
+/*
+ * The keytag field of the specified RRSIG RR
+ */
+uint16_t rr_rrsig_keytag(rr_type* rr);
+#endif
+
 struct namedb
 {
 	region_type*       region;

--- a/zonec.c
+++ b/zonec.c
@@ -493,7 +493,12 @@ apex_rrset_checks(namedb_type* db, rrset_type* rrset, domain_type* domain)
 		zone->ns_rrset = rrset;
 	} else if (rrset_rrtype(rrset) == TYPE_RRSIG) {
 		for (i = 0; i < rrset->rr_count; ++i) {
-			if(rr_rrsig_type_covered(&rrset->rrs[i])==TYPE_DNSKEY){
+			if(rr_rrsig_type_covered(&rrset->rrs[i])==TYPE_DNSKEY
+#ifdef MTL_MODE_FULL_CODE
+			|| (rr_rrsig_type_covered(&rrset->rrs[i])==TYPE_SOA &&
+			    rr_rrsig_algorithm(&rrset->rrs[i])==MTL_DNSSEC_ALG)
+#endif
+			){
 				zone->is_secure = 1;
 				break;
 			}


### PR DESCRIPTION
Enable with `--enable-draft-slh-dsa-mtl[=optcode]` to configure, where the EDNS opcode defaults to 65050. The algorithm number can be chosen with `--with-slh-dsa-mtl-dnssec-alg=alg` and defaults to 50.