### PR TITLE
Improve ignored old serial log message

### DIFF
--- a/xfrd.c
+++ b/xfrd.c
@@ -2303,10 +2303,10 @@ xfrd_parse_received_xfr_packet(xfrd_zone_type* zone, buffer_type* packet,
 			zone->state != xfrd_zone_expired /* if expired - accept anything */ &&
 			compare_serial(ntohl(soa->serial), ntohl(zone->soa_disk.serial)) < 0) {
 			DEBUG(DEBUG_XFRD,1, (LOG_INFO,
-				"xfrd: zone %s ignoring old serial (%u/%u) from %s",
+				"xfrd: zone %s ignoring old serial (local: %u, remote: %u) from %s",
 				zone->apex_str, ntohl(zone->soa_disk.serial), ntohl(soa->serial), zone->master->ip_address_spec));
 			VERBOSITY(1, (LOG_INFO,
-				"xfrd: zone %s ignoring old serial (%u/%u) from %s",
+				"xfrd: zone %s ignoring old serial (local: %u, remote: %u) from %s",
 				zone->apex_str, ntohl(zone->soa_disk.serial), ntohl(soa->serial), zone->master->ip_address_spec));
 			region_destroy(tempregion);
 			return xfrd_packet_bad;

--- a/xfrd.c
+++ b/xfrd.c
@@ -2302,12 +2302,12 @@ xfrd_parse_received_xfr_packet(xfrd_zone_type* zone, buffer_type* packet,
 		if(zone->soa_disk_acquired != 0 &&
 			zone->state != xfrd_zone_expired /* if expired - accept anything */ &&
 			compare_serial(ntohl(soa->serial), ntohl(zone->soa_disk.serial)) < 0) {
-                        DEBUG(DEBUG_XFRD,1, (LOG_INFO,
-                                "xfrd: zone %s ignoring old serial (%u/%u) from %s",
-                                zone->apex_str, ntohl(zone->soa_disk.serial), ntohl(soa->serial), zone->master->ip_address_spec));
-                        VERBOSITY(1, (LOG_INFO,
-                                "xfrd: zone %s ignoring old serial (%u/%u) from %s",
-                                zone->apex_str, ntohl(zone->soa_disk.serial), ntohl(soa->serial), zone->master->ip_address_spec));
+			DEBUG(DEBUG_XFRD,1, (LOG_INFO,
+				"xfrd: zone %s ignoring old serial (%u/%u) from %s",
+				zone->apex_str, ntohl(zone->soa_disk.serial), ntohl(soa->serial), zone->master->ip_address_spec));
+			VERBOSITY(1, (LOG_INFO,
+				"xfrd: zone %s ignoring old serial (%u/%u) from %s",
+				zone->apex_str, ntohl(zone->soa_disk.serial), ntohl(soa->serial), zone->master->ip_address_spec));
 			region_destroy(tempregion);
 			return xfrd_packet_bad;
 		}


### PR DESCRIPTION
Make it clear which serial is the old ignored one (received from the remote server) and which is the local, newer one.

You shouldn't have to read the source code to definitely tell which is which.

While you could infer which serial is which by checking which one is larger, it's not always easy to tell at a glance, so it's better to spell it out explicitly in the log message. I've already seen someone mix up the two serials in practice.

The best words I could come up with to describe the serials were `local`/`remote` which should make it clear which is which, but I'm open to better suggestions.
