### PR TITLE
set persist-credentials: false per zizmor suggestion

### DIFF
--- a/.github/workflows/analysis_ports.yml
+++ b/.github/workflows/analysis_ports.yml
@@ -51,6 +51,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          persist-credentials: false
       - name: cross-platform-action on ${{ matrix.cross_platform_os }} ${{ matrix.cross_platform_version }}
         if: ${{ matrix.with_cross_platform_action == 'yes' }}
         uses: cross-platform-actions/action@v0.25.0

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          persist-credentials: false
       - name: 'Workaround for actions/runner-images#9491'
         if: runner.os == 'Linux'
         run: sudo sysctl vm.mmap_rnd_bits=28

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          persist-credentials: false
       - id: install_packages
         shell: bash
         run: |


### PR DESCRIPTION
I don't think we currently have anything in CI that needs the (readonly) checkout credentials persisted to .git/config during the run.