### PR TITLE
Unlink tasklist udb_ptr's after failed fork() or failed apply_xfr tasks

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,6 @@
+17 January 2025: Willem
+	- Fix #424: Stalled updates after corrupt transfer.
+
 15 January 2025: Wouter
 	- Fix whitespace in comment.
 

--- a/doc/RELNOTES
+++ b/doc/RELNOTES
@@ -9,6 +9,7 @@ BUG FIXES:
 	  from old-main that it is done on the reload_listener pipe.            
 	  Thanks Otto Retter. 
 	- Fix whitespace in comment.
+	- Fix #424: Stalled updates after corrupt transfer.
 
 4.11.0
 ================


### PR DESCRIPTION
This needs to be fixed, because otherwise the udb_ptr's are inconsistent. I have good faith that this may well be the issue causing the 100% CPU in the reload process from issue #417