### PR TITLE
Fix to retry a catalog consumer zone over AXFR if IXFR didn't apply

### DIFF
--- a/tpkg/catzone-recovery.tdir/catzone-recovery.conf.in
+++ b/tpkg/catzone-recovery.tdir/catzone-recovery.conf.in
@@ -1,0 +1,24 @@
+server:
+	logfile: "nsd.log"
+	pidfile: "nsd.pid"
+	username: ""
+	zonesdir: ""
+	zonelistfile: "zones.list"
+	xfrdfile: "nsd.xfrd"
+	interface: 127.0.0.1
+	verbosity: 6
+
+remote-control:
+	control-enable: yes
+	control-interface: @PWD@/nsd.sock
+
+pattern:
+	name: "from-testns"
+	request-xfr: 127.0.0.1@@TESTNS_PORT@ NOKEY
+	allow-notify: 127.0.0.1 NOKEY
+
+zone:
+	name: catalog.invalid.
+	include-pattern: "from-testns"
+	catalog: consumer
+	catalog-member-pattern: "from-testns"

--- a/tpkg/catzone-recovery.tdir/catzone-recovery.dsc
+++ b/tpkg/catzone-recovery.tdir/catzone-recovery.dsc
@@ -1,0 +1,17 @@
+BaseName: catzone-recovery
+Version: 1.0
+Description: Check recovery of invalid catalog zone due to transfer issues
+CreationDate: wo  8 sep 2026 15:47:55 CEST
+Maintainer: Willem Toorop
+Category:
+Component:
+CmdDepends:
+Depends:
+Help: catzone-recovery.help
+Pre: catzone-recovery.pre
+Post: catzone-recovery.post
+Test: catzone-recovery.test
+AuxFiles: catzone-recovery.conf.in catzone-recovery.testns
+	catzone-recovery.testns-badfeed catzone-recovery.testns-badfeef
+Passed:
+Failure:

--- a/tpkg/catzone-recovery.tdir/catzone-recovery.help
+++ b/tpkg/catzone-recovery.tdir/catzone-recovery.help
@@ -1,0 +1,4 @@
+This test requires a specially for the purpose compiled version of NSD with
+modifications in the main code.  The additional code is available on the
+features/testing-code branch.  With this branch is merged in, the additional
+code needs to be enabled with the `enable-testing` option to configure.

--- a/tpkg/catzone-recovery.tdir/catzone-recovery.post
+++ b/tpkg/catzone-recovery.tdir/catzone-recovery.post
@@ -1,0 +1,10 @@
+# #-- catzone-recovery.post --#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# source the test var file when it's there
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+#
+# do your teardown here
+. ../common.sh
+kill_pid $TESTNS_PID
+kill_from_pidfile nsd.pid

--- a/tpkg/catzone-recovery.tdir/catzone-recovery.pre
+++ b/tpkg/catzone-recovery.tdir/catzone-recovery.pre
@@ -1,0 +1,26 @@
+# #-- catzone-recovery.pre--#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+PRE="../.."
+TPKG_NSD="$PRE/nsd"
+
+get_random_port 2
+TPKG_PORT=$RND_PORT
+TESTNS_PORT=`expr $RND_PORT + 1`
+sed -e "s/@TESTNS_PORT@/${TESTNS_PORT}/" \
+    -e "s#@PWD@#$(pwd)#g" < catzone-recovery.conf.in > edit.conf
+
+ldns-testns -v -p ${TESTNS_PORT} catzone-recovery.testns >testns.log 2>&1 &
+TESTNS_PID=$!
+
+# share the vars
+echo "export TPKG_PORT=$TPKG_PORT" >> .tpkg.var.test
+echo "export TESTNS_PORT=$TESTNS_PORT" >> .tpkg.var.test
+echo "export TESTNS_PID=$TESTNS_PID" >> .tpkg.var.test
+
+$TPKG_NSD -c edit.conf -p $TPKG_PORT
+wait_nsd_up nsd.log
+

--- a/tpkg/catzone-recovery.tdir/catzone-recovery.test
+++ b/tpkg/catzone-recovery.tdir/catzone-recovery.test
@@ -1,0 +1,87 @@
+# #-- catzone-recovery.test --#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+. ../common.sh
+PRE="../.."
+TPKG_CONTROL="$PRE/nsd-control -c edit.conf"
+if ! $TPKG_CONTROL testing xfrd on; then
+	echo "Non testing build. Skip testing"
+	exit 0
+fi
+wait_logfile nsd.log "zone catalog.invalid. serial 0 is updated to 1" 3
+wait_logfile nsd.log "zone one.invalid serial 0 is updated to 1" 3
+
+$TPKG_CONTROL zonestatus > zonestatus.1.out 2>&1
+echo ""
+echo "Status at serial 1"
+echo "=================="
+cat zonestatus.1.out
+
+# Equip next version of the zones at the primary
+#
+kill_pid $TESTNS_PID
+sleep .1
+ldns-testns -v -p ${TESTNS_PORT} catzone-recovery.testns-badfeed >testns-badfeed.log 2>&1 &
+TESTNS_PID=$!
+echo "export TESTNS_PID=$TESTNS_PID" >> .tpkg.var.test
+wait_logfile testns-badfeed.log "Listening on port ${TESTNS_PORT}" 3
+ldns-notify -z catalog.invalid -s 195952365 -p $TPKG_PORT 127.0.0.1 > ldns-notify.badfeed.out 2>&1
+
+wait_logfile nsd.log " is updated to 195952365" 3
+# Retry transfer over AXFR may take a second
+for i in {1..10}; do
+	sleep .1
+	if $TPKG_CONTROL zonestatus | grep -q catalog-invalid; then
+		:
+	else
+		break
+	fi
+done
+
+$TPKG_CONTROL zonestatus > zonestatus.badfeed.out 2>&1
+echo ""
+echo "Status at serial 0xBADFEED"
+echo "=========================="
+cat zonestatus.badfeed.out
+
+# Equip next version of the zones at the primary
+#
+kill_pid $TESTNS_PID
+sleep .1
+ldns-testns -v -p ${TESTNS_PORT} catzone-recovery.testns-badfeef >testns-badfeef.log 2>&1 &
+TESTNS_PID=$!
+echo "export TESTNS_PID=$TESTNS_PID" >> .tpkg.var.test
+wait_logfile testns-badfeef.log "Listening on port ${TESTNS_PORT}" 3
+ldns-notify -z catalog.invalid -s 195952367 -p $TPKG_PORT 127.0.0.1 > ldns-notify.badfeef.out 2>&1
+wait_logfile nsd.log " is updated to 195952367" 3
+
+# Retry transfer over AXFR may take a second
+for i in {1..10}; do
+	sleep .1
+	if $TPKG_CONTROL zonestatus | grep -q catalog-invalid; then
+		:
+	else
+		break
+	fi
+done
+
+$TPKG_CONTROL zonestatus > zonestatus.badfeef.out 2>&1
+echo ""
+echo "Status at serial 0xBADFEEF"
+echo "=========================="
+cat zonestatus.badfeef.out
+echo ""
+
+if $TPKG_CONTROL zonestatus | grep -q catalog-invalid; then
+	echo '!ERROR: Catalog zone did not recover from transfer issues'
+	echo ''
+	#cat .tpkg.var.test
+	#echo "cd `pwd`"
+	#read
+	exit 1
+else
+	exit 0
+fi
+

--- a/tpkg/catzone-recovery.tdir/catzone-recovery.testns
+++ b/tpkg/catzone-recovery.tdir/catzone-recovery.testns
@@ -1,0 +1,30 @@
+$TTL 3600
+
+$ORIGIN catalog.invalid.
+ENTRY_BEGIN
+MATCH opcode qtype qname
+MATCH TCP
+REPLY QUERY NOERROR
+ADJUST copy_id
+SECTION QUESTION
+@ AXFR
+SECTION ANSWER
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+version TXT "2"
+1.zones PTR one.invalid.
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+ENTRY_END
+
+$ORIGIN one.invalid.
+ENTRY_BEGIN
+MATCH opcode qtype qname
+MATCH TCP
+REPLY QUERY NOERROR
+ADJUST copy_id
+SECTION QUESTION
+@ AXFR
+SECTION ANSWER
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+ENTRY_END
+

--- a/tpkg/catzone-recovery.tdir/catzone-recovery.testns-badfeed
+++ b/tpkg/catzone-recovery.tdir/catzone-recovery.testns-badfeed
@@ -1,0 +1,64 @@
+$TTL 3600
+
+$ORIGIN catalog.invalid.
+
+;; IXFR for 1 -> 0xBADFEED
+;;
+ENTRY_BEGIN
+MATCH opcode qtype qname serial=1
+REPLY QUERY NOERROR
+ADJUST copy_id
+SECTION QUESTION
+@ IXFR
+SECTION ANSWER
+@ SOA testns.example. root 195952365 3600 28800 2419200 3600
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+;; Nothing to be removed from serial 1 -> 195952365
+@ SOA testns.example. root 195952365 3600 28800 2419200 3600
+2.zones PTR two.invalid.
+@ SOA testns.example. root 195952365 3600 28800 2419200 3600
+ENTRY_END
+
+;; AXFR for 0xBADFEED
+;;
+ENTRY_BEGIN
+MATCH opcode qtype qname
+MATCH TCP
+REPLY QUERY NOERROR
+ADJUST copy_id
+SECTION QUESTION
+@ AXFR
+SECTION ANSWER
+@ SOA testns.example. root 195952365 3600 28800 2419200 3600
+version TXT "2"
+1.zones PTR one.invalid.
+2.zones PTR two.invalid.
+@ SOA testns.example. root 195952365 3600 28800 2419200 3600
+ENTRY_END
+
+$ORIGIN one.invalid.
+ENTRY_BEGIN
+MATCH opcode qtype qname
+MATCH TCP
+REPLY QUERY NOERROR
+ADJUST copy_id
+SECTION QUESTION
+@ AXFR
+SECTION ANSWER
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+ENTRY_END
+
+$ORIGIN two.invalid.
+ENTRY_BEGIN
+MATCH opcode qtype qname
+MATCH TCP
+REPLY QUERY NOERROR
+ADJUST copy_id
+SECTION QUESTION
+@ AXFR
+SECTION ANSWER
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+ENTRY_END
+

--- a/tpkg/catzone-recovery.tdir/catzone-recovery.testns-badfeef
+++ b/tpkg/catzone-recovery.tdir/catzone-recovery.testns-badfeef
@@ -1,0 +1,94 @@
+$TTL 3600
+
+$ORIGIN catalog.invalid.
+
+ENTRY_BEGIN
+MATCH opcode qtype qname serial=195952365
+REPLY QUERY NOERROR
+ADJUST copy_id
+SECTION QUESTION
+@ IXFR
+SECTION ANSWER
+@ SOA testns.example. root 195952367 3600 28800 2419200 3600
+@ SOA testns.example. root 195952365 3600 28800 2419200 3600
+;; Nothing to be removed from 195952365 to  195952366
+@ SOA testns.example. root 195952366 3600 28800 2419200 3600
+;; Added with 195952366
+3.zones PTR three.invalid.
+@ SOA testns.example. root 195952366 3600 28800 2419200 3600
+;; Nothing to be removed from 195952366 to 195952367
+@ SOA testns.example. root 195952367 3600 28800 2419200 3600
+;; Added with 195952367
+4.zones PTR four.invalid.
+@ SOA testns.example. root 195952367 3600 28800 2419200 3600
+ENTRY_END
+
+ENTRY_BEGIN
+MATCH opcode qtype qname
+MATCH TCP
+REPLY QUERY NOERROR
+ADJUST copy_id
+SECTION QUESTION
+@ AXFR
+SECTION ANSWER
+@ SOA testns.example. root 195952367 3600 28800 2419200 3600
+version TXT "2"
+1.zones PTR one.invalid.
+2.zones PTR two.invalid.
+3.zones PTR three.invalid.
+4.zones PTR four.invalid.
+@ SOA testns.example. root 195952367 3600 28800 2419200 3600
+ENTRY_END
+
+$ORIGIN one.invalid.
+ENTRY_BEGIN
+MATCH opcode qtype qname
+MATCH TCP
+REPLY QUERY NOERROR
+ADJUST copy_id
+SECTION QUESTION
+@ AXFR
+SECTION ANSWER
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+ENTRY_END
+
+$ORIGIN two.invalid.
+ENTRY_BEGIN
+MATCH opcode qtype qname
+MATCH TCP
+REPLY QUERY NOERROR
+ADJUST copy_id
+SECTION QUESTION
+@ AXFR
+SECTION ANSWER
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+ENTRY_END
+
+$ORIGIN three.invalid.
+ENTRY_BEGIN
+MATCH opcode qtype qname
+MATCH TCP
+REPLY QUERY NOERROR
+ADJUST copy_id
+SECTION QUESTION
+@ AXFR
+SECTION ANSWER
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+ENTRY_END
+
+$ORIGIN four.invalid.
+ENTRY_BEGIN
+MATCH opcode qtype qname
+MATCH TCP
+REPLY QUERY NOERROR
+ADJUST copy_id
+SECTION QUESTION
+@ AXFR
+SECTION ANSWER
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+@ SOA testns.example. root 1 3600 28800 2419200 3600
+ENTRY_END
+

--- a/tpkg/do-tests
+++ b/tpkg/do-tests
@@ -46,6 +46,7 @@ NEED_CPU_AFFINITY="bad_cpu_affinity no_cpu_affinity cpu_affinity"
 NEED_FAKETIME="dnscookies"
 NEED_DEBUG="verify_again nsec3_ixfr_neg ixfrout-add-delete ixfr_badformat cpu_affinity ixfr_superlong"
 NEED_UNPRIVILEGED_USERNS="dns-cookies"
+NEED_TESTING_BUILD="catzone-recovery"
 
 # do we have dig9?
 DIG9=no
@@ -68,6 +69,8 @@ HAVE_DEBUG=no
 if $NSD -h 2>&1 | grep -- '-L' >/dev/null; then HAVE_DEBUG=yes; fi
 HAVE_UNPRIVILEGED_USERNS=yes
 if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ] && [ "x`cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns`" = "x1" ]; then HAVE_UNPRIVILEGED_USERNS=no; fi
+HAVE_TESTING_BUILD=no
+if $NSD -v 2>&1 | grep -- '--enable-testing' >/dev/null; then HAVE_TESTING_BUILD=yes; fi
 
 # run the tests
 tdir -a ../../ $tdirarg fake 0000_nsd-compile.tdir
@@ -112,6 +115,10 @@ for i in *.tdir; do
 	fi
 	if [ $HAVE_UNPRIVILEGED_USERNS = no ] && echo $NEED_UNPRIVILEGED_USERNS | grep `basename $i .tdir` >/dev/null; then
 		echo ">>> skipped $i: test needs unpriviledged userns"
+		skip=yes
+	fi
+	if [ $HAVE_TESTING_BUILD = no ] && echo $NEED_TESTING_BUILD | grep `basename $i .tdir` >/dev/null; then
+		echo ">>> skipped $i: test needs testing build"
 		skip=yes
 	fi
 	if [ $skip = no ]; then

--- a/xfrd.c
+++ b/xfrd.c
@@ -620,7 +620,8 @@ xfrd_init_zones()
 		(int)xfrd->catalog_consumer_zones->count));
 }
 
-static void
+/* returns 1 on failure, 0 on success */
+static int
 apply_xfrs_to_consumer_zone(struct xfrd_catalog_consumer_zone* consumer_zone,
 		zone_type* dbzone, xfrd_xfr_type* xfr)
 {
@@ -629,6 +630,7 @@ apply_xfrs_to_consumer_zone(struct xfrd_catalog_consumer_zone* consumer_zone,
 	if(xfr->msg_is_ixfr) {
 		uint32_t soa_serial=0, after_serial=0;
 		xfrd_xfr_type* prev;
+		int ret = 0;
 
 		if(dbzone->soa_rrset == NULL
 #ifndef PACKED_STRUCTS
@@ -642,7 +644,7 @@ apply_xfrs_to_consumer_zone(struct xfrd_catalog_consumer_zone* consumer_zone,
 			       "could not apply ixfr on catalog consumer zone "
 			       "\'%s\': invalid SOA resource record",
 			       consumer_zone->options->name);
-			return;
+			return 1;
 		}
 		if(soa_serial == xfr->msg_old_serial) 
 			goto apply_xfr;
@@ -651,19 +653,20 @@ apply_xfrs_to_consumer_zone(struct xfrd_catalog_consumer_zone* consumer_zone,
 				continue;
 			if(xfr->msg_old_serial != prev->msg_new_serial)
 				continue;
-			apply_xfrs_to_consumer_zone(consumer_zone, dbzone, prev);
+			ret |= apply_xfrs_to_consumer_zone(consumer_zone, dbzone, prev);
 			break;
 		}
 		if(!prev
-		|| !retrieve_soa_rdata_serial(dbzone->soa_rrset->rrs[0],
-			&after_serial)
-		|| xfr->msg_old_serial != after_serial) {
+		|| !retrieve_soa_rdata_serial( dbzone->soa_rrset->rrs[0]
+		                             , &after_serial)
+		|| xfr->msg_old_serial != after_serial
+		|| ret) {
 			make_catalog_consumer_invalid(consumer_zone,
 			       "could not find and/or apply xfrs for catalog "
 			       "consumer zone \'%s\': to update to serial %u",
 			       consumer_zone->options->name,
 			       xfr->msg_new_serial);
-			return;
+			return 1;
 		}
 	}
 apply_xfr:
@@ -675,13 +678,16 @@ apply_xfr:
 		make_catalog_consumer_invalid(consumer_zone,
 		       "could not open transfer file %lld: %s",
 		       (long long)xfr->xfrfilenumber, strerror(errno));
+		return 1;
 
 	} else if(0 >= apply_ixfr_for_zone(xfrd->nsd, dbzone, df,
 			xfrd->nsd->options, NULL, xfr->xfrfilenumber)) {
 		make_catalog_consumer_invalid(consumer_zone,
-			"error processing transfer file %lld",
-			(long long)xfr->xfrfilenumber);
+			"error applying %sXFR %u -> %u",
+			(xfr->msg_is_ixfr ? "I" : "A"),
+			xfr->msg_old_serial, xfr->msg_new_serial);
 		fclose(df);
+		return 1;
 	} else {
 		/* Make valid for reprocessing */
 		make_catalog_consumer_valid(consumer_zone);
@@ -690,6 +696,7 @@ apply_xfr:
 			"applied", (xfr->msg_is_ixfr ? "I" : "A"), xfr->msg_old_serial,
 			xfr->msg_new_serial, consumer_zone->options->name));
 	}
+	return 0;
 }
 
 static void
@@ -700,7 +707,8 @@ xfrd_process_soa_info_task(struct task_list_d* task)
 	xfrd_zone_type* zone;
 	struct xfrd_catalog_producer_zone* producer_zone;
 	struct xfrd_catalog_consumer_zone* consumer_zone = NULL;
-	zone_type* dbzone = NULL;
+	zone_type* consumer_dbzone = NULL;
+	int retry_consumer = 0;
 	xfrd_xfr_type* xfr;
 	xfrd_xfr_type* prev_xfr;
 	int xfr_was_ixfr = 0;
@@ -823,8 +831,8 @@ xfrd_process_soa_info_task(struct task_list_d* task)
 #endif
 	&& (consumer_zone = (struct xfrd_catalog_consumer_zone*)rbtree_search(
 			xfrd->catalog_consumer_zones, task->zname))) {
-		dbzone = namedb_find_or_create_zone( xfrd->nsd->db, task->zname
-		                                   , consumer_zone->options);
+		consumer_dbzone = namedb_find_or_create_zone(
+			xfrd->nsd->db, task->zname, consumer_zone->options);
 	}
 	if(zone->latest_xfr) {
 		xfr_was_ixfr = (zone->latest_xfr->query_type == TYPE_IXFR);
@@ -867,11 +875,12 @@ xfrd_process_soa_info_task(struct task_list_d* task)
 					xfrd->nsd, xfr->xfrfilenumber);
 				return;
 			}
-			if(consumer_zone && dbzone &&
-				/* Call consumer apply for most recent update*/
-				(soa_ptr && soa_ptr->serial == htonl(xfr->msg_new_serial)))
-				apply_xfrs_to_consumer_zone(
-					consumer_zone, dbzone, xfr);
+			/* Call consumer apply for most recent update*/
+			if(consumer_dbzone && soa_ptr
+			&& soa_ptr->serial == htonl(xfr->msg_new_serial)) {
+				retry_consumer |= apply_xfrs_to_consumer_zone(
+					consumer_zone, consumer_dbzone, xfr);
+			}
 		}
 		DEBUG(DEBUG_IPC, 1,
 			(LOG_INFO, "xfrd: zone %s delete update to serial %u",
@@ -916,6 +925,13 @@ xfrd_process_soa_info_task(struct task_list_d* task)
 	case soainfo_ok:
 		if(xfrd->reload_failed)
 			break;
+		if(retry_consumer && xfr_was_ixfr) {
+			/* A full transfer of the catalog zone might fix it */
+			zone->soa_disk_acquired = 0;
+			zone->soa_nsd_acquired = 0;
+			xfrd_handle_notify_and_start_xfr(zone, NULL);
+			break;
+		}
 		/* fall through */
 	case soainfo_gone:
 		if(hint == soainfo_gone) {


### PR DESCRIPTION
The tpkg test uses an artificially induced failure to apply a xfr for a specific SOA serial (0xBADFEED). For this nsd needs to be compiled with TESTING_CODE defined. This can be enabled by `--enable-testing`. Maybe this comes in handy for future issues that are hard to reproduce (like for example the throttling the TCP receive window down to 1 with 51cc814)