### PR TITLE
Add --with-dbdir to allow configuration of dbdir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,9 @@ AC_SUBST(logfile)
 # Database directory
 #
 dbdir=${localstatedir}/db/nsd
+AC_ARG_WITH([dbdir],
+	AS_HELP_STRING([--with-dbdir=dir],[NSD database directory]),
+	[dbdir=$withval])
 
 #
 # Determine the pidfile location. Check if /var/run exists, if so set pidfile


### PR DESCRIPTION
Hi!  In Debian we used a local hack to set the dbdir for a long time:

https://sources.debian.org/src/nsd/4.12.0-1/debian/patches/0002-Force-dbdir-to-be-var-lib-nsd-by-patching-configure.patch

This pull request allows configuration of this hard coded path using `--with-dbdir` instead.