### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,9 @@ build:
     - flex
     - bison
     - mandoc
+    - libprotobuf-c-dev
+    - protobuf-c-compiler
+    - libfstrm-dev
   tools:
     python: "3"
   jobs:


### PR DESCRIPTION
Now that many configure options are enabled by default, the readthedocs build fails due to missing dependencies.