### PR TITLE
Fix confusing report for default send and receive buffer-size by nsd-checkconf

### DIFF
--- a/configparser.y
+++ b/configparser.y
@@ -295,9 +295,25 @@ server_option:
   | VAR_IP_FREEBIND boolean
     { cfg_parser->opt->ip_freebind = $2; }
   | VAR_SEND_BUFFER_SIZE number
-    { cfg_parser->opt->send_buffer_size = (int)$2; }
+    {
+      if ($2 > 0) {
+        cfg_parser->opt->send_buffer_size = (int)$2;
+      } else if ($2 == 0) {
+        /* do nothing and use the default value */
+      } else {
+        yyerror("expected a number equal to or greater than zero");
+      }
+    }
   | VAR_RECEIVE_BUFFER_SIZE number
-    { cfg_parser->opt->receive_buffer_size = (int)$2; }
+    {
+      if ($2 > 0) {
+        cfg_parser->opt->receive_buffer_size = (int)$2;
+      } else if ($2 == 0) {
+        /* do nothing and use the default value */
+      } else {
+        yyerror("expected a number equal to or greater than zero");
+      }
+    }
   | VAR_DEBUG_MODE boolean
     { cfg_parser->opt->debug_mode = $2; }
   | VAR_USE_SYSTEMD boolean

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,7 @@
+15 September 2025: Jannik
+	- Fix confusing report for default send and receive buffer-size by
+	  nsd-checkconf
+
 11 September 2025: Jannik
 	- Merge #460: Add XDP_OBJ fixing link errors for XDP.
 	- Fix XDP build error with --enable-checking

--- a/doc/RELNOTES
+++ b/doc/RELNOTES
@@ -11,6 +11,8 @@ BUG FIXES:
 	- Merge #460: Add XDP_OBJ fixing link errors for XDP.
 	- Fix XDP build error with --enable-checking
 	- Resolve warnings about mixed declaration and code and unused variable
+	- Fix confusing report for default send and receive buffer-size by
+	  nsd-checkconf
 
 4.13.0
 ================

--- a/options.c
+++ b/options.c
@@ -65,8 +65,8 @@ nsd_options_create(region_type* region)
 	opt->ip_addresses = NULL;
 	opt->ip_transparent = 0;
 	opt->ip_freebind = 0;
-	opt->send_buffer_size = 0;
-	opt->receive_buffer_size = 0;
+	opt->send_buffer_size = 4*1024*1024;
+	opt->receive_buffer_size = 1*1024*1024;
 	opt->debug_mode = 0;
 	opt->verbosity = 0;
 	opt->hide_version = 0;

--- a/server.c
+++ b/server.c
@@ -1271,7 +1271,8 @@ set_setfib(struct nsd_socket *sock)
 static int
 open_udp_socket(struct nsd *nsd, struct nsd_socket *sock, int *reuseport_works)
 {
-	int rcv = 1*1024*1024, snd = 4*1024*1024;
+	int rcv = nsd->options->receive_buffer_size;
+	int snd = nsd->options->send_buffer_size;
 
 	if(-1 == (sock->s = socket(
 		sock->addr.ai_family, sock->addr.ai_socktype, 0)))
@@ -1295,13 +1296,9 @@ open_udp_socket(struct nsd *nsd, struct nsd_socket *sock, int *reuseport_works)
 	if(nsd->reuseport && reuseport_works && *reuseport_works)
 		*reuseport_works = (set_reuseport(sock) == 1);
 
-	if(nsd->options->receive_buffer_size > 0)
-		rcv = nsd->options->receive_buffer_size;
 	if(set_rcvbuf(sock, rcv) == -1)
 		return -1;
 
-	if(nsd->options->send_buffer_size > 0)
-		snd = nsd->options->send_buffer_size;
 	if(set_sndbuf(sock, snd) == -1)
 		return -1;
 #ifdef INET6


### PR DESCRIPTION
Jaap reported that although the release notes mention that the default for `send-buffer-size` has been changed to 4m, he doesn't see that happen and `nsd-checkconf -o send-buffer-size ./nsd.conf.sample` reports the buffer size to be zero while the default value in the example config is set to `# send-buffer-size: 4194304`.
I assume he just missed the part in the man page that states that the `send-buffer-size` value of `0` means to use the default, but this could still be a bit clearer. 
So maybe this change is appropriate? Or should the config option simply be removed when the user wants the default value (although that would break backwards compatibility)?