### PR TITLE
Replace SSLv23 methods with TLS methods

### DIFF
--- a/dnstap/dnstap.c
+++ b/dnstap/dnstap.c
@@ -162,7 +162,7 @@ tls_writer_init(char* ip, char* tls_server_name, char* tls_cert_bundle,
 		free(dtw);
 		return NULL;
 	}
-	dtw->ctx = SSL_CTX_new(SSLv23_client_method());
+	dtw->ctx = SSL_CTX_new(TLS_client_method());
 	if(!dtw->ctx) {
 		log_msg(LOG_ERR, "dnstap: SSL_CTX_new failed");
 		free(dtw->ip);

--- a/nsd-control.c
+++ b/nsd-control.c
@@ -186,7 +186,7 @@ setup_ctx(struct nsd_options* cfg)
 				cfg->zonesdir, strerror(errno));
 	}
 
-        ctx = SSL_CTX_new(SSLv23_client_method());
+        ctx = SSL_CTX_new(TLS_client_method());
 	if(!ctx)
 		ssl_err("could not allocate SSL_CTX pointer");
 #if SSL_OP_NO_SSLv2 != 0

--- a/server.c
+++ b/server.c
@@ -2140,7 +2140,7 @@ server_alpn_cb(SSL* ATTR_UNUSED(s),
 SSL_CTX*
 server_tls_ctx_setup(char* key, char* pem, char* verifypem)
 {
-	SSL_CTX *ctx = SSL_CTX_new(SSLv23_server_method());
+	SSL_CTX *ctx = SSL_CTX_new(TLS_server_method());
 	if(!ctx) {
 		log_crypto_err("could not SSL_CTX_new");
 		return NULL;


### PR DESCRIPTION
With https://github.com/openssl/openssl/pull/30128 OpenSSL v 4.0 has fixed TLS version methods removed.

SSLv23_method(), SSLv23_server_method() and SSLv23_client_method() were deprecated
and the preferred TLS_method(), TLS_server_method() and TLS_client_method()
functions were added in OpenSSL 1.1.0.

Aliases were created 11 years ago.
[(https://github.com/openssl/openssl/blob/d099e33e5733bb9d3975fc4f3ac4a85b6ed1a4cb/include/openssl/ssl.h.in#L2044-L2046)](https://github.com/openssl/openssl/blame/d099e33e5733bb9d3975fc4f3ac4a85b6ed1a4cb/include/openssl/ssl.h.in#L2044-L2046)
