### PR TITLE
Prometheus metrics: Move zonestats from metric name to label

### DIFF
--- a/metrics.c
+++ b/metrics.c
@@ -349,21 +349,23 @@ metrics_http_callback(struct evhttp_request *req, void *p)
 }
 
 #ifdef BIND8_STATS
-const char*
-metrics_validate_label_value(const char* value) {
-	const char* s = value;
+/** Change characters disallowed in Prometheus label values to underscores.
+ * Return whether any changes were made. */
+int
+metrics_make_label_value_valid(char* value) {
+	int made_changes = 0;
+	char* s = value;
 	while(*s) {
 		switch (*s) {
 			case '\\':
-				return "character '\\' is not allowed";
 			case '"':
-				return "charater '\"' is not allowed";
 			case '\n':
-				return "newline is not allowed";
+				*s = '_';
+				made_changes = 1;
 		}
 		s++;
 	}
-	return NULL;
+	return made_changes;
 }
 
 #define METRIC_MAX_LABELS 2
@@ -567,10 +569,19 @@ void
 metrics_zonestat_print_one(struct evbuffer *buf, char *name,
                            struct nsdst *zst)
 {
+	char* name_valid;
 	struct metrics_metric metric;
 	metric_init_with_prefix(&metric, "nsd_zonestats_");
-	/* The zonestat name is validated at startup to be a valid label value. */
-	metric_push_label(&metric, "zone", name);
+
+	/* The zonestat name can contain characters like '"' that would break the
+	 * label value; replace them. */
+	name_valid = strdup(name);
+	if (!name_valid) {
+		log_msg(LOG_ERR, "malloc failure");
+		return;
+	}
+	metrics_make_label_value_valid(name_valid);
+	metric_push_label(&metric, "zone", name_valid);
 
 	metric_set_name_and_type(&metric, "queries_total", "counter");
 	metric_print_help(&metric, buf, "Total number of queries received.");
@@ -578,6 +589,7 @@ metrics_zonestat_print_one(struct evbuffer *buf, char *name,
 		(uint64_t)(zst->qudp + zst->qudp6 + zst->ctcp +
 			zst->ctcp6 + zst->ctls + zst->ctls6));
 	print_stat_block(buf, zst, &metric);
+	free(name_valid);
 }
 #endif /*USE_ZONE_STATS*/
 

--- a/metrics.c
+++ b/metrics.c
@@ -349,17 +349,14 @@ metrics_http_callback(struct evhttp_request *req, void *p)
 }
 
 #ifdef BIND8_STATS
-/** Change disallowed characters, '.' ':' to underscores '_'. */
+/** Change disallowed characters to underscores '_'. */
 static void
-change_string_underscores(char* prefix)
+replace_disallowed_label_chars(char* value)
 {
-	/* Prometheus does not want '.' in the metric names. But the zone
-	 * statistics could have then in their name.
-	 * Also ':' is not allowed. This routine enforeces that it
-	 * has letters,digits,underscores. */
-	char* s = prefix;
+	/* Replace characters that are not allowed in quoted label values. */
+	char* s = value;
 	while(*s) {
-		if(!isalnum((unsigned char)*s) && *s != '_')
+		if (*s == '\\' || *s == '\n' || *s == '"')
 			*s = '_';
 		s++;
 	}
@@ -389,6 +386,8 @@ metric_set_name_and_type(struct metrics_metric *metric, const char *name, const 
 	metric->type = type;
 }
 
+/* Add a `name="value"` label to the metric.
+ * The value must not contain `\`, `\n`, or `"`. */
 static void
 metric_push_label(struct metrics_metric *metric, const char *name, const char *value) {
 	assert(metric->label_count < METRIC_MAX_LABELS);
@@ -564,11 +563,11 @@ void
 metrics_zonestat_print_one(struct evbuffer *buf, char *name,
                            struct nsdst *zst)
 {
-	char prefix[512] = {0};
 	struct metrics_metric metric;
-	snprintf(prefix, sizeof(prefix), "nsd_zonestats_%s_", name);
-	change_string_underscores(prefix);
-	metric_init_with_prefix(&metric, prefix);
+	metric_init_with_prefix(&metric, "nsd_zonestats_");
+	/* TODO: Can we instead validate at startup? */
+	replace_disallowed_label_chars(name);
+	metric_push_label(&metric, "zone", name);
 
 	metric_set_name_and_type(&metric, "queries_total", "counter");
 	metric_print_help(&metric, buf, "Total number of queries received.");

--- a/metrics.c
+++ b/metrics.c
@@ -380,6 +380,7 @@ print_longnum(struct evbuffer *buf, char* desc, uint64_t x)
 	}
 }
 
+// TODO: Delete this after migrating everything to `struct metrics_metric`.
 static void
 print_metric_help_and_type(struct evbuffer *buf, char *prefix, char *name,
 						   char *help, char *type)
@@ -388,10 +389,75 @@ print_metric_help_and_type(struct evbuffer *buf, char *prefix, char *name,
 	                    prefix, name, help, prefix, name, type);
 }
 
+#define METRIC_MAX_LABELS 2
+
+struct metrics_metric {
+	const char *prefix;
+	const char *name;
+	const char *type;
+	size_t label_count;
+	const char *label_names[METRIC_MAX_LABELS];
+	const char *label_values[METRIC_MAX_LABELS];
+};
+
 static void
-print_stat_block(struct evbuffer *buf, struct nsdst* st,
-                  char *name)
-{
+metric_init_with_prefix(struct metrics_metric *metric, const char *prefix) {
+	metric->prefix = prefix;
+	metric->name = "";
+	metric->label_count = 0;
+}
+
+static void
+metric_set_name_and_type(struct metrics_metric *metric, const char *name, const char *type) {
+	metric->name = name;
+	metric->type = type;
+}
+
+static void
+metric_push_label(struct metrics_metric *metric, const char *name, const char *value) {
+	assert(metric->label_count < METRIC_MAX_LABELS);
+	metric->label_names[metric->label_count] = name;
+	metric->label_values[metric->label_count] = value;
+	metric->label_count++;
+}
+
+static void
+metric_pop_label(struct metrics_metric *metric) {
+	assert(metric->label_count > 0);
+	metric->label_count--;
+}
+
+static void
+metric_print(struct metrics_metric *metric, struct evbuffer *buf, unsigned long value) {
+	evbuffer_add_printf(buf, "%s%s", metric->prefix, metric->name);
+	for (size_t i = 0; i < metric->label_count; i++) {
+		evbuffer_add_printf(buf, "%c%s=\"%s\"",
+			i == 0 ? '{' : ',',
+			metric->label_names[i],
+			metric->label_values[i]);
+	}
+	if (metric->label_count > 0) {
+		evbuffer_add_printf(buf, "} %lu\n", value);
+	} else {
+		evbuffer_add_printf(buf, " %lu\n", value);
+	}
+}
+
+static void
+metric_print_pop(struct metrics_metric *metric, struct evbuffer *buf, unsigned long value) {
+	metric_print(metric, buf, value);
+	metric_pop_label(metric);
+}
+
+static void
+metric_print_help(struct metrics_metric *metric, struct evbuffer *buf, const char *help) {
+	evbuffer_add_printf(buf, "# HELP %s%s %s\n# TYPE %s%s %s\n",
+		metric->prefix, metric->name, help,
+		metric->prefix, metric->name, metric->type);
+}
+
+static void
+print_stat_block(struct evbuffer *buf, struct nsdst* st, struct metrics_metric *metric) {
 	size_t i;
 
 	const char* rcstr[] = {"NOERROR", "FORMERR", "SERVFAIL", "NXDOMAIN",
@@ -400,124 +466,110 @@ print_stat_block(struct evbuffer *buf, struct nsdst* st,
 		"BADVERS"
 	};
 
-	char prefix[512] = {0};
-	if (name) {
-		snprintf(prefix, sizeof(prefix), "nsd_zonestats_%s_", name);
-		change_string_underscores(prefix);
-	} else {
-		snprintf(prefix, sizeof(prefix), "nsd_");
-	}
-
 	/* nsd_queries_by_type_total */
-	print_metric_help_and_type(buf, prefix, "queries_by_type_total",
-	                           "Total number of queries received by type.",
-	                           "counter");
+	metric_set_name_and_type(metric, "queries_by_type_total", "counter");
+	metric_print_help(metric, buf, "Total number of queries received by type.");
 	for(i=0; i<= 255; i++) {
 		if(metrics_inhibit_zero && st->qtype[i] == 0 &&
 			strncmp(rrtype_to_string(i), "TYPE", 4) == 0)
 			continue;
-		evbuffer_add_printf(buf, "%squeries_by_type_total{type=\"%s\"} %lu\n",
-			prefix, rrtype_to_string(i), (unsigned long)st->qtype[i]);
+		metric_push_label(metric, "type", rrtype_to_string(i));
+		metric_print_pop(metric, buf, (unsigned long)st->qtype[i]);
 	}
 
 	/* nsd_queries_by_class_total */
-	print_metric_help_and_type(buf, prefix, "queries_by_class_total",
-	                           "Total number of queries received by class.",
-	                           "counter");
+	metric_set_name_and_type(metric, "queries_by_class_total", "counter");
+	metric_print_help(metric, buf, "Total number of queries received by class.");
 	for(i=0; i<4; i++) {
 		if(metrics_inhibit_zero && st->qclass[i] == 0 && i != CLASS_IN)
 			continue;
-		evbuffer_add_printf(buf, "%squeries_by_class_total{class=\"%s\"} %lu\n",
-			prefix, rrclass_to_string(i), (unsigned long)st->qclass[i]);
+		metric_push_label(metric, "class", rrclass_to_string(i));
+		metric_print_pop(metric, buf, (unsigned long)st->qclass[i]);
 	}
 
 	/* nsd_queries_by_opcode_total */
-	print_metric_help_and_type(buf, prefix, "queries_by_opcode_total",
-	                           "Total number of queries received by opcode.",
-	                           "counter");
+	metric_set_name_and_type(metric, "queries_by_opcode_total", "counter");
+	metric_print_help(metric, buf, "Total number of queries received by opcode.");
 	for(i=0; i<6; i++) {
 		if(metrics_inhibit_zero && st->opcode[i] == 0 && i != OPCODE_QUERY)
 			continue;
-		evbuffer_add_printf(buf, "%squeries_by_opcode_total{opcode=\"%s\"} %lu\n",
-			prefix, opcode2str(i), (unsigned long)st->opcode[i]);
+		metric_push_label(metric, "opcode", opcode2str(i));
+		metric_print_pop(metric, buf, (unsigned long)st->opcode[i]);
 	}
 
 	/* nsd_queries_by_rcode_total */
-	print_metric_help_and_type(buf, prefix, "queries_by_rcode_total",
-	                           "Total number of queries received by rcode.",
-	                           "counter");
+	metric_set_name_and_type(metric, "queries_by_rcode_total", "counter");
+	metric_print_help(metric, buf, "Total number of queries received by rcode.");
 	for(i=0; i<17; i++) {
 		if(metrics_inhibit_zero && st->rcode[i] == 0 &&
 			i > RCODE_YXDOMAIN) /*NSD does not use larger*/
 			continue;
-		evbuffer_add_printf(buf, "%squeries_by_rcode_total{rcode=\"%s\"} %lu\n",
-			prefix, rcstr[i], (unsigned long)st->rcode[i]);
+		metric_push_label(metric, "rcode", rcstr[i]);
+		metric_print_pop(metric, buf, (unsigned long)st->rcode[i]);
 	}
 
 	/* nsd_queries_by_transport_total */
-	print_metric_help_and_type(buf, prefix, "queries_by_transport_total",
-		"Total number of queries received by transport.",
-		"counter");
-	evbuffer_add_printf(buf, "%squeries_by_transport_total{transport=\"udp\"} %lu\n", prefix, (unsigned long)st->qudp);
-	evbuffer_add_printf(buf, "%squeries_by_transport_total{transport=\"udp6\"} %lu\n", prefix, (unsigned long)st->qudp6);
+	metric_set_name_and_type(metric, "queries_by_transport_total", "counter");
+	metric_print_help(metric, buf, "Total number of queries received by transport.");
+	metric_push_label(metric, "transport", "udp");
+	metric_print_pop(metric, buf, (unsigned long)st->qudp);
+	metric_push_label(metric, "transport", "udp6");
+	metric_print_pop(metric, buf, (unsigned long)st->qudp6);
 
 	/* nsd_queries_with_edns_total */
-	print_metric_help_and_type(buf, prefix, "queries_with_edns_total",
-		"Total number of queries received with EDNS OPT.",
-		"counter");
-	evbuffer_add_printf(buf, "%squeries_with_edns_total %lu\n", prefix, (unsigned long)st->edns);
+	metric_set_name_and_type(metric, "queries_with_edns_total", "counter");
+	metric_print_help(metric, buf, "Total number of queries received with EDNS OPT.");
+	metric_print(metric, buf, (unsigned long)st->edns);
 
 	/* nsd_queries_with_edns_failed_total */
-	print_metric_help_and_type(buf, prefix, "queries_with_edns_failed_total",
-		"Total number of queries received with EDNS OPT where EDNS parsing failed.",
-		"counter");
-	evbuffer_add_printf(buf, "%squeries_with_edns_failed_total %lu\n", prefix, (unsigned long)st->ednserr);
+	metric_set_name_and_type(metric, "queries_with_edns_failed_total", "counter");
+	metric_print_help(metric, buf, "Total number of queries received with EDNS OPT where EDNS parsing failed.");
+	metric_print(metric, buf, (unsigned long)st->ednserr);
 
 	/* nsd_connections_total */
-	print_metric_help_and_type(buf, prefix, "connections_total",
-		"Total number of connections.",
-		"counter");
-	evbuffer_add_printf(buf, "%sconnections_total{transport=\"tcp\"} %lu\n", prefix, (unsigned long)st->ctcp);
-	evbuffer_add_printf(buf, "%sconnections_total{transport=\"tcp6\"} %lu\n", prefix, (unsigned long)st->ctcp6);
-	evbuffer_add_printf(buf, "%sconnections_total{transport=\"tls\"} %lu\n", prefix, (unsigned long)st->ctls);
-	evbuffer_add_printf(buf, "%sconnections_total{transport=\"tls6\"} %lu\n", prefix, (unsigned long)st->ctls6);
+	metric_set_name_and_type(metric, "connections_total", "counter");
+	metric_print_help(metric, buf, "Total number of connections.");
+	metric_push_label(metric, "transport", "tcp");
+	metric_print_pop(metric, buf, (unsigned long)st->ctcp);
+	metric_push_label(metric, "transport", "tcp6");
+	metric_print_pop(metric, buf, (unsigned long)st->ctcp6);
+	metric_push_label(metric, "transport", "tls");
+	metric_print_pop(metric, buf, (unsigned long)st->ctls);
+	metric_push_label(metric, "transport", "tls6");
+	metric_print_pop(metric, buf, (unsigned long)st->ctls6);
 
 	/* nsd_xfr_requests_served_total */
-	print_metric_help_and_type(buf, prefix, "xfr_requests_served_total",
-		"Total number of answered zone transfers.",
-		"counter");
-	evbuffer_add_printf(buf, "%sxfr_requests_served_total{xfrtype=\"AXFR\"} %lu\n", prefix, (unsigned long)st->raxfr);
-	evbuffer_add_printf(buf, "%sxfr_requests_served_total{xfrtype=\"IXFR\"} %lu\n", prefix, (unsigned long)st->rixfr);
+	metric_set_name_and_type(metric, "xfr_requests_served_total", "counter");
+	metric_print_help(metric, buf, "Total number of answered zone transfers.");
+	metric_push_label(metric, "xfrtype", "AXFR");
+	metric_print_pop(metric, buf, (unsigned long)st->raxfr);
+	metric_push_label(metric, "xfrtype", "IXFR");
+	metric_print_pop(metric, buf, (unsigned long)st->rixfr);
 
 	/* nsd_queries_dropped_total */
-	print_metric_help_and_type(buf, prefix, "queries_dropped_total",
-		"Total number of dropped queries.",
-		"counter");
-	evbuffer_add_printf(buf, "%squeries_dropped_total %lu\n", prefix, (unsigned long)st->dropped);
+	metric_set_name_and_type(metric, "queries_dropped_total", "counter");
+	metric_print_help(metric, buf, "Total number of dropped queries.");
+	metric_print(metric, buf, (unsigned long)st->dropped);
 
 	/* nsd_queries_rx_failed_total */
-	print_metric_help_and_type(buf, prefix, "queries_rx_failed_total",
-		"Total number of queries where receive failed.",
-		"counter");
-	evbuffer_add_printf(buf, "%squeries_rx_failed_total %lu\n", prefix, (unsigned long)st->rxerr);
+	metric_set_name_and_type(metric, "queries_rx_failed_total", "counter");
+	metric_print_help(metric, buf, "Total number of queries where receive failed.");
+	metric_print(metric, buf, (unsigned long)st->rxerr);
 
 	/* nsd_answers_tx_failed_total */
-	print_metric_help_and_type(buf, prefix, "answers_tx_failed_total",
-		"Total number of answers where transmit failed.",
-		"counter");
-	evbuffer_add_printf(buf, "%sanswers_tx_failed_total %lu\n", prefix, (unsigned long)st->txerr);
+	metric_set_name_and_type(metric, "answers_tx_failed_total", "counter");
+	metric_print_help(metric, buf, "Total number of answers where transmit failed.");
+	metric_print(metric, buf, (unsigned long)st->txerr);
 
 	/* nsd_answers_without_aa_total */
-	print_metric_help_and_type(buf, prefix, "answers_without_aa_total",
-		"Total number of NOERROR answers without AA flag set.",
-		"counter");
-	evbuffer_add_printf(buf, "%sanswers_without_aa_total %lu\n", prefix, (unsigned long)st->nona);
+	metric_set_name_and_type(metric, "answers_without_aa_total", "counter");
+	metric_print_help(metric, buf, "Total number of NOERROR answers without AA flag set.");
+	metric_print(metric, buf, (unsigned long)st->nona);
 
 	/* nsd_answers_truncated_total */
-	print_metric_help_and_type(buf, prefix, "answers_truncated_total",
-		"Total number of truncated answers.",
-		"counter");
-	evbuffer_add_printf(buf, "%sanswers_truncated_total %lu\n", prefix, (unsigned long)st->truncated);
+	metric_set_name_and_type(metric, "answers_truncated_total", "counter");
+	metric_print_help(metric, buf, "Total number of truncated answers.");
+	metric_print(metric, buf, (unsigned long)st->truncated);
 }
 
 #ifdef USE_ZONE_STATS
@@ -526,15 +578,17 @@ metrics_zonestat_print_one(struct evbuffer *buf, char *name,
                            struct nsdst *zst)
 {
 	char prefix[512] = {0};
+	struct metrics_metric metric;
 	snprintf(prefix, sizeof(prefix), "nsd_zonestats_%s_", name);
 	change_string_underscores(prefix);
+	metric_init_with_prefix(&metric, prefix);
 
-	print_metric_help_and_type(buf, prefix, "queries_total",
-		"Total number of queries received.", "counter");
-	evbuffer_add_printf(buf, "%squeries_total %lu\n", prefix,
+	metric_set_name_and_type(&metric, "queries_total", "counter");
+	metric_print_help(&metric, buf, "Total number of queries received.");
+	metric_print(&metric, buf,
 		(unsigned long)(zst->qudp + zst->qudp6 + zst->ctcp +
 			zst->ctcp6 + zst->ctls + zst->ctls6));
-	print_stat_block(buf, zst, name);
+	print_stat_block(buf, zst, &metric);
 }
 #endif /*USE_ZONE_STATS*/
 
@@ -545,6 +599,7 @@ metrics_print_stats(struct evbuffer *buf, xfrd_state_type *xfrd,
 {
 	size_t i;
 	struct timeval elapsed, uptime;
+	struct metrics_metric metric;
 
 	/* nsd_queries_total */
 	print_metric_help_and_type(buf, "nsd_", "queries_total",
@@ -555,7 +610,8 @@ metrics_print_stats(struct evbuffer *buf, xfrd_state_type *xfrd,
 			(int)i, (unsigned long)xfrd->nsd->children[i].query_count);
 	}
 
-	print_stat_block(buf, st, NULL);
+	metric_init_with_prefix(&metric, "nsd_");
+	print_stat_block(buf, st, &metric);
 
 	/* uptime (in seconds) */
 	timeval_subtract(&uptime, now, &xfrd->nsd->metrics->boot_time);

--- a/metrics.c
+++ b/metrics.c
@@ -365,30 +365,6 @@ change_string_underscores(char* prefix)
 	}
 }
 
-/** print long number*/
-static int
-print_longnum(struct evbuffer *buf, char* desc, uint64_t x)
-{
-	if(x > (uint64_t)1024*1024*1024) {
-		/*more than a Gb*/
-		size_t front = (size_t)(x / (uint64_t)1000000);
-		size_t back = (size_t)(x % (uint64_t)1000000);
-		return evbuffer_add_printf(buf, "%s%lu%6.6lu\n", desc,
-			(unsigned long)front, (unsigned long)back);
-	} else {
-		return evbuffer_add_printf(buf, "%s%lu\n", desc, (unsigned long)x);
-	}
-}
-
-// TODO: Delete this after migrating everything to `struct metrics_metric`.
-static void
-print_metric_help_and_type(struct evbuffer *buf, char *prefix, char *name,
-						   char *help, char *type)
-{
-	evbuffer_add_printf(buf, "# HELP %s%s %s\n# TYPE %s%s %s\n",
-	                    prefix, name, help, prefix, name, type);
-}
-
 #define METRIC_MAX_LABELS 2
 
 struct metrics_metric {
@@ -428,7 +404,7 @@ metric_pop_label(struct metrics_metric *metric) {
 }
 
 static void
-metric_print(struct metrics_metric *metric, struct evbuffer *buf, unsigned long value) {
+metric_print(struct metrics_metric *metric, struct evbuffer *buf, uint64_t value) {
 	evbuffer_add_printf(buf, "%s%s", metric->prefix, metric->name);
 	for (size_t i = 0; i < metric->label_count; i++) {
 		evbuffer_add_printf(buf, "%c%s=\"%s\"",
@@ -437,14 +413,25 @@ metric_print(struct metrics_metric *metric, struct evbuffer *buf, unsigned long 
 			metric->label_values[i]);
 	}
 	if (metric->label_count > 0) {
-		evbuffer_add_printf(buf, "} %lu\n", value);
+		evbuffer_add_printf(buf, "} %" PRIu64 "\n", value);
 	} else {
-		evbuffer_add_printf(buf, " %lu\n", value);
+		evbuffer_add_printf(buf, " %" PRIu64 "\n", value);
 	}
 }
 
+/** Print a metric value of `integral + decimals_micro * 1e-6`. */
 static void
-metric_print_pop(struct metrics_metric *metric, struct evbuffer *buf, unsigned long value) {
+metric_print_micros(struct metrics_metric *metric, struct evbuffer *buf,
+	unsigned long integral, unsigned long decimals_micro)
+{
+	assert(metric->label_count == 0
+		&& "metric_print_micros is not implemented for metrics with labels");
+	evbuffer_add_printf(buf, "%s%s %lu.%6.6lu\n",
+		metric->prefix, metric->name, integral, decimals_micro);
+}
+
+static void
+metric_print_pop(struct metrics_metric *metric, struct evbuffer *buf, uint64_t value) {
 	metric_print(metric, buf, value);
 	metric_pop_label(metric);
 }
@@ -474,7 +461,7 @@ print_stat_block(struct evbuffer *buf, struct nsdst* st, struct metrics_metric *
 			strncmp(rrtype_to_string(i), "TYPE", 4) == 0)
 			continue;
 		metric_push_label(metric, "type", rrtype_to_string(i));
-		metric_print_pop(metric, buf, (unsigned long)st->qtype[i]);
+		metric_print_pop(metric, buf, (uint64_t)st->qtype[i]);
 	}
 
 	/* nsd_queries_by_class_total */
@@ -484,7 +471,7 @@ print_stat_block(struct evbuffer *buf, struct nsdst* st, struct metrics_metric *
 		if(metrics_inhibit_zero && st->qclass[i] == 0 && i != CLASS_IN)
 			continue;
 		metric_push_label(metric, "class", rrclass_to_string(i));
-		metric_print_pop(metric, buf, (unsigned long)st->qclass[i]);
+		metric_print_pop(metric, buf, (uint64_t)st->qclass[i]);
 	}
 
 	/* nsd_queries_by_opcode_total */
@@ -494,7 +481,7 @@ print_stat_block(struct evbuffer *buf, struct nsdst* st, struct metrics_metric *
 		if(metrics_inhibit_zero && st->opcode[i] == 0 && i != OPCODE_QUERY)
 			continue;
 		metric_push_label(metric, "opcode", opcode2str(i));
-		metric_print_pop(metric, buf, (unsigned long)st->opcode[i]);
+		metric_print_pop(metric, buf, (uint64_t)st->opcode[i]);
 	}
 
 	/* nsd_queries_by_rcode_total */
@@ -505,71 +492,71 @@ print_stat_block(struct evbuffer *buf, struct nsdst* st, struct metrics_metric *
 			i > RCODE_YXDOMAIN) /*NSD does not use larger*/
 			continue;
 		metric_push_label(metric, "rcode", rcstr[i]);
-		metric_print_pop(metric, buf, (unsigned long)st->rcode[i]);
+		metric_print_pop(metric, buf, (uint64_t)st->rcode[i]);
 	}
 
 	/* nsd_queries_by_transport_total */
 	metric_set_name_and_type(metric, "queries_by_transport_total", "counter");
 	metric_print_help(metric, buf, "Total number of queries received by transport.");
 	metric_push_label(metric, "transport", "udp");
-	metric_print_pop(metric, buf, (unsigned long)st->qudp);
+	metric_print_pop(metric, buf, (uint64_t)st->qudp);
 	metric_push_label(metric, "transport", "udp6");
-	metric_print_pop(metric, buf, (unsigned long)st->qudp6);
+	metric_print_pop(metric, buf, (uint64_t)st->qudp6);
 
 	/* nsd_queries_with_edns_total */
 	metric_set_name_and_type(metric, "queries_with_edns_total", "counter");
 	metric_print_help(metric, buf, "Total number of queries received with EDNS OPT.");
-	metric_print(metric, buf, (unsigned long)st->edns);
+	metric_print(metric, buf, (uint64_t)st->edns);
 
 	/* nsd_queries_with_edns_failed_total */
 	metric_set_name_and_type(metric, "queries_with_edns_failed_total", "counter");
 	metric_print_help(metric, buf, "Total number of queries received with EDNS OPT where EDNS parsing failed.");
-	metric_print(metric, buf, (unsigned long)st->ednserr);
+	metric_print(metric, buf, (uint64_t)st->ednserr);
 
 	/* nsd_connections_total */
 	metric_set_name_and_type(metric, "connections_total", "counter");
 	metric_print_help(metric, buf, "Total number of connections.");
 	metric_push_label(metric, "transport", "tcp");
-	metric_print_pop(metric, buf, (unsigned long)st->ctcp);
+	metric_print_pop(metric, buf, (uint64_t)st->ctcp);
 	metric_push_label(metric, "transport", "tcp6");
-	metric_print_pop(metric, buf, (unsigned long)st->ctcp6);
+	metric_print_pop(metric, buf, (uint64_t)st->ctcp6);
 	metric_push_label(metric, "transport", "tls");
-	metric_print_pop(metric, buf, (unsigned long)st->ctls);
+	metric_print_pop(metric, buf, (uint64_t)st->ctls);
 	metric_push_label(metric, "transport", "tls6");
-	metric_print_pop(metric, buf, (unsigned long)st->ctls6);
+	metric_print_pop(metric, buf, (uint64_t)st->ctls6);
 
 	/* nsd_xfr_requests_served_total */
 	metric_set_name_and_type(metric, "xfr_requests_served_total", "counter");
 	metric_print_help(metric, buf, "Total number of answered zone transfers.");
 	metric_push_label(metric, "xfrtype", "AXFR");
-	metric_print_pop(metric, buf, (unsigned long)st->raxfr);
+	metric_print_pop(metric, buf, (uint64_t)st->raxfr);
 	metric_push_label(metric, "xfrtype", "IXFR");
-	metric_print_pop(metric, buf, (unsigned long)st->rixfr);
+	metric_print_pop(metric, buf, (uint64_t)st->rixfr);
 
 	/* nsd_queries_dropped_total */
 	metric_set_name_and_type(metric, "queries_dropped_total", "counter");
 	metric_print_help(metric, buf, "Total number of dropped queries.");
-	metric_print(metric, buf, (unsigned long)st->dropped);
+	metric_print(metric, buf, (uint64_t)st->dropped);
 
 	/* nsd_queries_rx_failed_total */
 	metric_set_name_and_type(metric, "queries_rx_failed_total", "counter");
 	metric_print_help(metric, buf, "Total number of queries where receive failed.");
-	metric_print(metric, buf, (unsigned long)st->rxerr);
+	metric_print(metric, buf, (uint64_t)st->rxerr);
 
 	/* nsd_answers_tx_failed_total */
 	metric_set_name_and_type(metric, "answers_tx_failed_total", "counter");
 	metric_print_help(metric, buf, "Total number of answers where transmit failed.");
-	metric_print(metric, buf, (unsigned long)st->txerr);
+	metric_print(metric, buf, (uint64_t)st->txerr);
 
 	/* nsd_answers_without_aa_total */
 	metric_set_name_and_type(metric, "answers_without_aa_total", "counter");
 	metric_print_help(metric, buf, "Total number of NOERROR answers without AA flag set.");
-	metric_print(metric, buf, (unsigned long)st->nona);
+	metric_print(metric, buf, (uint64_t)st->nona);
 
 	/* nsd_answers_truncated_total */
 	metric_set_name_and_type(metric, "answers_truncated_total", "counter");
 	metric_print_help(metric, buf, "Total number of truncated answers.");
-	metric_print(metric, buf, (unsigned long)st->truncated);
+	metric_print(metric, buf, (uint64_t)st->truncated);
 }
 
 #ifdef USE_ZONE_STATS
@@ -586,7 +573,7 @@ metrics_zonestat_print_one(struct evbuffer *buf, char *name,
 	metric_set_name_and_type(&metric, "queries_total", "counter");
 	metric_print_help(&metric, buf, "Total number of queries received.");
 	metric_print(&metric, buf,
-		(unsigned long)(zst->qudp + zst->qudp6 + zst->ctcp +
+		(uint64_t)(zst->qudp + zst->qudp6 + zst->ctcp +
 			zst->ctcp6 + zst->ctls + zst->ctls6));
 	print_stat_block(buf, zst, &metric);
 }
@@ -600,24 +587,27 @@ metrics_print_stats(struct evbuffer *buf, xfrd_state_type *xfrd,
 	size_t i;
 	struct timeval elapsed, uptime;
 	struct metrics_metric metric;
-
-	/* nsd_queries_total */
-	print_metric_help_and_type(buf, "nsd_", "queries_total",
-	                           "Total number of queries received.", "counter");
-	/*per CPU and total*/
-	for(i=0; i<xfrd->nsd->child_count; i++) {
-		evbuffer_add_printf(buf, "nsd_queries_total{server=\"%d\"} %lu\n",
-			(int)i, (unsigned long)xfrd->nsd->children[i].query_count);
-	}
+	char server_str[16] = {0};
 
 	metric_init_with_prefix(&metric, "nsd_");
+
+	/* nsd_queries_total */
+	metric_set_name_and_type(&metric, "queries_total", "counter");
+	metric_print_help(&metric, buf, "Total number of queries received.");
+	/*per CPU and total*/
+	for(i=0; i<xfrd->nsd->child_count; i++) {
+		sprintf(server_str, "%d", (int)i);
+		metric_push_label(&metric, "server", server_str);
+		metric_print_pop(&metric, buf, (uint64_t)xfrd->nsd->children[i].query_count);
+	}
+
 	print_stat_block(buf, st, &metric);
 
 	/* uptime (in seconds) */
 	timeval_subtract(&uptime, now, &xfrd->nsd->metrics->boot_time);
-	print_metric_help_and_type(buf, "nsd_", "time_up_seconds_total",
-	                           "Uptime since server boot in seconds.", "counter");
-	evbuffer_add_printf(buf, "nsd_time_up_seconds_total %lu.%6.6lu\n",
+	metric_set_name_and_type(&metric, "time_up_seconds_total", "counter");
+	metric_print_help(&metric, buf, "Uptime since server boot in seconds.");
+	metric_print_micros(&metric, buf,
 		(unsigned long)uptime.tv_sec, (unsigned long)uptime.tv_usec);
 
 	/* time elapsed since last nsd-control stats reset (in seconds) */
@@ -628,48 +618,43 @@ metrics_print_stats(struct evbuffer *buf, xfrd_state_type *xfrd,
 	} else {
 		timeval_subtract(&elapsed, now, &xfrd->nsd->metrics->stats_time);
 	}
-	print_metric_help_and_type(buf, "nsd_", "time_elapsed_seconds",
-	                           "Time since last statistics printout and "
-	                           "reset (by nsd-control stats) in seconds.",
-	                           "untyped");
-	evbuffer_add_printf(buf, "nsd_time_elapsed_seconds %lu.%6.6lu\n",
+	metric_set_name_and_type(&metric, "time_elapsed_seconds", "untyped");
+	metric_print_help(&metric, buf,
+		"Time since last statistics printout and "
+	        "reset (by nsd-control stats) in seconds.");
+	metric_print_micros(&metric, buf,
 		(unsigned long)elapsed.tv_sec, (unsigned long)elapsed.tv_usec);
 
 	/*mem info, database on disksize*/
-	print_metric_help_and_type(buf, "nsd_", "size_db_on_disk_bytes",
-	                           "Size of DNS database on disk.", "gauge");
-	print_longnum(buf, "nsd_size_db_on_disk_bytes ", st->db_disk);
+	metric_set_name_and_type(&metric, "size_db_on_disk_bytes", "gauge");
+	metric_print_help(&metric, buf, "Size of DNS database on disk.");
+	metric_print(&metric, buf, st->db_disk);
 
-	print_metric_help_and_type(buf, "nsd_", "size_db_in_mem_bytes",
-	                           "Size of DNS database in memory.", "gauge");
-	print_longnum(buf, "nsd_size_db_in_mem_bytes ", st->db_mem);
+	metric_set_name_and_type(&metric, "size_db_in_mem_bytes", "gauge");
+	metric_print_help(&metric, buf, "Size of DNS database in memory.");
+	metric_print(&metric, buf, st->db_mem);
 
-	print_metric_help_and_type(buf, "nsd_", "size_xfrd_in_mem_bytes",
-	                           "Size of zone transfers and notifies in xfrd process, excluding TSIG data.",
-	                           "gauge");
-	print_longnum(buf, "nsd_size_xfrd_in_mem_bytes ", region_get_mem(xfrd->region));
+	metric_set_name_and_type(&metric, "size_xfrd_in_mem_bytes", "gauge");
+	metric_print_help(&metric, buf, "Size of zone transfers and notifies in xfrd process, excluding TSIG data.");
+	metric_print(&metric, buf, region_get_mem(xfrd->region));
 
-	print_metric_help_and_type(buf, "nsd_", "size_config_on_disk_bytes",
-	                           "Size of zonelist file on disk, excluding nsd.conf.",
-	                           "gauge");
-	print_longnum(buf, "nsd_size_config_on_disk_bytes ",
-		xfrd->nsd->options->zonelist_off);
+	metric_set_name_and_type(&metric, "size_config_on_disk_bytes", "gauge");
+	metric_print_help(&metric, buf, "Size of zonelist file on disk, excluding nsd.conf.");
+	metric_print(&metric, buf, xfrd->nsd->options->zonelist_off);
 
-	print_metric_help_and_type(buf, "nsd_", "size_config_in_mem_bytes",
-	                           "Size of config data in memory.", "gauge");
-	print_longnum(buf, "nsd_size_config_in_mem_bytes ", region_get_mem(
-		xfrd->nsd->options->region));
+	metric_set_name_and_type(&metric, "size_config_in_mem_bytes", "gauge");
+	metric_print_help(&metric, buf, "Size of config data in memory.");
+	metric_print(&metric, buf, region_get_mem(xfrd->nsd->options->region));
 
 	/* number of zones serverd */
-	print_metric_help_and_type(buf, "nsd_", "zones_primary",
-	                           "Number of primary zones served.", "gauge");
-	evbuffer_add_printf(buf, "nsd_zones_primary %lu\n",
-		(unsigned long)(xfrd->notify_zones->count - xfrd->zones->count));
+	metric_set_name_and_type(&metric, "zones_primary", "gauge");
+	metric_print_help(&metric, buf, "Number of primary zones served.");
+	metric_print(&metric, buf,
+		(uint64_t)(xfrd->notify_zones->count - xfrd->zones->count));
 
-	print_metric_help_and_type(buf, "nsd_", "zones_secondary",
-	                           "Number of secondary zones served.", "gauge");
-	evbuffer_add_printf(buf, "nsd_zones_secondary %lu\n",
-		(unsigned long)xfrd->zones->count);
+	metric_set_name_and_type(&metric, "zones_secondary", "gauge");
+	metric_print_help(&metric, buf, "Number of secondary zones served.");
+	metric_print(&metric, buf, (uint64_t)xfrd->zones->count);
 
 #ifdef USE_ZONE_STATS
 	zonestat_print(NULL, buf, xfrd, clear, zonestats); /*per-zone statistics*/

--- a/metrics.c
+++ b/metrics.c
@@ -349,17 +349,21 @@ metrics_http_callback(struct evhttp_request *req, void *p)
 }
 
 #ifdef BIND8_STATS
-/** Change disallowed characters to underscores '_'. */
-static void
-replace_disallowed_label_chars(char* value)
-{
-	/* Replace characters that are not allowed in quoted label values. */
-	char* s = value;
+const char*
+metrics_validate_label_value(const char* value) {
+	const char* s = value;
 	while(*s) {
-		if (*s == '\\' || *s == '\n' || *s == '"')
-			*s = '_';
+		switch (*s) {
+			case '\\':
+				return "character '\\' is not allowed";
+			case '"':
+				return "charater '\"' is not allowed";
+			case '\n':
+				return "newline is not allowed";
+		}
 		s++;
 	}
+	return NULL;
 }
 
 #define METRIC_MAX_LABELS 2
@@ -565,8 +569,7 @@ metrics_zonestat_print_one(struct evbuffer *buf, char *name,
 {
 	struct metrics_metric metric;
 	metric_init_with_prefix(&metric, "nsd_zonestats_");
-	/* TODO: Can we instead validate at startup? */
-	replace_disallowed_label_chars(name);
+	/* The zonestat name is validated at startup to be a valid label value. */
 	metric_push_label(&metric, "zone", name);
 
 	metric_set_name_and_type(&metric, "queries_total", "counter");

--- a/metrics.h
+++ b/metrics.h
@@ -62,18 +62,18 @@ void daemon_metrics_attach(struct daemon_metrics* m, struct xfrd_state* xfrd);
 #ifdef BIND8_STATS
 
 /**
- * Check that a Prometheus label value contains no disallowed characters.
+ * Replace characters disallowed in Prometheus label values with '_'.
  *
  * According to [1], label values can be any UTF-8 characters, but backslash,
- * double-quote, and line feed must be escaped. We could do full validation but
- * in practice for zonestats names you don't need these characters anyway so we
- * just ban them.
+ * double-quote, and line feed must be escaped. We could escape them bad that
+ * changes the length of the string, and in practice for zonestats names you
+ * don't need these characters anyway so we just replace them.
  * [1]: https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information>
  *
- * @param value: the label value to validate.
- * @return NULL on success or the failure reason on error.
+ * @param value: the label value to edit.
+ * @return 1 if any changes were needed, 0 if the value was already valid.
  */
-const char* metrics_validate_label_value(const char* value);
+int metrics_make_label_value_valid(char* value);
 
 /**
  * Print stats as prometheus metrics to HTTP buffer

--- a/metrics.h
+++ b/metrics.h
@@ -65,7 +65,7 @@ void daemon_metrics_attach(struct daemon_metrics* m, struct xfrd_state* xfrd);
  * Replace characters disallowed in Prometheus label values with '_'.
  *
  * According to [1], label values can be any UTF-8 characters, but backslash,
- * double-quote, and line feed must be escaped. We could escape them bad that
+ * double-quote, and line feed must be escaped. We could escape them but that
  * changes the length of the string, and in practice for zonestats names you
  * don't need these characters anyway so we just replace them.
  * [1]: https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information>

--- a/metrics.h
+++ b/metrics.h
@@ -60,6 +60,21 @@ int daemon_metrics_open_ports(struct daemon_metrics* m,
 void daemon_metrics_attach(struct daemon_metrics* m, struct xfrd_state* xfrd);
 
 #ifdef BIND8_STATS
+
+/**
+ * Check that a Prometheus label value contains no disallowed characters.
+ *
+ * According to [1], label values can be any UTF-8 characters, but backslash,
+ * double-quote, and line feed must be escaped. We could do full validation but
+ * in practice for zonestats names you don't need these characters anyway so we
+ * just ban them.
+ * [1]: https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information>
+ *
+ * @param value: the label value to validate.
+ * @return NULL on success or the failure reason on error.
+ */
+const char* metrics_validate_label_value(const char* value);
+
 /**
  * Print stats as prometheus metrics to HTTP buffer
  * @param buf: the HTTP buffer to write to

--- a/options.c
+++ b/options.c
@@ -2942,6 +2942,8 @@ unsigned getzonestatid(struct nsd_options* opt, struct zone_options* zopt)
 {
 #ifdef USE_ZONE_STATS
 	const char* statname;
+	char* statname_valid;
+	int name_was_modified;
 	struct zonestatname* n;
 	rbnode_type* res;
 	/* try to find the instantiated zonestat name */
@@ -2949,12 +2951,19 @@ unsigned getzonestatid(struct nsd_options* opt, struct zone_options* zopt)
 		return 0; /* no zone stats */
 	statname = config_cook_string(zopt, zopt->pattern->zonestats);
 
-	const char* statname_error = metrics_validate_label_value(statname);
-	if (statname_error) {
-		log_msg(LOG_ERR, "invalid zonestats name \"%s\": %s",
-			statname, statname_error);
+	/* warn when we will lossily change the zonestat name in metrics */
+	statname_valid = strdup(statname);
+	if(!statname_valid) {
+		log_msg(LOG_ERR, "malloc failed: %s", strerror(errno));
 		exit(1);
 	}
+	name_was_modified = metrics_make_label_value_valid(statname_valid);
+	if (name_was_modified) {
+		log_msg(LOG_WARNING, "zonestats name \"%s\" contains disallowed characters, using \"%s\" in metrics",
+			statname, statname_valid);
+	}
+	free(statname_valid);
+
 	res = rbtree_search(opt->zonestatnames, statname);
 	if(res)
 		return ((struct zonestatname*)res)->id;

--- a/options.c
+++ b/options.c
@@ -29,6 +29,7 @@
 #include "rrl.h"
 #include "bitset.h"
 #include "xfrd.h"
+#include "metrics.h"
 
 #include "configparser.h"
 config_parser_state_type* cfg_parser = 0;
@@ -2947,6 +2948,13 @@ unsigned getzonestatid(struct nsd_options* opt, struct zone_options* zopt)
 	if(!zopt->pattern->zonestats || zopt->pattern->zonestats[0]==0)
 		return 0; /* no zone stats */
 	statname = config_cook_string(zopt, zopt->pattern->zonestats);
+
+	const char* statname_error = metrics_validate_label_value(statname);
+	if (statname_error) {
+		log_msg(LOG_ERR, "invalid zonestats name \"%s\": %s",
+			statname, statname_error);
+		exit(1);
+	}
 	res = rbtree_search(opt->zonestatnames, statname);
 	if(res)
 		return ((struct zonestatname*)res)->id;

--- a/tpkg/prometheus_metrics.tdir/prometheus_metrics.test
+++ b/tpkg/prometheus_metrics.tdir/prometheus_metrics.test
@@ -86,7 +86,7 @@ else
 fi
 
 # check zonestats metrics
-if grep -Fx "nsd_zonestats_examplestats_queries_by_type_total{type=\"NS\"} $NUM_NS_QUERIES" metrics.out; then
+if grep -Fx "nsd_zonestats_queries_by_type_total{zone=\"examplestats\",type=\"NS\"} $NUM_NS_QUERIES" metrics.out; then
 	echo "OK"
 else
 	echo "FAIL"
@@ -127,7 +127,7 @@ else
 	exit 1
 fi
 
-if grep -Fx "nsd_zonestats_examplestats_queries_by_type_total{type=\"NS\"} 0" metrics.out2; then
+if grep -Fx "nsd_zonestats_queries_by_type_total{zone=\"examplestats\",type=\"NS\"} 0" metrics.out2; then
 	echo "OK"
 else
 	echo "FAIL"

--- a/tpkg/prometheus_metrics_without_remote_control.tdir/prometheus_metrics_without_remote_control.test
+++ b/tpkg/prometheus_metrics_without_remote_control.tdir/prometheus_metrics_without_remote_control.test
@@ -83,7 +83,7 @@ else
 fi
 
 # check zonestats metrics
-if grep -Fx "nsd_zonestats_examplestats_queries_by_type_total{type=\"NS\"} $NUM_NS_QUERIES" metrics.out; then
+if grep -Fx "nsd_zonestats_queries_by_type_total{zone=\"examplestats\",type=\"NS\"} $NUM_NS_QUERIES" metrics.out; then
 	echo "OK"
 else
 	echo "FAIL"


### PR DESCRIPTION
This implements the change proposed in #482, moving the zonestats name out of the metric name and into a label.

This pull request is structured in separate commits that can be reviewed one at a time.

* The first commit introduces a helper struct to format metrics with labels. This is only a refactor, no behavioral changes.
* It’s not really needed to use the helper everywhere because some metrics don’t need labels, but I thought it would be nicer for consistency, so in the second commit I switch all Prometheus metrics to use the helper.
   * Instead of `print_longnum`, I use a `PRIu64` format string, which is used in the codebase already, but only in one place. Does `print_longnum` exist only for historical reasons, or is it important to only use `%lu` in format strings?
   * Up to this point the output should not change, and I verified this by diffing the `/metrics` response on a binary built from `master` vs. this commit.
* Then move the zonestats name out of the prefix and into a label, which is now a very small change.
* I thought that instead of silently replacing disallowed characters in the zonestats name, it would be nicer to fail on it. I implemented that in the final commit, but it’s only validated at startup. It would be nice if `nsd-checkconf` could catch it already, but this is a bit tricky because the zonestats name can be a template like `%s` and we have to validate after applying the template, which looks like it would be a larger change to `nsd-checkconf`, so I’m not sure if that’s worth it.

I tested locally with Prometheus 3.11.2 that it can still parse the `/metrics` response, and it can.