### PR TITLE
Fix pedantic/CodeQL warning in sources

### DIFF
--- a/difffile.h
+++ b/difffile.h
@@ -125,7 +125,7 @@ struct task_list_d {
 	uint32_t oldserial, newserial;
 	/** general variable.  for some used to see if zname is present. */
 	uint64_t yesno;
-	struct dname zname[0];
+	struct dname zname[];
 };
 #define TASKLIST(ptr) ((struct task_list_d*)UDB_PTR(ptr))
 /** create udb for tasks */

--- a/rdata.c
+++ b/rdata.c
@@ -701,7 +701,7 @@ svcparam_must_not_have_value(uint16_t svcparamkey)
 		break;
 	}
 	return 0;
-};
+}
 
 /*
  * Skip over the svcparams in the packet. Moves position.

--- a/udb.h
+++ b/udb.h
@@ -213,7 +213,6 @@ struct udb_base {
 	int useful_compact;
 };
 
-typedef enum udb_chunk_type udb_chunk_type;
 /** chunk type enum, setting these types help recovery and debug */
 enum udb_chunk_type {
 	udb_chunk_type_free = 0,
@@ -221,6 +220,7 @@ enum udb_chunk_type {
 	udb_chunk_type_task,
 	udb_chunk_type_internal
 };
+typedef enum udb_chunk_type udb_chunk_type;
 
 typedef struct udb_chunk_d udb_chunk_d;
 /**
@@ -242,7 +242,7 @@ struct udb_chunk_d {
 	 * In the free chunk this is the previous pointer. */
 	udb_void ptrlist;
 	/* user data space starts here, 64-bit aligned */
-	uint8_t data[0];
+	uint8_t data[];
 	/* last octet: exp of chunk */
 };
 
@@ -287,7 +287,7 @@ struct udb_xl_chunk_d {
 	/** size of this chunk in bytes */
 	uint64_t size;
 	/** data of the XL chunk */
-	uint8_t data[0];
+	uint8_t data[];
 	/* uint64_t endsize: before last octet the size again. */
 	/* uint8_t pad[7]: padding to make last octet last. */
 	/* last octet: exp of chunk: special XL value */

--- a/verify.c
+++ b/verify.c
@@ -371,11 +371,13 @@ verify_handle_command(int fd, short event, void *arg)
 	sig_atomic_t mode;
 
 	assert(nsd != NULL);
-	assert((event & (EV_READ
+	{
+		short ev_read = EV_READ;
 #ifdef EV_CLOSED
-	| EV_CLOSED
+		ev_read |= EV_CLOSED;
 #endif
-	)));
+		assert((event & ev_read));
+	}
 
 	if((len = read(fd, &mode, sizeof(mode))) == -1) {
 		log_msg(LOG_ERR, "verify: verify_handle_command: read: %s",

--- a/xfrd-tcp.c
+++ b/xfrd-tcp.c
@@ -321,7 +321,7 @@ void pick_id_values(uint16_t* array, int num, int max)
 	for(j = max-num; j<max; j++) {
 		/* random generate creates from 0..arg-1 */
 		int t;
-		if(j+1 <= 1)
+		if(j < 1)
 			t = 0;
 		else	t = random_generate(j+1);
 		if(!inserted[t]) {


### PR DESCRIPTION
- udb.h: define enum udb_chunk_type before typedef; use [] flexible arrays.
- difffile.h: use flexible array for task_list_d.zname.
- rdata.c: drop stray }; after svcparam_must_not_have_value.
- verify.c: avoid preprocessor directives inside assert() arguments.
- xfrd-tcp.c: use j < 1 instead of j+1 <= 1 (same logic; CodeQL overflow rule).