### PR TITLE
Add "Wants" dependency to systemd service

### DIFF
--- a/contrib/nsd.service
+++ b/contrib/nsd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=NSD DNS Server
 After=syslog.target network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
Having an actual "Wants" dependency is generally considered good hygiene in systemd services, as a dependency with "After" only ensures that the service gets started after "network-online.target", but it does not necessarily ensure that "network-online.target" is started at all.

Practically speaking, it should not matter a lot, because there will most likely be another dependency on the systemd that makes use of "network-online.target", but defining it explicitly is still good practice in my opinion, as well as the opinion of various downstream distributions.