### PR TITLE
OpenRC: fix network deps and support both supervisors

### DIFF
--- a/contrib/nsd.openrc.conf
+++ b/contrib/nsd.openrc.conf
@@ -1,2 +1,8 @@
 # Extra command-line arguments to pass to the NSD daemon.
 #NSD_EXTRA_OPTS=""
+
+# NSD runs under both the classic start-stop-daemon and the more
+# modern supervise-daemon. Below we default to supervise-daemon, but
+# only if $supervisor is unset. If you prefer start-stop-daemon,
+# comment out the following line.
+: ${supervisor:=supervise-daemon}

--- a/contrib/nsd.openrc.in
+++ b/contrib/nsd.openrc.in
@@ -28,7 +28,6 @@ required_files="${config_file}"
 
 depend() {
 	use logger
-	need net
 }
 
 checkconfig() {

--- a/contrib/nsd.openrc.in
+++ b/contrib/nsd.openrc.in
@@ -1,5 +1,4 @@
 #!/sbin/openrc-run
-supervisor=supervise-daemon
 
 description="The NLnet Labs Name Server Daemon (NSD)"
 extra_commands="configtest"

--- a/contrib/nsd.openrc.in
+++ b/contrib/nsd.openrc.in
@@ -66,6 +66,13 @@ stop_pre() {
 reload() {
 	checkconfig || return $?
 	ebegin "Reloading config and zone files"
-	supervise-daemon "${RC_SVCNAME}" -s SIGHUP
+	case "${supervisor}" in
+		supervise-daemon)
+			supervise-daemon "${RC_SVCNAME}" -s SIGHUP
+			;;
+		*)
+			start-stop-daemon --signal HUP --pidfile "${pidfile}"
+			;;
+	esac
 	eend $?
 }


### PR DESCRIPTION
1. Remove `need net` from the service dependencies. it's almost always wrong, and is in this case (the commit message explains why).
2. Support both start-stop-daemon _and_ supervise-daemon by moving the `supervisor=` line into the conf file. There are some things that s-s-d does that supervise-daemon still cannot do.

cc @lanodan 