### PR TITLE
Include inttypes.h from metrics.c

### DIFF
--- a/metrics.c
+++ b/metrics.c
@@ -19,6 +19,7 @@
 #include <event2/event.h>
 #include <event2/http.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include "nsd.h"
 #include "xfrd.h"


### PR DESCRIPTION
I broke the build in at least one context in #483 by adding a use of `PRIu64` without including `inttypes.h`. Although it compiled on an Arch installation with both Clang and GCC, when I tried to package NSD 4.15.0 in Nixpkgs, the compiler complained:

```
metrics.c: In function 'metric_print':
metrics.c:402:47: error: expected ')' before 'PRIu64'
  402 |                 evbuffer_add_printf(buf, "} %" PRIu64 "\n", value);
      |                                    ~          ^~~~~~~
      |                                               )
metrics.c:28:1: note: 'PRIu64' is defined in header '<inttypes.h>'; this is probably fixable by adding '#include <inttypes.h>'
   27 | #include "metrics.h"
  +++ |+#include <inttypes.h>
   28 | 
metrics.c:402:45: warning: spurious trailing '%' in format [-Wformat=]
  402 |                 evbuffer_add_printf(buf, "} %" PRIu64 "\n", value);
      |                                             ^
metrics.c:404:46: error: expected ')' before 'PRIu64'
  404 |                 evbuffer_add_printf(buf, " %" PRIu64 "\n", value);
      |                                    ~         ^~~~~~~
      |                                              )
metrics.c:404:47: note: 'PRIu64' is defined in header '<inttypes.h>'; this is probably fixable by adding '#include <inttypes.h>'
  404 |                 evbuffer_add_printf(buf, " %" PRIu64 "\n", value);
      |                                               ^~~~~~
metrics.c:404:44: warning: spurious trailing '%' in format [-Wformat=]
  404 |                 evbuffer_add_printf(buf, " %" PRIu64 "\n", value);
      |                                            ^
```

Add the missing include. I confirmed that with this change, the package compiles in Nixpkgs.

(It seems this is not the first time this snuck in, 9a1a5ed7ae928ff5fb75ef7798832158bc996df1 and 70a099e3666afa245f493520858979914703ae2e are similar fixes. I don’t know if it affects Ubuntu too, but if it does, it was not caught in CI because [the configuration tested there](https://github.com/NLnetLabs/nsd/blob/051423f24bb3700d504e06214be7518633518bcd/.github/workflows/build-test.yml#L55) does not include `--enable-zone-stats` and `--enable-bind8-stats`. If resources allow it, maybe it’s a good idea to test more configurations?)