### PR TITLE
contrib/nsd.openrc.in: use supervise-daemon and add `need net`

### DIFF
--- a/contrib/nsd.openrc.in
+++ b/contrib/nsd.openrc.in
@@ -1,4 +1,5 @@
 #!/sbin/openrc-run
+supervisor=supervise-daemon
 
 description="The NLnet Labs Name Server Daemon (NSD)"
 extra_commands="configtest"
@@ -27,6 +28,7 @@ required_files="${config_file}"
 
 depend() {
 	use logger
+	need net
 }
 
 checkconfig() {
@@ -66,6 +68,6 @@ stop_pre() {
 reload() {
 	checkconfig || return $?
 	ebegin "Reloading config and zone files"
-	start-stop-daemon --signal HUP --pidfile "${pidfile}"
+	supervise-daemon "${RC_SVCNAME}" -s SIGHUP
 	eend $?
 }


### PR DESCRIPTION
* supervise-daemon for restarts after a crash
* `need net` to safely bind to specific addresses/interfaces rather than ::0
