### PR TITLE
Fix TLS ALPN selection to only accept "dot" (#476)

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,9 @@
+26 July 2026: Jared
+	- Fix TLS ALPN selection to only accept "dot" (DNS-over-TLS).
+	  Previously OPENSSL_NPN_NO_OVERLAP was ignored, so a client that
+	  offered only HTTP-related ALPNs could have that protocol selected.
+	  Thanks to Andreas Schulze for the report (GitHub #476).
+
 16 July 2026: Willem
 	- Merge #500: Support for the "oots" SVCB Service Parameter Key
 

--- a/server.c
+++ b/server.c
@@ -2129,10 +2129,20 @@ server_alpn_cb(SSL* ATTR_UNUSED(s),
 		const unsigned char* in, unsigned int inlen,
 		void* ATTR_UNUSED(arg))
 {
+	/* Only DNS-over-TLS ("dot"). Do not accept unrelated client ALPNs
+	 * (h2, http/1.1, spdy, ...): SSL_select_next_proto returns the first
+	 * client protocol on OPENSSL_NPN_NO_OVERLAP. */
 	static const unsigned char alpns[] = { 3, 'd', 'o', 't' };
 	unsigned char* tmp_out;
+	int ret;
 
-	SSL_select_next_proto(&tmp_out, outlen, alpns, sizeof(alpns), in, inlen);
+	ret = SSL_select_next_proto(&tmp_out, outlen, alpns, sizeof(alpns),
+		in, inlen);
+	if(ret == OPENSSL_NPN_NO_OVERLAP) {
+		/* Client sent ALPN but no overlap with "dot". Continue
+		 * without ALPN rather than selecting a non-DNS protocol. */
+		return SSL_TLSEXT_ERR_NOACK;
+	}
 	*out = tmp_out;
 	return SSL_TLSEXT_ERR_OK;
 }


### PR DESCRIPTION
Handle OPENSSL_NPN_NO_OVERLAP so HTTP-related client ALPNs are not selected when negotiating DNS-over-TLS.