### PR TITLE
Treat a mismatch in RRset TTLs as a warning

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -22,6 +22,9 @@
 	- Many thanks to Melroy van den Berg for the documentation improvements
 	  and fixes in PRs #391, #394, #395 and #404
 
+28 October 2024: Jeroen
+	- Fix #396: Treat a mismatch in RRset TTLs as a warning.
+
 24 October 2024: Wouter
 	- Fix #392: Inconsistent documentation about control-interface.
 	- Merge #395: Explain the zonefile example better.

--- a/doc/RELNOTES
+++ b/doc/RELNOTES
@@ -29,6 +29,7 @@ BUG FIXES:
 	- Merge #395: Explain zonefile example better
 	- Merge #394: Fix doc path (fixes "Edit on GitHub" button in the docs)
 	- Fix Makefile for parallel build failure around bison rule.
+	- Treat a mismatch in RRset TTLs as a warning.
 
 4.10.1
 ================

--- a/zonec.c
+++ b/zonec.c
@@ -267,7 +267,7 @@ int32_t zonec_accept(
 	} else {
 		struct rr *rrs;
 		if (type != TYPE_RRSIG && ttl != rrset->rrs[0].ttl) {
-			zone_log(parser, priority, "%s TTL %"PRIu32" does not match TTL %u of %s RRset",
+			zone_log(parser, ZONE_WARNING, "%s TTL %"PRIu32" does not match TTL %u of %s RRset",
 				domain_to_string(domain), ttl, rrset->rrs[0].ttl,
 					rrtype_to_string(type));
 		}


### PR DESCRIPTION
Fixes #396.