### PR TITLE
Main code facilitated testing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1268,6 +1268,15 @@ case "$enable_tcp_fastopen" in
                ;;
 esac
 
+AC_ARG_ENABLE(testing, [])
+case "$enable_testing" in
+        yes)
+		AC_DEFINE_UNQUOTED([TESTING_CODE], [], [Define this to enable artificially induced errors for unit tests. NEVER USE THIS IN PRODUCTION!])
+		;;
+        no|*)
+                ;;
+esac
+
 AH_BOTTOM([
 /* define before includes as it specifies what standard to use. */
 #if (defined(HAVE_PSELECT) && !defined (HAVE_PSELECT_PROTO)) \

--- a/difffile.c
+++ b/difffile.c
@@ -1592,6 +1592,15 @@ apply_ixfr_for_zone(nsd_type* nsd, zone_type* zone, FILE* in,
 			"skipping diff file commit with bad serial"));
 		return -2; /* Success in "main" process, failure in "xfrd" */
 	}
+#ifdef TESTING_CODE
+	if(nsd->testing && new_serial == 0xBADFEED) {
+		log_msg(LOG_ERR,
+			"Pretending an error occured for testing purposes for "
+			"difffile %s from serial %" PRIu32 " -> %" PRIu32,
+			zone_buf, old_serial, new_serial);
+		return -2;
+	}
+#endif
 
 	if(!zone->is_skipped)
 	{

--- a/nsd-control.c
+++ b/nsd-control.c
@@ -139,6 +139,9 @@ usage()
 	printf("  drop_cookie_secret		drop a staging cookie secret\n");
 	printf("  activate_cookie_secret	make a staging cookie secret active\n");
 	printf("  print_cookie_secrets		show all cookie secrets with their status\n");
+#ifdef TESTING_CODE
+	printf("  testing <proc role> <on|off>	Do not use! For non-production builds only!\n");
+#endif
 	exit(1);
 }
 

--- a/nsd.c
+++ b/nsd.c
@@ -916,7 +916,9 @@ main(int argc, char *argv[])
 	nsd.options = nsd_options_create(region_create_custom(xalloc, free,
 		DEFAULT_CHUNK_SIZE, DEFAULT_LARGE_OBJECT_SIZE,
 		DEFAULT_INITIAL_CLEANUP_SIZE, 1));
-
+#ifdef TESTING_CODE
+	nsd.testing = 0;
+#endif
 	/* Parse the command line... */
 	while ((c = getopt(argc, argv, "46a:c:df:hi:I:l:N:n:P:p:s:u:t:X:V:v"
 #ifndef NDEBUG /* <mattthijs> only when configured with --enable-checking */

--- a/nsd.h
+++ b/nsd.h
@@ -405,7 +405,9 @@ struct	nsd
 	char* cookie_secrets_filename;
 
 	struct nsd_options* options;
-
+#ifdef TESTING_CODE
+	int testing;
+#endif
 #ifdef HAVE_SSL
 	/* TLS specific configuration */
 	SSL_CTX *tls_ctx;

--- a/remote.c
+++ b/remote.c
@@ -2751,6 +2751,38 @@ do_print_cookie_secrets(RES* ssl, xfrd_state_type* xrfd, char* arg) {
 	explicit_bzero(secret_hex, sizeof(secret_hex));
 }
 
+#ifdef TESTING_CODE
+static void
+do_testing(RES* ssl, xfrd_state_type* xfrd, char* arg) {
+	char* arg2 = strchr(arg, ' ');
+	if (arg2) {
+		*arg2++ = 0;
+		while(isspace(*arg2))
+			arg2++;
+		if(!*arg2)
+			arg2 = NULL;
+	}
+	if(strcmp(arg, "xfrd") != 0) {
+		(void)ssl_printf(ssl,
+			"testing in process role %s is not yet supported\n",
+			arg);
+		return;
+	}
+	if(!arg2)
+		; /* pass */
+	else if (strcmp(arg2, "on") == 0)
+		xfrd->nsd->testing = 1;
+	else if (strcmp(arg2, "off") == 0)
+		xfrd->nsd->testing = 0;
+	else
+		(void)ssl_printf(ssl,
+			"2nd argument must be \"on\" or \"off\"\n");
+
+	(void)ssl_printf(ssl, "testing in process role \"%s\": %s\n",
+		arg, (xfrd->nsd->testing ? "on" : "off"));
+}
+#endif
+
 /** check for name with end-of-string, space or tab after it */
 static int
 cmdcmp(char* p, const char* cmd, size_t len)
@@ -2822,6 +2854,10 @@ execute_cmd(struct daemon_remote* rc, RES* ssl, char* cmd)
 		do_print_cookie_secrets(ssl, rc->xfrd, skipwhite(p+20));
 	} else if(cmdcmp(p, "activate_cookie_secret", 22)) {
 		do_activate_cookie_secret(ssl, rc->xfrd, skipwhite(p+22));
+#ifdef TESTING_CODE
+	} else if(cmdcmp(p, "testing", 7)) {
+		do_testing(ssl, rc->xfrd, skipwhite(p+7));
+#endif
 	} else {
 		(void)ssl_printf(ssl, "error unknown command '%s'\n", p);
 	}


### PR DESCRIPTION
This branch is for tests that need changes in NSD's main code. Since we don't want anyone to run this in production, we keep it in a separate branch.
Use the --enable-testing option to configure to build an NSD equipped with code to facilitate testing.
Specific code can then be enabled or disables with the `testing` command with `nsd-control`
