### PR TITLE
Bug: Server should check only specific tls-auth

### DIFF
--- a/options.c
+++ b/options.c
@@ -2025,6 +2025,27 @@ acl_check_incoming(struct acl_options* acl, struct query* q,
 		}
 #endif
 		if(acl_addr_matches(acl, q) && acl_key_matches(acl, q)) {
+#ifdef HAVE_SSL
+			/* we are in a acl with tls_auth */
+			if (acl->tls_auth_name) {
+				/* we have auth_domain_name in tls_auth */
+				if (acl->tls_auth_options && acl->tls_auth_options->auth_domain_name) {
+					if (!acl_tls_hostname_matches(q->tls_auth, acl->tls_auth_options->auth_domain_name)) {
+						VERBOSITY(3, (LOG_WARNING,
+								"client cert does not match %s %s",
+								acl->tls_auth_name, acl->tls_auth_options->auth_domain_name));
+						q->cert_cn = NULL;
+						return -1;
+					}
+					VERBOSITY(5, (LOG_INFO, "%s %s verified",
+						acl->tls_auth_name, acl->tls_auth_options->auth_domain_name));
+					q->cert_cn = acl->tls_auth_options->auth_domain_name;
+				} else {
+					/* nsd gives error on start for this, but check just in case */
+					log_msg(LOG_ERR, "auth-domain-name not defined in %s", acl->tls_auth_name);
+				}
+			}
+#endif
 			if(!match)
 			{
 				match = acl; /* remember first match */
@@ -2036,27 +2057,6 @@ acl_check_incoming(struct acl_options* acl, struct query* q,
 				return -1;
 			}
 		}
-#ifdef HAVE_SSL
-		/* we are in a acl with tls_auth */
-		if (acl->tls_auth_name) {
-			/* we have auth_domain_name in tls_auth */
-			if (acl->tls_auth_options && acl->tls_auth_options->auth_domain_name) {
-				if (!acl_tls_hostname_matches(q->tls_auth, acl->tls_auth_options->auth_domain_name)) {
-					VERBOSITY(3, (LOG_WARNING,
-							"client cert does not match %s %s",
-							acl->tls_auth_name, acl->tls_auth_options->auth_domain_name));
-					q->cert_cn = NULL;
-					return -1;
-				}
-				VERBOSITY(5, (LOG_INFO, "%s %s verified",
-					acl->tls_auth_name, acl->tls_auth_options->auth_domain_name));
-				q->cert_cn = acl->tls_auth_options->auth_domain_name;
-			} else {
-				/* nsd gives error on start for this, but check just in case */
-				log_msg(LOG_ERR, "auth-domain-name not defined in %s", acl->tls_auth_name);
-			}
-		}
-#endif
 		number++;
 		acl = acl->next;
 	}


### PR DESCRIPTION
If you have a zone with multiple acls on provide-xfr with tls-auth like this:

```
tls-auth:
       name: "tls-auth-1"
       auth-domain-name: "sec1.example.com"

tls-auth:
       name: "tls-auth-2"
       auth-domain-name: "sec2.example.com"

zone:
       name: example.com
       provide-xfr: 1.2.3.4 tsig1 tls-auth-1
       provide-xfr: 2.3.4.5 tsig2 tls-auth-2
```
server is checking ACLs independently of tls-auth. 

So in this case, when secondary 2.3.4.5 (sec2.example.com) connects with tls-auth for zone transfer,
acl checks first for IP and tsig key. After that we have the SSL check.
Server searches first for `auth-domain-name` of `tls-auth-1` and it fails.

Server should not check other tls-auth definitions.
If an IP is matched in a specific ACL, check that specific tls-auth that is defined in that specific ACL.

Effectively this is only a logic change (no code change) and we move the TLS AUTH check code inside 
`if(acl_addr_matches(acl, q) && acl_key_matches(acl, q)) {`
and not after it.