### PR TITLE
ohttp and tls-supported-groups SvcParam support

### DIFF
--- a/dns.h
+++ b/dns.h
@@ -141,9 +141,9 @@ typedef enum nsd_rc nsd_rc_type;
 #define TYPE_CDNSKEY	60	/* RFC 7344 */
 #define TYPE_OPENPGPKEY 61	/* RFC 7929 */
 #define TYPE_CSYNC	62	/* RFC 7477 */
-#define TYPE_ZONEMD	63	/* draft-ietf-dnsop-dns-zone-digest */
-#define TYPE_SVCB	64	/* draft-ietf-dnsop-svcb-https-03 */
-#define TYPE_HTTPS	65	/* draft-ietf-dnsop-svcb-https-03 */
+#define TYPE_ZONEMD	63	/* RFC 8976 */
+#define TYPE_SVCB	64	/* RFC 9460 */
+#define TYPE_HTTPS	65	/* RFC 9460 */
 
 #define TYPE_SPF        99      /* RFC 4408 */
 
@@ -172,10 +172,12 @@ typedef enum nsd_rc nsd_rc_type;
 #define SVCB_KEY_NO_DEFAULT_ALPN	2
 #define SVCB_KEY_PORT			3
 #define SVCB_KEY_IPV4HINT		4
-#define SVCB_KEY_ECH		5
+#define SVCB_KEY_ECH			5
 #define SVCB_KEY_IPV6HINT		6
 #define SVCB_KEY_DOHPATH		7
-#define SVCPARAMKEY_COUNT 8
+#define SVCB_KEY_OHTTP			8
+#define SVCB_KEY_TLS_SUPPORTED_GROUPS	9
+#define SVCPARAMKEY_COUNT 10
 
 #define MAXLABELLEN	63
 #define MAXDOMAINLEN	255

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,6 @@
+12 November 2024: Willem
+	- Merge #406: ohttp and tls-supported-groups SvcParam support
+
 7 November 2024: Willem
 	- Merge #398: RFC 9660 The DNS Zone Version (ZONEVERSION) Option
 

--- a/rdata.c
+++ b/rdata.c
@@ -812,7 +812,7 @@ rdata_svcparam_tls_supported_groups_to_string(buffer_type *output,
 {
 	assert(val_len > 0); /* Guaranteed by rdata_svcparam_to_string */
 
-	if ((val_len % sizeof(uint16_t)) == 0)
+	if ((val_len % sizeof(uint16_t)) == 1)
 		return 0; /* A series of uint16_t is an even number of bytes */
 
 	buffer_printf(output, "=%d", (int)ntohs(*data++));

--- a/tpkg/svcb.tdir/svcb.failure-cases-24
+++ b/tpkg/svcb.tdir/svcb.failure-cases-24
@@ -1,0 +1,10 @@
+$ORIGIN failure-cases.
+$TTL 3600
+
+@       SOA     primary admin 0 0 0 0 0
+
+; From RFC9540 Section 4:                                                      
+;   Both the presentation and wire-format values for the "ohttp" parameter     
+;   MUST be empty. 
+
+ohttp-f1 HTTPS 1 . ( alpn=h2 ohttp=hopsa )

--- a/tpkg/svcb.tdir/svcb.failure-cases-25
+++ b/tpkg/svcb.tdir/svcb.failure-cases-25
@@ -1,0 +1,10 @@
+$ORIGIN failure-cases.
+$TTL 3600
+
+@       SOA     primary admin 0 0 0 0 0
+
+; From draft-ietf-tls-key-share-prediction-01 Section 3.1:
+;   An empty list of values is invalid
+tsg-f1	7200	IN	SVCB 3 server.example.net. (
+	port="8004" tls-supported-groups )
+

--- a/tpkg/svcb.tdir/svcb.failure-cases-26
+++ b/tpkg/svcb.tdir/svcb.failure-cases-26
@@ -1,0 +1,10 @@
+$ORIGIN failure-cases.
+$TTL 3600
+
+@       SOA     primary admin 0 0 0 0 0
+
+; From draft-ietf-tls-key-share-prediction-01 Section 3.1:
+;   An list containing duplicates is invalid
+tsg-f1	7200	IN	SVCB 3 server.example.net. (
+	port="8004" tls-supported-groups=29,23,29 )
+

--- a/tpkg/svcb.tdir/svcb.test
+++ b/tpkg/svcb.tdir/svcb.test
@@ -184,6 +184,23 @@ then
 	echo "Incorrectly succeeded"
 	exit 1
 
+elif $PRE/nsd-checkzone failure-cases svcb.failure-cases-24
+then
+	echo "Failure case 24: values for the ohttp parameter MUST be empty"
+	echo "Incorrectly succeeded"
+	exit 1
+
+elif $PRE/nsd-checkzone failure-cases svcb.failure-cases-25
+then
+	echo "Failure case 25: An empty list of tls-supported-groups values is invalid"
+	echo "Incorrectly succeeded"
+	exit 1
+
+elif $PRE/nsd-checkzone failure-cases svcb.failure-cases-26
+then
+	echo "Failure case 26: A tls-supported-groups list containing duplicates is invalid"
+	echo "Incorrectly succeeded"
+	exit 1
 else
 	echo "All failure cases test successfully"
 fi

--- a/tpkg/svcb.tdir/svcb.test-vectors-pf.zone
+++ b/tpkg/svcb.tdir/svcb.test-vectors-pf.zone
@@ -90,3 +90,9 @@ v18	HTTPS	16 foo.example.org. (alpn=h2,h3-19 mandatory=ipv4hint,alpn
 v19	HTTPS	16 foo.example.org. alpn="f\\\\oo\\,bar,h2"
 v20	HTTPS	16 foo.example.org. alpn=f\\\092oo\092,bar,h2
 
+ohttp-s1	HTTPS	1 . ( alpn=h2 ohttp )
+ohttp-s2	HTTPS	1 . ( mandatory=ohttp ohttp )
+ohttp-s3 	SVCB	1 doh.example.net. ( alpn=h2 dohpath=/dns-query{?dns} ohttp )
+tsg-s1	7200	IN	SVCB	3 server.example.net. (
+	port="8004" tls-supported-groups=29,23 )
+

--- a/tpkg/svcb.tdir/svcb.test-vectors-wf.zone
+++ b/tpkg/svcb.tdir/svcb.test-vectors-wf.zone
@@ -230,3 +230,29 @@ v20	HTTPS	\# 35 (
 68 32                                              ; alpn value
 )
 
+ohttp-s1	HTTPS	\# 14 (
+00 01                ; priority
+00                   ; target
+00 01 00 03 02 68 32 ; alpn=h2
+00 08 00 00          ; ohttp
+)
+ohttp-s2	HTTPS	\# 13 (
+00 01                ; priority
+00                   ; target
+00 00 00 02 00 08    ; mandatory=ohttp                      
+00 08 00 00          ; ohttp
+)
+ohttp-s3	SVCB	\# 50 (
+00 01                                                       ; priority
+03 64 6f 68 07 65 78 61 6d 70 6c 65 03 6e 65 74 00          ; target
+00 01 00 03 02 68 32                                        ; alpn=h2
+00 07 00 10 2f 64 6e 73 2d 71 75 65 72 79 7b 3f 64 6e 73 7d ; dohpath=/dns-query{?dns}
+00 08 00 00                                                 ; ohttp
+)
+tsg-s1	7200	IN	SVCB	\# 36 (
+00 03                                                       ; priority
+06 73 65 72 76 65 72 07 65 78 61 6d 70 6c 65 03 6e 65 74 00 ; target
+00 03 00 02 1f 44                                           ; port="8004"
+00 09 00 04 00 1d 00 17                                     ; tls-supported-groups=2923
+)
+


### PR DESCRIPTION
Currently includes simdzone from the `svcb-tls-supported-groups` branch. I'll commit chaning that to `main` once that has been approved and merged.