### PR TITLE
Tweaking logging verbosity levels

### DIFF
--- a/dbcreate.c
+++ b/dbcreate.c
@@ -256,6 +256,8 @@ namedb_write_zonefile(struct nsd* nsd, struct zone_options* zopt)
 			return;
 		}
 		zone->is_changed = 0;
+		VERBOSITY(3, (LOG_INFO, "zone %s written to file %s",
+			zone->opts->name, zfile));
 		/* fetch the mtime of the just created zonefile so we
 		 * do not waste effort reading it back in */
 		if(!file_get_mtime(zfile, &mtime, &notexist)) {

--- a/xfrd-tcp.c
+++ b/xfrd-tcp.c
@@ -1018,6 +1018,9 @@ xfrd_tcp_setup_write_packet(struct xfrd_tcp_pipeline* tp, xfrd_zone_type* zone)
 		DEBUG(DEBUG_XFRD,1, (LOG_INFO, "request full zone transfer "
 						"(AXFR) for %s to %s",
 			zone->apex_str, zone->master->ip_address_spec));
+		VERBOSITY(3, (LOG_INFO, "request full zone transfer "
+						"(AXFR) for %s to %s",
+			zone->apex_str, zone->master->ip_address_spec));
 
 		xfrd_setup_packet(tcp->packet, TYPE_AXFR, CLASS_IN, zone->apex,
 			zone->query_id, NULL);
@@ -1025,6 +1028,9 @@ xfrd_tcp_setup_write_packet(struct xfrd_tcp_pipeline* tp, xfrd_zone_type* zone)
 	} else {
 		int apex_compress = 0;
 		DEBUG(DEBUG_XFRD,1, (LOG_INFO, "request incremental zone "
+						"transfer (IXFR) for %s to %s",
+			zone->apex_str, zone->master->ip_address_spec));
+		VERBOSITY(3, (LOG_INFO, "request incremental zone "
 						"transfer (IXFR) for %s to %s",
 			zone->apex_str, zone->master->ip_address_spec));
 

--- a/xfrd.c
+++ b/xfrd.c
@@ -2468,10 +2468,20 @@ xfrd_handle_received_xfr_packet(xfrd_zone_type* zone, buffer_type* packet)
 		zone->latest_xfr->msg_seq_nr,
 		buffer_begin(packet), buffer_limit(packet), xfrd->nsd,
 		zone->latest_xfr->xfrfilenumber);
-	VERBOSITY(3, (LOG_INFO,
-		"xfrd: zone %s written received XFR packet from %s with serial %u to "
-		"disk", zone->apex_str, zone->master->ip_address_spec,
-		(int)zone->latest_xfr->msg_new_serial));
+
+	if(verbosity < 4 || zone->latest_xfr->msg_seq_nr == 0)
+		; /* pass */
+
+	else if((verbosity >= 6)
+	     || (verbosity >= 5 && zone->latest_xfr->msg_seq_nr %  1000 == 0)
+	     || (verbosity >= 4 && zone->latest_xfr->msg_seq_nr % 10000 == 0)) {
+		VERBOSITY(4, (LOG_INFO,
+			"xfrd: zone %s written received XFR packet %u from %s "
+			"with serial %u to disk", zone->apex_str,
+			zone->latest_xfr->msg_seq_nr,
+			zone->master->ip_address_spec,
+			(int)zone->latest_xfr->msg_new_serial));
+	}
 	zone->latest_xfr->msg_seq_nr++;
 
 	xfrfile_size = xfrd_get_xfrfile_size(


### PR DESCRIPTION
So we not only see when a transfer ends (level 1), but also when it started (at verbosity level 3) And we do not only see when a zone write started (level 1), but also when it ends (with verbosity level 3).

Furthermore, you now need at least verbosity 4 to see confirmation of received XFR packets, with level 4 logging every 10000th packet, level 5 logging every 1000th packet and only level 6 logging every XFR packet (as level 3 did before)