### PR TITLE
Add XDP_OBJ fixing link errors for XDP.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -101,10 +101,10 @@ XDP_OBJ=xdp-server.o xdp-util.o
 NSD_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) $(XDP_OBJ) difffile.o ipc.o mini_event.o netio.o nsd.o server.o dbaccess.o dbcreate.o zonec.o verify.o
 ALL_OBJ=$(NSD_OBJ) nsd-checkconf.o nsd-checkzone.o nsd-control.o nsd-mem.o xfr-inspect.o
 NSD_CHECKCONF_OBJ=$(COMMON_OBJ) nsd-checkconf.o
-NSD_CHECKZONE_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o nsd-checkzone.o verify.o
+NSD_CHECKZONE_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) $(XDP_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o nsd-checkzone.o verify.o
 NSD_CONTROL_OBJ=$(COMMON_OBJ) nsd-control.o
-CUTEST_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o verify.o zonec.o cutest_dname.o cutest_dns.o cutest_iterated_hash.o cutest_run.o cutest_radtree.o cutest_rbtree.o cutest_namedb.o cutest_options.o cutest_region.o cutest_rrl.o cutest_udb.o cutest_util.o cutest_xfrd_tcp.o cutest_bitset.o cutest_popen3.o cutest_iter.o cutest_event.o cutest.o qtest.o
-NSD_MEM_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o verify.o server.o zonec.o nsd-mem.o
+CUTEST_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) $(XDP_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o verify.o zonec.o cutest_dname.o cutest_dns.o cutest_iterated_hash.o cutest_run.o cutest_radtree.o cutest_rbtree.o cutest_namedb.o cutest_options.o cutest_region.o cutest_rrl.o cutest_udb.o cutest_util.o cutest_xfrd_tcp.o cutest_bitset.o cutest_popen3.o cutest_iter.o cutest_event.o cutest.o qtest.o
+NSD_MEM_OBJ=$(COMMON_OBJ) $(XFRD_OBJ) $(XDP_OBJ) dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o verify.o server.o zonec.o nsd-mem.o
 
 .PHONY: all html
 


### PR DESCRIPTION
I got build errors without this.

https://salsa.debian.org/jas/nsd/-/jobs/8255756

```
gcc -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/builds/jas/nsd/debian/output/source_dir=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -W -Wall -Wextra -Wdeclaration-after-statement -I/usr/include/google -Wl,-z,relro -Wl,-z,now -o nsd answer.o axfr.o ixfr.o ixfrcreate.o buffer.o configlexer.o configparser.o dname.o dns.o edns.o iterated_hash.o lookup3.o namedb.o nsec3.o options.o packet.o query.o rbtree.o radtree.o rdata.o region-allocator.o rrl.o siphash.o tsig.o tsig-openssl.o udb.o util.o bitset.o popen3.o proxy_protocol.o xfrd-catalog-zones.o xfrd-disk.o xfrd-notify.o xfrd-tcp.o xfrd.o remote.o metrics.o dnstap.o dnstap_collector.o dnstap.pb-c.o xdp-server.o xdp-util.o difffile.o ipc.o mini_event.o netio.o nsd.o server.o dbaccess.o dbcreate.o zonec.o verify.o cpuset.o b64_pton.o b64_ntop.o setproctitle.o simdzone/libzone.a -lssl -lprotobuf-c -lfstrm -lcap -lbpf -lxdp -lcrypto -levent -lsystemd 
gcc -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/builds/jas/nsd/debian/output/source_dir=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -W -Wall -Wextra -Wdeclaration-after-statement -I/usr/include/google -Wl,-z,relro -Wl,-z,now -o nsd-checkconf answer.o axfr.o ixfr.o ixfrcreate.o buffer.o configlexer.o configparser.o dname.o dns.o edns.o iterated_hash.o lookup3.o namedb.o nsec3.o options.o packet.o query.o rbtree.o radtree.o rdata.o region-allocator.o rrl.o siphash.o tsig.o tsig-openssl.o udb.o util.o bitset.o popen3.o proxy_protocol.o nsd-checkconf.o simdzone/libzone.a cpuset.o b64_pton.o b64_ntop.o setproctitle.o -lssl -lprotobuf-c -lfstrm -lcap -lbpf -lxdp -lcrypto -levent -lsystemd 
gcc -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/builds/jas/nsd/debian/output/source_dir=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -W -Wall -Wextra -Wdeclaration-after-statement -I/usr/include/google -Wl,-z,relro -Wl,-z,now -o nsd-checkzone answer.o axfr.o ixfr.o ixfrcreate.o buffer.o configlexer.o configparser.o dname.o dns.o edns.o iterated_hash.o lookup3.o namedb.o nsec3.o options.o packet.o query.o rbtree.o radtree.o rdata.o region-allocator.o rrl.o siphash.o tsig.o tsig-openssl.o udb.o util.o bitset.o popen3.o proxy_protocol.o xfrd-catalog-zones.o xfrd-disk.o xfrd-notify.o xfrd-tcp.o xfrd.o remote.o metrics.o dnstap.o dnstap_collector.o dnstap.pb-c.o dbaccess.o dbcreate.o difffile.o ipc.o mini_event.o netio.o server.o zonec.o nsd-checkzone.o verify.o cpuset.o b64_pton.o b64_ntop.o setproctitle.o simdzone/libzone.a -lssl -lprotobuf-c -lfstrm -lcap -lbpf -lxdp -lcrypto -levent -lsystemd 
gcc -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/builds/jas/nsd/debian/output/source_dir=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -W -Wall -Wextra -Wdeclaration-after-statement -I/usr/include/google -Wl,-z,relro -Wl,-z,now -o nsd-control answer.o axfr.o ixfr.o ixfrcreate.o buffer.o configlexer.o configparser.o dname.o dns.o edns.o iterated_hash.o lookup3.o namedb.o nsec3.o options.o packet.o query.o rbtree.o radtree.o rdata.o region-allocator.o rrl.o siphash.o tsig.o tsig-openssl.o udb.o util.o bitset.o popen3.o proxy_protocol.o nsd-control.o cpuset.o b64_pton.o b64_ntop.o setproctitle.o simdzone/libzone.a -lssl -lprotobuf-c -lfstrm -lcap -lbpf -lxdp -lcrypto -levent -lsystemd 
/usr/bin/ld: server.o: in function `server_main':
././server.c:3205:(.text+0x88c5): undefined reference to `xdp_server_cleanup'
/usr/bin/ld: server.o: in function `handle_xdp':
././server.c:5706:(.text+0x20e5): undefined reference to `xdp_handle_recv_and_send'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:224: nsd-checkzone] Error 1
```