### PR TITLE
Do not delete nodes from non-existent zone's NSEC3 hash trees

### DIFF
--- a/namedb.c
+++ b/namedb.c
@@ -160,7 +160,7 @@ int domain_is_prehash(domain_table_type* table, domain_type* domain)
 void
 zone_del_domain_in_hash_tree(rbtree_type* tree, rbnode_type* node)
 {
-	if(!node->key)
+	if(!node->key || !tree)
 		return;
 	rbtree_delete(tree, node->key);
 	/* note that domain is no longer in the tree */


### PR DESCRIPTION
This fixes a bug where the reload process crashes because a node in a zone's NSEC3 hash tree is tried to be deleted, but the tree is not or no longer there. I.e. zone->hashtree == NULL.

I still don not know what the root cause of the zone->hashtree being NULL is, but the consequence of the crash is quite severe. Not only will the zone in question not be updated, but since the xfr that caused it is not marked faulty, the reload will just happen again and again with all the outstanding xfrs, causing the crash to just happen over and over again, and none of the other outstanding xfrs being applied (stalling those zones).

We may consider conveying the xfr number being processed by the `reload` process to the `old-main` process, so that the `old-main` can mark it as faulty if a crash happens during processing of that xfr, so that the other xfrs can still be processed (and will not be blocked). @wcawijngaards @mozzieongit WDYT?