### PR TITLE
old-main can quit before informing reload

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,8 @@
+7 January 2025: Willem
+	- Fix #421: old-main can quit before the reload process received        
+	  from old-main that it is done on the reload_listener pipe.                    
+	  Thanks Otto Retter.
+
 3 January 2025: Willem
 	- Fix #414: XoT interoperability with BIND and Knot
 

--- a/doc/RELNOTES
+++ b/doc/RELNOTES
@@ -5,6 +5,9 @@ NSD RELEASE NOTES
 BUG FIXES:
         - Fix #415: Fix out of tree builds. Thanks Florian Obser (@fobser).
 	- Fix #414: XoT interoperability with BIND and Knot
+	- Fix #421: old-main can quit before the reload process received        
+	  from old-main that it is done on the reload_listener pipe.            
+	  Thanks Otto Retter. 
 
 4.11.0
 ================

--- a/server.c
+++ b/server.c
@@ -2447,7 +2447,8 @@ static void server_reload_handle_quit_sync_ack(int cmdsocket, short event,
 	r = read(cmdsocket, cb_data->to_read.buf + cb_data->read,
 			sizeof(cb_data->to_read.cmd) - cb_data->read);
 	if(r == 0) {
-		log_msg(LOG_ERR, "reload: old-main quit during quit sync");
+		DEBUG(DEBUG_IPC, 1, (LOG_WARNING,
+			"reload: old-main quit during quit sync"));
 		cb_data->to_read.cmd = NSD_RELOAD;
 
 	} else if(r == -1) {


### PR DESCRIPTION
When during a reload, old-main has finished all it's tasks (killing the old server processes, informing xfrd that it's going to exit etc.), it will shutdown (cmd == NSD_QUIT), but before it shuts down, it informs the reload process that it is done by sending it NSD_RELOAD over the reload_listerener. However, on some platforms, the reload_listener pipe may be closed (by old-main's) shutdown, before the reload process can read from it. This was nog logged as an error before (NSD 4.8) and neither should it now.

Thanks Otto Retter for reporting this on the nsd-users list.