### PR TITLE
feat(xdp): add checksum verification on rx path

### DIFF
--- a/xdp-util.h
+++ b/xdp-util.h
@@ -124,4 +124,89 @@ static inline uint16_t calc_csum_udp4(struct udphdr *udp, struct iphdr *ipv4) {
 		return (uint16_t) sum;
 }
 
+/*
+ * This function code has been taken from
+ * Linux kernel lib/checksum.c
+ */
+static inline unsigned short from32to16(unsigned int x)
+{
+	/* add up 16-bit and 16-bit for 16+c bit */
+	x = (x & 0xffff) + (x >> 16);
+	/* add up carry.. */
+	x = (x & 0xffff) + (x >> 16);
+	return x;
+}
+
+/*
+ * This function code has been taken from
+ * Linux kernel lib/checksum.c
+ */
+static unsigned int do_csum(const unsigned char *buff, int len)
+{
+	unsigned int result = 0;
+	int odd;
+
+	if (len <= 0)
+		goto out;
+	odd = 1 & (unsigned long)buff;
+	if (odd) {
+#ifdef __LITTLE_ENDIAN
+		result += (*buff << 8);
+#else
+		result = *buff;
+#endif
+		len--;
+		buff++;
+	}
+	if (len >= 2) {
+		if (2 & (unsigned long)buff) {
+			result += *(unsigned short *)buff;
+			len -= 2;
+			buff += 2;
+		}
+		if (len >= 4) {
+			const unsigned char *end = buff +
+						   ((unsigned int)len & ~3);
+			unsigned int carry = 0;
+
+			do {
+				unsigned int w = *(unsigned int *)buff;
+
+				buff += 4;
+				result += carry;
+				result += w;
+				carry = (w > result);
+			} while (buff < end);
+			result += carry;
+			result = (result & 0xffff) + (result >> 16);
+		}
+		if (len & 2) {
+			result += *(unsigned short *)buff;
+			buff += 2;
+		}
+	}
+	if (len & 1)
+#ifdef __LITTLE_ENDIAN
+		result += *buff;
+#else
+		result += (*buff << 8);
+#endif
+	result = from32to16(result);
+	if (odd)
+		result = ((result >> 8) & 0xff) | ((result & 0xff) << 8);
+out:
+	return result;
+}
+
+/*
+ *	This is a version of ip_compute_csum() optimized for IP headers,
+ *	which always checksum on 4 octet boundaries.
+ *	This function code has been taken from
+ *	Linux kernel lib/checksum.c
+ */
+static inline __sum16 ip_fast_csum(const void *iph, unsigned int ihl)
+{
+	return (__sum16)~do_csum(iph, ihl * 4);
+}
+
 #endif /* XDP_UTIL_H */


### PR DESCRIPTION
This PR introduces checksum verification for IPv4 and UDP in the XDP rx path. It fixes #465 

For UDP I utilized the available functions in `xdp-util.h`. As for IP, I followed the example from [xdp-project](github.com/xdp-project/bpf-examples/blob/main/AF_XDP-example/xdpsock.c), and I "borrowed" the functions from the Kernel (I don't think this causes any issues in terms of Licensing).

Furthermore, since this implies some extra computing per each packet/request, I wanted to measure the performance implications. With a server running on a machine with an Intel i5-9500 and an Intel 10G X550T NIC, at a rate of 1M packets/requests per second, the average CPU usage across all CPU cores went from **11.18%** to **11.57%**.

For a single client sending synchronous requests, its rate drops from an average of **12360 req/s** to **12315 req/s**.

If this minor performance hit is an issue, we could perhaps add a compile flag so checksum verification would become optional. 

