### PR TITLE
Minimize disruptions on reconfig

### DIFF
--- a/dnstap/dnstap.m4
+++ b/dnstap/dnstap.m4
@@ -27,6 +27,30 @@ AC_DEFUN([dt_DNSTAP],
     if test -z "$PROTOC_C"; then
       AC_MSG_ERROR([[The protoc or protoc-c program was not found. It is needed for dnstap, use --disable-dnstap, or install protobuf-c to provide protoc or protoc-c]])
     fi
+    
+    # Check for protoc-gen-c plugin
+    AC_PATH_PROG([PROTOC_GEN_C], [protoc-gen-c])
+    if test -z "$PROTOC_GEN_C"; then
+      AC_MSG_ERROR([[The protoc-gen-c plugin was not found. It is needed for dnstap, use --disable-dnstap, or install protobuf-c-compiler to provide protoc-gen-c]])
+    fi
+    
+    # Test that protoc-gen-c actually works
+    AC_MSG_CHECKING([if protoc-gen-c plugin works])
+    cat > conftest.proto << EOF
+syntax = "proto2";
+message TestMessage {
+  optional string test_field = 1;
+}
+EOF
+    if $PROTOC_C --c_out=. conftest.proto >/dev/null 2>&1; then
+      AC_MSG_RESULT([yes])
+      rm -f conftest.proto conftest.pb-c.c conftest.pb-c.h
+    else
+      AC_MSG_RESULT([no])
+      rm -f conftest.proto conftest.pb-c.c conftest.pb-c.h
+      AC_MSG_ERROR([[The protoc-gen-c plugin is not working properly. Please ensure protobuf-c-compiler is properly installed]])
+    fi
+    
     AC_ARG_WITH([protobuf-c], AS_HELP_STRING([--with-protobuf-c=path],
     	[Path where protobuf-c is installed, for dnstap]), [
 	  # workaround for protobuf-c includes at old dir before protobuf-c-1.0.0

--- a/server.c
+++ b/server.c
@@ -4650,7 +4650,11 @@ handle_tcp_writing(int fd, short event, void* arg)
 #ifdef EPIPE
 				  if(verbosity >= 2 || errno != EPIPE)
 #endif /* EPIPE 'broken pipe' */
-				    log_msg(LOG_ERR, "failed writing to tcp: %s", strerror(errno));
+				{
+					char client_ip[128];
+					addr2str(&data->query->client_addr, client_ip, sizeof(client_ip));
+					log_msg(LOG_ERR, "failed writing to tcp from %s: %s", client_ip, strerror(errno));
+				}
 				cleanup_tcp_handler(data);
 				return;
 			}
@@ -4689,7 +4693,11 @@ handle_tcp_writing(int fd, short event, void* arg)
 #ifdef EPIPE
 				  if(verbosity >= 2 || errno != EPIPE)
 #endif /* EPIPE 'broken pipe' */
-			log_msg(LOG_ERR, "failed writing to tcp: %s", strerror(errno));
+		{
+			char client_ip[128];
+			addr2str(&data->query->client_addr, client_ip, sizeof(client_ip));
+			log_msg(LOG_ERR, "failed writing to tcp from %s: %s", client_ip, strerror(errno));
+		}
 			cleanup_tcp_handler(data);
 			return;
 		}
@@ -5260,7 +5268,11 @@ handle_tls_writing(int fd, short event, void* arg)
 			tcp_handler_setup_event(data, handle_tls_reading, fd, EV_PERSIST | EV_READ | EV_TIMEOUT);
 		} else if(want != SSL_ERROR_WANT_WRITE) {
 			cleanup_tcp_handler(data);
-			log_crypto_err("could not SSL_write");
+			{
+				char client_ip[128];
+				addr2str(&data->query->client_addr, client_ip, sizeof(client_ip));
+				log_msg(LOG_ERR, "failed writing to tls from %s: %s", client_ip, "SSL_write error");
+			}
 		}
 		return;
 	}


### PR DESCRIPTION
reconfig is called every 5 minutes from cron in my use case, the intent here is to reduce the negative impacts if the configuration as generated from database is not changed