### PR TITLE
Correctly load tls-cert-bundle with chroot

### DIFF
--- a/nsd.c
+++ b/nsd.c
@@ -1395,6 +1395,9 @@ main(int argc, char *argv[])
 		} else if (!file_inside_chroot(nsd.options->xfrdir, nsd.chrootdir)) {
 			error("xfrdir %s is not relative to %s: chroot not possible",
 				nsd.options->xfrdir, nsd.chrootdir);
+		} else if (!file_inside_chroot(nsd.options->tls_cert_bundle, nsd.chrootdir)) {
+			error("tls-cert-bundle %s is not relative to %s: chroot not possible",
+				nsd.options->tls_cert_bundle, nsd.chrootdir);
 		}
 	}
 
@@ -1602,6 +1605,9 @@ main(int argc, char *argv[])
 			nsd.options->zonelistfile += l;
 		if (nsd.options->xfrdir[0] == '/')
 			nsd.options->xfrdir += l;
+		if (nsd.options->tls_cert_bundle && nsd.options->tls_cert_bundle[0] == '/') {
+			nsd.options->tls_cert_bundle += l;
+		}
 
 		/* strip chroot from pathnames of "include:" statements
 		 * on subsequent repattern commands */

--- a/options.c
+++ b/options.c
@@ -1995,6 +1995,27 @@ acl_check_incoming(struct acl_options* acl, struct query* q,
 			(acl->blocked?"BLOCKED":acl->key_name)));
 #endif
 		if(acl_addr_matches(acl, q) && acl_key_matches(acl, q)) {
+#ifdef HAVE_SSL
+			/* we are in a acl with tls_auth */
+			if (acl->tls_auth_name && q->tls_auth) {
+				/* we have auth_domain_name in tls_auth */
+				if (acl->tls_auth_options && acl->tls_auth_options->auth_domain_name) {
+					if (!acl_tls_hostname_matches(q->tls_auth, acl->tls_auth_options->auth_domain_name)) {
+						VERBOSITY(3, (LOG_WARNING,
+								"client cert does not match %s %s",
+								acl->tls_auth_name, acl->tls_auth_options->auth_domain_name));
+						q->cert_cn = NULL;
+						return -1;
+					}
+					VERBOSITY(5, (LOG_INFO, "%s %s verified",
+						acl->tls_auth_name, acl->tls_auth_options->auth_domain_name));
+					q->cert_cn = acl->tls_auth_options->auth_domain_name;
+				} else {
+					/* nsd gives error on start for this, but check just in case */
+					log_msg(LOG_ERR, "auth-domain-name not defined in %s", acl->tls_auth_name);
+				}
+			}
+#endif
 			if(!match)
 			{
 				match = acl; /* remember first match */
@@ -2006,27 +2027,6 @@ acl_check_incoming(struct acl_options* acl, struct query* q,
 				return -1;
 			}
 		}
-#ifdef HAVE_SSL
-		/* we are in a acl with tls_auth */
-		if (acl->tls_auth_name && q->tls_auth) {
-			/* we have auth_domain_name in tls_auth */
-			if (acl->tls_auth_options && acl->tls_auth_options->auth_domain_name) {
-				if (!acl_tls_hostname_matches(q->tls_auth, acl->tls_auth_options->auth_domain_name)) {
-					VERBOSITY(3, (LOG_WARNING,
-							"client cert does not match %s %s",
-							acl->tls_auth_name, acl->tls_auth_options->auth_domain_name));
-					q->cert_cn = NULL;
-					return -1;
-				}
-				VERBOSITY(5, (LOG_INFO, "%s %s verified",
-					acl->tls_auth_name, acl->tls_auth_options->auth_domain_name));
-				q->cert_cn = acl->tls_auth_options->auth_domain_name;
-			} else {
-				/* nsd gives error on start for this, but check just in case */
-				log_msg(LOG_ERR, "auth-domain-name not defined in %s", acl->tls_auth_name);
-			}
-		}
-#endif
 		number++;
 		acl = acl->next;
 	}


### PR DESCRIPTION
I've noticed an error about the `tls-cert-bundle`
`xfrd tls: Unable to set the certificate bundle file /var/nsd/etc/cert-bundle.pem`

I see that this comes from
```
server_start_xfrd()
  -> xfrd_init()
     -> xfrd_tcp_set_create()
         -> SSL_CTX_load_verify_locations()
```
which is happening after chroot

