### PR TITLE
Improve build from source section

### DIFF
--- a/doc/manual/conf.py.in
+++ b/doc/manual/conf.py.in
@@ -63,7 +63,7 @@ extensions = [
     'sphinx.ext.autosectionlabel',
     'notfound.extension',
     'sphinxcontrib.jquery',
-    'sphinx_rtd_theme',    
+    'sphinx_rtd_theme',
     'sphinx_substitution_extensions',
 ]
 

--- a/doc/manual/conf.py.in
+++ b/doc/manual/conf.py.in
@@ -63,7 +63,8 @@ extensions = [
     'sphinx.ext.autosectionlabel',
     'notfound.extension',
     'sphinxcontrib.jquery',
-    'sphinx_rtd_theme',
+    'sphinx_rtd_theme',    
+    'sphinx_substitution_extensions',
 ]
 
 intersphinx_mapping = {

--- a/doc/manual/installation.rst
+++ b/doc/manual/installation.rst
@@ -42,18 +42,19 @@ configured<configuration>`.
 Building from source
 ====================
 
-Ubuntu 20.04 LTS
-****************
+Ubuntu
+******
 
 First of all, we need our copy of the NSD code. `On our website
 <https://nlnetlabs.nl/projects/nsd/about/>`_ you can find the latest version
-and the changelog. In this example we'll use version 4.10.1. Please note
+and the changelog. In this example we'll use version |version|. Please note
 that this may not be the latest version currently.
 
 .. code-block:: bash
+  :substitutions:
 
-    wget https://nlnetlabs.nl/downloads/nsd/nsd-4.10.1.tar.gz
-    tar xzf nsd-4.10.1.tar.gz
+    wget https://nlnetlabs.nl/downloads/nsd/nsd-|version|.tar.gz
+    tar xzf nsd-|version|.tar.gz
 
 
 We'll need some tools, such as a compiler and the :command:`make` program.

--- a/doc/manual/installation.rst
+++ b/doc/manual/installation.rst
@@ -99,7 +99,7 @@ NSD using :command:`make`; compilation might take a while.
 
 .. code-block:: bash
 
-    make
+    make -j4
 
 After successfully compiling, we can install NSD to make it available for
 the machine.

--- a/doc/manual/requirements.txt
+++ b/doc/manual/requirements.txt
@@ -1,8 +1,8 @@
-sphinx==5.0.2
+Sphinx==5.0.2
 sphinx-version-warning==1.1.2
 sphinx-tabs==3.4.4
 sphinx-copybutton==0.5.2
 sphinx-rtd-theme
 sphinx-notfound-page
 requests
-Sphinx-Substitution-Extensions
+sphinx-substitution-extensions

--- a/doc/manual/requirements.txt
+++ b/doc/manual/requirements.txt
@@ -5,3 +5,4 @@ sphinx-copybutton==0.5.2
 sphinx-rtd-theme
 sphinx-notfound-page
 requests
+Sphinx-Substitution-Extensions


### PR DESCRIPTION
- Add `Sphinx-Substitution-Extensions` to pypi requirements: https://pypi.org/project/sphinx-substitution-extensions/
- Use Sphinix extension for code blocks: `sphinx_substitution_extensions`
- Rename Ubuntu 20.04 LTS to just Ubuntu
- Use substitution for the `version` number in both the text as well as the code block

---

Should we also try to upgrade [Sphinx](https://pypi.org/project/Sphinx/) to v8.1.3 next?