### PR TITLE
Fix the docs build! + Remove unsupported options from Sphinx config + Update deps + add rst_prolog

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -4,6 +4,7 @@
 	- Merge #391: Update Copyright lines in help output
 	- Merge #395: Explain zonefile example better
 	- Merge #394: Fix doc path (fixes "Edit on GitHub" button in the docs)
+	- Many thanks to Melroy van den Berg for the documentation improvements and fixes in PRs #391, #394, #395 and #404
 
 24 October 2024: Wouter
 	- Fix #392: Inconsistent documentation about control-interface.

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,4 @@
-28 October 2024: Jeroen
+28 October 2024: Melroy
 	- Merge #404: Introducing Sphinx substitution in code blocks.
 	  As well as other fixes with Sphinx build.
 	- Merge #391: Update Copyright lines in help output

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,4 @@
-28 October 2024: Melroy
+28 October 2024: Jeroen
 	- Merge #404: Introducing Sphinx substitution in code blocks.
 	  As well as other fixes with Sphinx build.
 	- Merge #391: Update Copyright lines in help output

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,10 @@
+28 October 2024: Melroy
+	- Merge #404: Introducing Sphinx substitution in code blocks.
+	  As well as other fixes with Sphinx build.
+	- Update Copyright lines in help output
+	- Merge #395: Explain zonefile example better
+	- Merge #394: Fix doc path (fixes "Edit on GitHub" button in the docs)
+
 24 October 2024: Wouter
 	- Fix #392: Inconsistent documentation about control-interface.
 	- Merge #395: Explain the zonefile example better.

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,7 +1,7 @@
-28 October 2024: Melroy
+28 October 2024: Jeroen
 	- Merge #404: Introducing Sphinx substitution in code blocks.
 	  As well as other fixes with Sphinx build.
-	- Update Copyright lines in help output
+	- Merge #391: Update Copyright lines in help output
 	- Merge #395: Explain zonefile example better
 	- Merge #394: Fix doc path (fixes "Edit on GitHub" button in the docs)
 

--- a/doc/RELNOTES
+++ b/doc/RELNOTES
@@ -23,6 +23,11 @@ BUG FIXES:
 	- Merge #395: Explain the zonefile example better.
 	- Merge #394: Fix the path to use doc/manual/.
 	- Fix analyzer issue in do_print_cookie_secrets to check for failure.
+	- Merge #404: Introducing Sphinx substitution in code blocks.
+	  As well as other fixes with Sphinx build.
+	- Update Copyright lines in help output
+	- Merge #395: Explain zonefile example better
+	- Merge #394: Fix doc path (fixes "Edit on GitHub" button in the docs)
 
 4.10.1
 ================

--- a/doc/manual/conf.py.in
+++ b/doc/manual/conf.py.in
@@ -295,4 +295,6 @@ rst_epilog = ".. |pidfile| replace:: @pidfile@\n" \
              ".. |configfile| replace:: @nsdconfigfile@\n" \
              ".. |logfile| replace:: @logfile@\n" \
              ".. |xfrdfile| replace:: @xfrdfile@\n" \
-             ".. |zonelistfile| replace:: @zonelistfile@\n"
+             ".. |zonelistfile| replace:: @zonelistfile@\n" \
+             ".. |version| replace:: @version@"
+

--- a/doc/manual/conf.py.in
+++ b/doc/manual/conf.py.in
@@ -300,4 +300,4 @@ rst_epilog = ".. |pidfile| replace:: @pidfile@\n" \
 
 # -- Options for substitution extension --------------------------------------
 
-rst_prolog = ".. |version| replace:: {version}".format(version = version)
+rst_prolog = ".. |version| replace:: @version@"

--- a/doc/manual/conf.py.in
+++ b/doc/manual/conf.py.in
@@ -115,7 +115,6 @@ html_logo = 'resources/nsd-duotone-white.png'
 html_favicon = 'resources/favicon.ico'
 html_theme_options = {
     'logo_only': True,
-    'display_version': True,
 }
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/doc/manual/conf.py.in
+++ b/doc/manual/conf.py.in
@@ -295,6 +295,9 @@ rst_epilog = ".. |pidfile| replace:: @pidfile@\n" \
              ".. |configfile| replace:: @nsdconfigfile@\n" \
              ".. |logfile| replace:: @logfile@\n" \
              ".. |xfrdfile| replace:: @xfrdfile@\n" \
-             ".. |zonelistfile| replace:: @zonelistfile@\n" \
-             ".. |version| replace:: @version@"
+             ".. |zonelistfile| replace:: @zonelistfile@\n"
 
+
+# -- Options for substitution extension --------------------------------------
+
+rst_prolog = ".. |version| replace:: {version}".format(version = version)

--- a/doc/manual/conf.py.in
+++ b/doc/manual/conf.py.in
@@ -111,7 +111,6 @@ pygments_style = 'sphinx'
 # a list of builtin themes.
 #
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_logo = 'resources/nsd-duotone-white.png'
 html_favicon = 'resources/favicon.ico'
 html_theme_options = {

--- a/doc/manual/installation.rst
+++ b/doc/manual/installation.rst
@@ -51,7 +51,7 @@ and the changelog. In this example we'll use version |version|. Please note
 that this may not be the latest version currently.
 
 .. code-block:: bash
-  :substitutions:
+   :substitutions:
 
     wget https://nlnetlabs.nl/downloads/nsd/nsd-|version|.tar.gz
     tar xzf nsd-|version|.tar.gz

--- a/doc/manual/requirements.txt
+++ b/doc/manual/requirements.txt
@@ -5,4 +5,4 @@ sphinx-copybutton==0.5.2
 sphinx-rtd-theme
 sphinx-notfound-page
 requests
-sphinx-substitution-extensions
+sphinx-substitution-extensions==2024.10.17

--- a/doc/manual/requirements.txt
+++ b/doc/manual/requirements.txt
@@ -1,6 +1,6 @@
-Sphinx==7.2
+Sphinx==8.1.3
 sphinx-version-warning==1.1.2
-sphinx-tabs==3.4.4
+sphinx-tabs==3.4.7
 sphinx-copybutton==0.5.2
 sphinx-rtd-theme
 sphinx-notfound-page


### PR DESCRIPTION
@k0ekk0ek  Problem found! 

- I was missing the following config in the `conf.py.in` file:

  ```py
  rst_prolog = ".. |version| replace:: @version@"
  ```
  Output is now correct:
  ![image](https://github.com/user-attachments/assets/6bf18c03-480e-40f4-8dec-e4ef1b309b8f)


- Updated directly to the latest version of Sphinx (v8).
   - Also updated  sphinx-tabs, etc.
- I also explicitly pinned the version of `sphinx-substitution-extensions`, since it was installing 2022 for some reason (instead of 2024)
- Extend RELNOTES & ChangeLog

---

Plus I saw some warnings, so hence this PR to fix those as well:

- Remove unsupported theme option `display_version` , see: https://github.com/readthedocs/sphinx_rtd_theme/issues/1623#issuecomment-2441298351
- Remove `html_theme_path`, this is not required anymore. See: https://sphinx-rtd-theme.readthedocs.io/en/latest/changelog.html


Original build output:

```
....
mandoc -T html -O fragment nsd-control.8 > doc/manual/manpages/nsd-control.8.html
sed -i '/<table class="\(head\|foot\)">/,/<\/table>/ d' doc/manual/manpages/nsd-control.8.html
sphinx-build -M html ./doc/manual doc/manual -N -q
WARNING: Calling get_html_theme_path is deprecated. If you are calling it to define html_theme_path, you are safe to remove that code.
WARNING: unsupported theme option 'display_version' given
/media/melroy/Data/Projects/nsd/doc/manual/catalog-zones.rst:46: WARNING: unknown document: 'running/xot'
/media/melroy/Data/Projects/nsd/doc/manual/configuration.rst:15: WARNING: unknown option: '-c'
/media/melroy/Data/Projects/nsd/doc/manual/configuration.rst:214: WARNING: unknown option: '-c'
/media/melroy/Data/Projects/nsd/doc/manual/installation.rst:118: WARNING: unknown option: '-V'
/media/melroy/Data/Projects/nsd/doc/manual/installation.rst:130: WARNING: unknown option: '-d'
/media/melroy/Data/Projects/nsd/doc/manual/installation.rst:130: WARNING: unknown option: '-V'
/media/melroy/Data/Projects/nsd/doc/manual/running/interfaces.rst:4: WARNING: unknown option: '-4'
/media/melroy/Data/Projects/nsd/doc/manual/running/interfaces.rst:4: WARNING: unknown option: '-6'
/media/melroy/Data/Projects/nsd/doc/manual/running/interfaces.rst:9: WARNING: unknown option: '-a'
```