### PR TITLE
Add SM2SM3 and ECC-GOST12 DNSSEC algorithm names (#473)

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,9 @@
+26 July 2026: Jared
+	- Recognize DNSSEC algorithms SM2SM3 (17, RFC 9563) and ECC-GOST12
+	  (23, RFC 9558) in presentation and zone parsing, and recognize
+	  ED25519/ED448 mnemonics in simdzone. Mark ECC-GOST (12) as obsolete.
+	  Based on a patch by Igor V. Ruzanov (GitHub #473).
+
 16 July 2026: Willem
 	- Merge #500: Support for the "oots" SVCB Service Parameter Key
 

--- a/rdata.c
+++ b/rdata.c
@@ -58,11 +58,13 @@ lookup_table_type dns_algorithms[] = {
 	{ 7, "RSASHA1-NSEC3-SHA1" },	/* RFC 5155 */
 	{ 8, "RSASHA256" },		/* RFC 5702 */
 	{ 10, "RSASHA512" },		/* RFC 5702 */
-	{ 12, "ECC-GOST" },		/* RFC 5933 */
+	{ 12, "ECC-GOST" },		/* RFC 5933, obsolete (RFC 9906) */
 	{ 13, "ECDSAP256SHA256" },	/* RFC 6605 */
 	{ 14, "ECDSAP384SHA384" },	/* RFC 6605 */
 	{ 15, "ED25519" },		/* RFC 8080 */
 	{ 16, "ED448" },		/* RFC 8080 */
+	{ 17, "SM2SM3" },		/* RFC 9563 */
+	{ 23, "ECC-GOST12" },		/* RFC 9558 */
 	{ 252, "INDIRECT" },
 	{ 253, "PRIVATEDNS" },
 	{ 254, "PRIVATEOID" },


### PR DESCRIPTION
Recognize algorithms 17 (SM2SM3, RFC 9563) and 23 (ECC-GOST12, RFC 9558) in presentation format and zone parsing, and teach simdzone the ED25519 and ED448 mnemonics as well. Mark algorithm 12 (ECC-GOST) as obsolete.

Thanks to Igor V. Ruzanov (iruzanov) for the patch and report.