### PR TITLE
Disable UDP on TLS configured ports

### DIFF
--- a/nsd.conf.5.in
+++ b/nsd.conf.5.in
@@ -567,6 +567,8 @@ openssl ocsp -no_nonce \\
 .B tls\-port:\fR <number>
 The port number on which to provide TCP TLS service, default is 853, only
 interfaces configured with that port number as @number get DNS over TLS service.
+UDP service is implicitly turned off for the same port as to not mix encrypted
+and plain text communication.
 .TP
 .B tls\-auth\-port:\fR <number>
 The port number on which to provide TCP TLS service to authenticated clients only.

--- a/nsd.conf.sample.in
+++ b/nsd.conf.sample.in
@@ -258,6 +258,7 @@ server:
 	# Service clients over TLS (on the TCP sockets), with plain DNS inside
 	# the TLS stream. Give the certificate to use and private key.
 	# Default is "" (disabled). Requires restart to take effect.
+	# UDP on the same port is implicitly turned off.
 	# tls-service-key: "path/to/privatekeyfile.key"
 	# tls-service-pem: "path/to/publiccertfile.pem"
 	# tls-service-ocsp: "path/to/ocsp.pem"

--- a/nsd.h
+++ b/nsd.h
@@ -447,6 +447,7 @@ SSL_CTX* server_tls_ctx_setup(char* key, char* pem, char* verifypem);
 SSL_CTX* server_tls_ctx_create(struct nsd *nsd, char* verifypem, char* ocspfile);
 void perform_openssl_init(void);
 #endif
+int using_tls_port(struct sockaddr* addr, const char* tls_port);
 ssize_t block_read(struct nsd* nsd, int s, void* p, ssize_t sz, int timeout);
 
 #endif	/* NSD_H */


### PR DESCRIPTION
Currently breaks software that sends the SOA probe query over UDP.